### PR TITLE
クライアントが直接サマリプロキシに接続するオプション

### DIFF
--- a/packages/backend/migration/1717644139656-addDirectSummalyProxy.js
+++ b/packages/backend/migration/1717644139656-addDirectSummalyProxy.js
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project, noridev, cherrypick-project, esurio
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export class addDirectSummalyProxy1717644139656 {
+	name = 'addDirectSummalyProxy1717644139656'
+
+	async up(queryRunner) {
+			await queryRunner.query(`ALTER TABLE "meta" ADD "directSummalyProxy" boolean NOT NULL DEFAULT false`);
+	}
+	async down(queryRunner) {
+			await queryRunner.query(`ALTER TABLE "meta" DROP COLUMN "directSummalyProxy"`);
+	}
+}

--- a/packages/backend/src/models/Meta.ts
+++ b/packages/backend/src/models/Meta.ts
@@ -280,6 +280,11 @@ export class MiMeta {
 	@Column('boolean', {
 		default: false,
 	})
+	public directSummalyProxy: boolean;
+
+	@Column('boolean', {
+		default: false,
+	})
 	public enableEmail: boolean;
 
 	@Column('varchar', {

--- a/packages/backend/src/server/api/endpoints/admin/meta.ts
+++ b/packages/backend/src/server/api/endpoints/admin/meta.ts
@@ -709,6 +709,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				urlPreviewRequireContentLength: instance.urlPreviewRequireContentLength,
 				urlPreviewUserAgent: instance.urlPreviewUserAgent,
 				urlPreviewSummaryProxyUrl: instance.urlPreviewSummaryProxyUrl,
+				urlPreviewDirectSummalyProxy: instance.directSummalyProxy,
 				doNotSendNotificationEmailsForAbuseReport: instance.doNotSendNotificationEmailsForAbuseReport,
 				emailToReceiveAbuseReport: instance.emailToReceiveAbuseReport,
 				enableReceivePrerelease: instance.enableReceivePrerelease,

--- a/packages/backend/src/server/api/endpoints/admin/update-meta.ts
+++ b/packages/backend/src/server/api/endpoints/admin/update-meta.ts
@@ -181,6 +181,7 @@ export const paramDef = {
 		urlPreviewRequireContentLength: { type: 'boolean' },
 		urlPreviewUserAgent: { type: 'string', nullable: true },
 		urlPreviewSummaryProxyUrl: { type: 'string', nullable: true },
+		urlPreviewDirectSummalyProxy: { type: 'boolean' },
 		doNotSendNotificationEmailsForAbuseReport: { type: 'boolean' },
 		emailToReceiveAbuseReport: { type: 'string', nullable: true },
 		enableReceivePrerelease: { type: 'boolean' },
@@ -722,6 +723,10 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 			if (ps.summalyProxy !== undefined || ps.urlPreviewSummaryProxyUrl !== undefined) {
 				const value = ((ps.urlPreviewSummaryProxyUrl ?? ps.summalyProxy) ?? '').trim();
 				set.urlPreviewSummaryProxyUrl = value === '' ? null : value;
+			}
+
+			if (ps.urlPreviewDirectSummalyProxy !== undefined) {
+				set.directSummalyProxy = ps.urlPreviewDirectSummalyProxy;
 			}
 
 			if (ps.doNotSendNotificationEmailsForAbuseReport !== undefined) {

--- a/packages/backend/src/server/api/endpoints/meta.ts
+++ b/packages/backend/src/server/api/endpoints/meta.ts
@@ -246,6 +246,10 @@ export const meta = {
 				type: 'string',
 				optional: false, nullable: false,
 			},
+			urlPreviewEndpoint: {
+				type: 'string',
+				optional: false, nullable: false,
+			},
 			features: {
 				type: 'object',
 				optional: true, nullable: false,
@@ -419,6 +423,8 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				policies: { ...DEFAULT_POLICIES, ...instance.policies },
 
 				mediaProxy: this.config.mediaProxy,
+				// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+				urlPreviewEndpoint: instance.directSummalyProxy ? (instance.urlPreviewSummaryProxyUrl || `${this.config.url}/url` ) : `${this.config.url}/url`,
 
 				...(ps.detail ? {
 					cacheRemoteFiles: instance.cacheRemoteFiles,

--- a/packages/cherrypick-js/src/autogen/types.ts
+++ b/packages/cherrypick-js/src/autogen/types.ts
@@ -9615,6 +9615,7 @@ export type operations = {
           urlPreviewRequireContentLength?: boolean;
           urlPreviewUserAgent?: string | null;
           urlPreviewSummaryProxyUrl?: string | null;
+          urlPreviewDirectSummalyProxy?: boolean;
           doNotSendNotificationEmailsForAbuseReport?: boolean;
           emailToReceiveAbuseReport?: string | null;
           enableReceivePrerelease?: boolean;
@@ -20745,6 +20746,7 @@ export type operations = {
             translatorAvailable: boolean;
             proxyAccountName: string | null;
             mediaProxy: string;
+            urlPreviewEndpoint: string;
             features?: {
               registration: boolean;
               localTimeline: boolean;

--- a/packages/frontend/src/components/MkUrlPreview.vue
+++ b/packages/frontend/src/components/MkUrlPreview.vue
@@ -92,6 +92,8 @@ import { deviceKind } from '@/scripts/device-kind.js';
 import MkButton from '@/components/MkButton.vue';
 import { versatileLang } from '@/scripts/intl-const.js';
 import { defaultStore } from '@/store.js';
+import { instance } from '@/instance.js';
+import { getProxiedImageUrlNullable } from '@/scripts/media-proxy.js';
 
 type SummalyResult = Awaited<ReturnType<typeof summaly>>;
 
@@ -149,7 +151,7 @@ if (requestUrl.hostname === 'music.youtube.com' && requestUrl.pathname.match('^/
 
 requestUrl.hash = '';
 
-window.fetch(`/url?url=${encodeURIComponent(requestUrl.href)}&lang=${versatileLang}`)
+window.fetch(`${instance.urlPreviewEndpoint}?url=${encodeURIComponent(requestUrl.href)}&lang=${versatileLang}`)
 	.then(res => {
 		if (!res.ok) {
 			if (_DEV_) {
@@ -172,8 +174,8 @@ window.fetch(`/url?url=${encodeURIComponent(requestUrl.href)}&lang=${versatileLa
 
 		title.value = info.title;
 		description.value = info.description;
-		thumbnail.value = info.thumbnail;
-		icon.value = info.icon;
+		thumbnail.value = getProxiedImageUrlNullable(info.thumbnail, 'avatar', true);
+		icon.value = getProxiedImageUrlNullable(info.icon, 'emoji', true);
 		sitename.value = info.sitename;
 		player.value = info.player;
 		sensitive.value = info.sensitive ?? false;

--- a/packages/frontend/src/pages/admin/settings.vue
+++ b/packages/frontend/src/pages/admin/settings.vue
@@ -156,6 +156,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 							<MkSwitch v-model="urlPreviewEnabled">
 								<template #label>{{ i18n.ts._urlPreviewSetting.enable }}</template>
 							</MkSwitch>
+							<MkSwitch v-model="urlPreviewDirectSummalyProxy">
+								<template #label>DirectAccess</template>
+							</MkSwitch>
 
 							<MkSwitch v-model="urlPreviewRequireContentLength">
 								<template #label>{{ i18n.ts._urlPreviewSetting.requireContentLength }}</template>
@@ -268,6 +271,7 @@ const urlPreviewMaximumContentLength = ref<number>(1024 * 1024 * 10);
 const urlPreviewRequireContentLength = ref<boolean>(true);
 const urlPreviewUserAgent = ref<string | null>(null);
 const urlPreviewSummaryProxyUrl = ref<string | null>(null);
+const urlPreviewDirectSummalyProxy = ref<boolean>(false);
 
 async function init(): Promise<void> {
 	const meta = await misskeyApi('admin/meta');
@@ -299,6 +303,7 @@ async function init(): Promise<void> {
 	urlPreviewRequireContentLength.value = meta.urlPreviewRequireContentLength;
 	urlPreviewUserAgent.value = meta.urlPreviewUserAgent;
 	urlPreviewSummaryProxyUrl.value = meta.urlPreviewSummaryProxyUrl;
+	urlPreviewDirectSummalyProxy.value = meta.urlPreviewDirectSummalyProxy;
 }
 
 async function save() {
@@ -331,6 +336,7 @@ async function save() {
 		urlPreviewRequireContentLength: urlPreviewRequireContentLength.value,
 		urlPreviewUserAgent: urlPreviewUserAgent.value,
 		urlPreviewSummaryProxyUrl: urlPreviewSummaryProxyUrl.value,
+		urlPreviewDirectSummalyProxy: urlPreviewDirectSummalyProxy.value,
 	});
 
 	fetchInstance();


### PR DESCRIPTION
close: #81 
サマリプロキシの実装によってはCORSエラーになるので設定で従来方式と直接接続方式を切り替えられるようにしてある