### PR TITLE
fix: 存在しないアイコンを指定している問題

### DIFF
--- a/packages/frontend/src/navbar.ts
+++ b/packages/frontend/src/navbar.ts
@@ -133,7 +133,7 @@ export const navbarItemDef = reactive({
 	},
 	official_tags: {
 		title: i18n.ts._official_tag.navbar,
-		icon: 'ti ti-bookmarks',
+		icon: 'ti ti-bookmark',
 		to: '/official-tags',
 	},
 	ui: {

--- a/packages/frontend/src/pages/admin/index.vue
+++ b/packages/frontend/src/pages/admin/index.vue
@@ -172,7 +172,7 @@ const menuDef = computed(() => [{
 		to: '/admin/abuses',
 		active: currentPage.value?.route.name === 'abuses',
 	}, {
-		icon: 'ti ti-bookmarks',
+		icon: 'ti ti-bookmark',
 		text: i18n.ts._official_tag.navbar,
 		to: '/admin/official-tags',
 		active: currentPage.value?.route.name === 'officialTags',

--- a/packages/frontend/src/pages/admin/official-tags.vue
+++ b/packages/frontend/src/pages/admin/official-tags.vue
@@ -123,7 +123,7 @@ const headerTabs = computed(() => []);
 
 definePageMetadata(() => ({
 	title: i18n.ts._official_tag.navbar,
-	icon: 'ti ti-bookmarks',
+	icon: 'ti ti-bookmark',
 }));
 </script>
 

--- a/packages/frontend/src/pages/official-tags.vue
+++ b/packages/frontend/src/pages/official-tags.vue
@@ -29,7 +29,7 @@ const official_tags = ref<Misskey.entities.OfficialTagsShowResponse>([]);
 
 definePageMetadata(() => ({
 	title: i18n.ts._official_tag.title,
-	icon: 'ti ti-bookmarks',
+	icon: 'ti ti-bookmark',
 }));
 </script>
 


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

存在しないタグを読み込もうとしてフロントエンドがクラッシュする問題を修正

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->


フロントエンドがクラッシュするため

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

アイコンを利用したい場合、現在は下記URLのwebアイコンを利用している。以後こちらを参照すること。
https://tabler.io/icons

## Checklist
- [ ] Read the [contribution guide](https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Update CHANGELOG_CHERRYPICK.md
- [ ] (If possible) Add tests
