### PR TITLE
リモートのクリップを見る機能

### DIFF
--- a/.config/docker_example.yml
+++ b/.config/docker_example.yml
@@ -103,6 +103,16 @@ redis:
 #  #prefix: example-prefix
 #  #db: 1
 
+#redisForRemoteClips:
+#  host: localhost
+#  port: 6379
+#  #family: 0  # 0=Both, 4=IPv4, 6=IPv6
+#  #pass: example-pass
+#  #prefix: example-prefix
+#  #db: 1
+#  # You can specify more ioredis options...
+#  #username: example-username
+
 #   ┌───────────────────────────┐
 #───┘ MeiliSearch configuration └─────────────────────────────
 

--- a/.config/example.yml
+++ b/.config/example.yml
@@ -175,6 +175,16 @@ redis:
 #  # You can specify more ioredis options...
 #  #username: example-username
 
+#redisForRemoteClips:
+#  host: localhost
+#  port: 6379
+#  #family: 0  # 0=Both, 4=IPv4, 6=IPv6
+#  #pass: example-pass
+#  #prefix: example-prefix
+#  #db: 1
+#  # You can specify more ioredis options...
+#  #username: example-username
+
 #   ┌───────────────────────────┐
 #───┘ MeiliSearch configuration └─────────────────────────────
 

--- a/packages/backend/src/GlobalModule.ts
+++ b/packages/backend/src/GlobalModule.ts
@@ -117,6 +117,13 @@ const $redisForTimelines: Provider = {
 	},
 	inject: [DI.config],
 };
+const $redisForRemoteClips: Provider = {
+	provide: DI.redisForRemoteClips,
+	useFactory: (config: Config) => {
+		return new Redis.Redis(config.redisForRemoteClips);
+	},
+	inject: [DI.config],
+};
 
 const $redisForJobQueue: Provider = {
 	provide: DI.redisForJobQueue,
@@ -133,8 +140,8 @@ const $redisForJobQueue: Provider = {
 @Global()
 @Module({
 	imports: [RepositoryModule],
-	providers: [$config, $db, $meilisearch, $opensearch, $cloudLogging, $redis, $redisForPub, $redisForSub, $redisForTimelines, $redisForJobQueue],
-	exports: [$config, $db, $meilisearch, $opensearch, $cloudLogging, $redis, $redisForPub, $redisForSub, $redisForTimelines, $redisForJobQueue, RepositoryModule],
+	providers: [$config, $db, $meilisearch, $opensearch, $cloudLogging, $redis, $redisForPub, $redisForSub, $redisForTimelines, $redisForJobQueue, $redisForRemoteClips],
+	exports: [$config, $db, $meilisearch, $opensearch, $cloudLogging, $redis, $redisForPub, $redisForSub, $redisForTimelines, $redisForJobQueue, $redisForRemoteClips, RepositoryModule],
 })
 export class GlobalModule implements OnApplicationShutdown {
 	constructor(
@@ -144,6 +151,7 @@ export class GlobalModule implements OnApplicationShutdown {
 		@Inject(DI.redisForSub) private redisForSub: Redis.Redis,
 		@Inject(DI.redisForTimelines) private redisForTimelines: Redis.Redis,
 		@Inject(DI.redisForJobQueue) private redisForJobQueue: Redis.Redis,
+		@Inject(DI.redisForRemoteClips) private redisForRemoteClips: Redis.Redis,
 	) { }
 
 	public async dispose(): Promise<void> {
@@ -157,6 +165,7 @@ export class GlobalModule implements OnApplicationShutdown {
 			this.redisForSub.disconnect(),
 			this.redisForTimelines.disconnect(),
 			this.redisForJobQueue.disconnect(),
+			this.redisForRemoteClips.disconnect(),
 		]);
 	}
 

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -50,6 +50,7 @@ type Source = {
 	redisForPubsub?: RedisOptionsSource;
 	redisForJobQueue?: RedisOptionsSource;
 	redisForTimelines?: RedisOptionsSource;
+	redisForRemoteClips?: RedisOptionsSource;
 	meilisearch?: {
 		host: string;
 		port: string;
@@ -208,6 +209,7 @@ export type Config = {
 	redisForPubsub: RedisOptions & RedisOptionsSource;
 	redisForJobQueue: RedisOptions & RedisOptionsSource;
 	redisForTimelines: RedisOptions & RedisOptionsSource;
+	redisForRemoteClips: RedisOptions & RedisOptionsSource;
 	sentryForBackend: { options: Partial<Sentry.NodeOptions>; enableNodeProfiling: boolean; } | undefined;
 	sentryForFrontend: { options: Partial<Sentry.NodeOptions> } | undefined;
 	perChannelMaxNoteCacheCount: number;
@@ -287,6 +289,7 @@ export function loadConfig(): Config {
 		redisForPubsub: config.redisForPubsub ? convertRedisOptions(config.redisForPubsub, host) : redis,
 		redisForJobQueue: config.redisForJobQueue ? convertRedisOptions(config.redisForJobQueue, host) : redis,
 		redisForTimelines: config.redisForTimelines ? convertRedisOptions(config.redisForTimelines, host) : redis,
+		redisForRemoteClips: config.redisForRemoteClips ? convertRedisOptions(config.redisForRemoteClips, host) : redis,
 		sentryForBackend: config.sentryForBackend,
 		sentryForFrontend: config.sentryForFrontend,
 		id: config.id,

--- a/packages/backend/src/di-symbols.ts
+++ b/packages/backend/src/di-symbols.ts
@@ -14,6 +14,7 @@ export const DI = {
 	redisForSub: Symbol('redisForSub'),
 	redisForTimelines: Symbol('redisForTimelines'),
 	redisForJobQueue: Symbol('redisForJobQueue'),
+	redisForRemoteClips: Symbol('redisForRemoteClips'),
 
 	//#region Repositories
 	usersRepository: Symbol('usersRepository'),

--- a/packages/backend/src/server/HealthServerService.ts
+++ b/packages/backend/src/server/HealthServerService.ts
@@ -27,6 +27,9 @@ export class HealthServerService {
 		@Inject(DI.redisForTimelines)
 		private redisForTimelines: Redis.Redis,
 
+		@Inject(DI.redisForRemoteClips)
+		private redisForRemoteClips: Redis.Redis,
+
 		@Inject(DI.db)
 		private db: DataSource,
 
@@ -43,6 +46,7 @@ export class HealthServerService {
 				this.redisForPub.ping(),
 				this.redisForSub.ping(),
 				this.redisForTimelines.ping(),
+				this.redisForRemoteClips.ping(),
 				this.db.query('SELECT 1'),
 				...(this.meilisearch ? [this.meilisearch.health()] : []),
 			]).then(() => 200, () => 503));

--- a/packages/backend/src/server/api/endpoints/clips/favorite.ts
+++ b/packages/backend/src/server/api/endpoints/clips/favorite.ts
@@ -31,13 +31,18 @@ export const meta = {
 			code: 'ALREADY_FAVORITED',
 			id: '92658936-c625-4273-8326-2d790129256e',
 		},
+		unimplemented: {
+			message: 'Unimplemented.',
+			code: 'UNIMPLEMENTED',
+			id: '92658936-c625-4273-8326-2d790129256e',
+		},
 	},
 } as const;
 
 export const paramDef = {
 	type: 'object',
 	properties: {
-		clipId: { type: 'string', format: 'misskey:id' },
+		clipId: { type: 'string' },
 	},
 	required: ['clipId'],
 } as const;
@@ -54,6 +59,9 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 		private idService: IdService,
 	) {
 		super(meta, paramDef, async (ps, me) => {
+			if (ps.clipId.split('@').length > 1) {
+				throw new ApiError(meta.errors.unimplemented);
+			}
 			const clip = await this.clipsRepository.findOneBy({ id: ps.clipId });
 			if (clip == null) {
 				throw new ApiError(meta.errors.noSuchClip);

--- a/packages/backend/src/server/api/endpoints/clips/favorite.ts
+++ b/packages/backend/src/server/api/endpoints/clips/favorite.ts
@@ -34,7 +34,7 @@ export const meta = {
 		unimplemented: {
 			message: 'Unimplemented.',
 			code: 'UNIMPLEMENTED',
-			id: '92658936-c625-4273-8326-2d790129256e',
+			id: '37561aed-4ba4-4a53-9efe-a0aa255e9bb3',
 		},
 	},
 } as const;

--- a/packages/backend/src/server/api/endpoints/clips/notes.ts
+++ b/packages/backend/src/server/api/endpoints/clips/notes.ts
@@ -198,7 +198,8 @@ async function remote(
 			notes_or_null.push(remoteNote(apNoteService, note.uri, redisForRemoteClips, host, note.id));
 		}
 	}
-	const notes = await awaitAll(notes_or_null);
+	const notes = await Promise.all(notes_or_null);
+	console.log(notes);
 	const some_notes = [];
 	for (const note of notes) {
 		if (note !== null)some_notes.push(note);

--- a/packages/backend/src/server/api/endpoints/clips/notes.ts
+++ b/packages/backend/src/server/api/endpoints/clips/notes.ts
@@ -210,7 +210,6 @@ async function remote(
 		}
 	}
 	const notes = await Promise.all(notes_or_null);
-	console.log(notes);
 	const some_notes = [];
 	for (const note of notes) {
 		if (note !== null)some_notes.push(note);
@@ -230,6 +229,7 @@ async function remoteNote(
 	const fetchedMeta = await metaService.fetch();
 	if (utilityService.isBlockedHost(fetchedMeta.blockedHosts, utilityService.extractDbHost(uri))) return null;
 	//取得or null
+	console.log(uri);
 	let note = await apNoteService.fetchNote(uri);
 	if (note == null) {
 		note = await apNoteService.createNote(uri, undefined, true);

--- a/packages/backend/src/server/api/endpoints/clips/notes.ts
+++ b/packages/backend/src/server/api/endpoints/clips/notes.ts
@@ -201,9 +201,10 @@ async function remote(
 			}),
 		});
 		remote_json = await res.text();
-	}
-	if (remote_json === null) {
-		throw new ApiError(meta.errors.noSuchClip);
+		redisForRemoteClips.set(cache_key, remote_json);
+		redisForRemoteClips.expire(cache_key, 10 * 60);
+	} else {
+		remote_json = cache_value;
 	}
 	const remote_notes = JSON.parse(remote_json);
 	//リモートに照会する回数の上限

--- a/packages/backend/src/server/api/endpoints/clips/notes.ts
+++ b/packages/backend/src/server/api/endpoints/clips/notes.ts
@@ -232,7 +232,7 @@ async function remoteNote(
 	//取得or null
 	const note = await apNoteService.fetchNote(uri);
 	if (note !== null) {
-		redisForRemoteClips.sadd(note.id + '@' + host, remote_note_id);
+		redisForRemoteClips.set(note.id + '@' + host, remote_note_id);
 	}
 	return note;
 }

--- a/packages/backend/src/server/api/endpoints/clips/notes.ts
+++ b/packages/backend/src/server/api/endpoints/clips/notes.ts
@@ -230,7 +230,10 @@ async function remoteNote(
 	const fetchedMeta = await metaService.fetch();
 	if (utilityService.isBlockedHost(fetchedMeta.blockedHosts, utilityService.extractDbHost(uri))) return null;
 	//取得or null
-	const note = await apNoteService.fetchNote(uri);
+	let note = await apNoteService.fetchNote(uri);
+	if (note == null) {
+		note = await apNoteService.createNote(uri, undefined, true);
+	}
 	if (note !== null) {
 		redisForRemoteClips.set(note.id + '@' + host, remote_note_id);
 	}

--- a/packages/backend/src/server/api/endpoints/clips/notes.ts
+++ b/packages/backend/src/server/api/endpoints/clips/notes.ts
@@ -158,7 +158,7 @@ async function remote(
 	sinceId:string|undefined,
 	untilId:string|undefined,
 ) {
-	const cache_key = local_id + '-' + (sinceId ? sinceId : '') + '-' + (untilId ? untilId : '');
+	const cache_key = local_id + '-' + (sinceId ? sinceId : '') + '-' + (untilId ? untilId : '') + limit;
 	const cache_value = await redisForRemoteClips.get(cache_key);
 	let remote_json = null;
 	if (cache_value === null) {

--- a/packages/backend/src/server/api/endpoints/clips/notes.ts
+++ b/packages/backend/src/server/api/endpoints/clips/notes.ts
@@ -4,11 +4,20 @@
  */
 
 import { Inject, Injectable } from '@nestjs/common';
+import got, * as Got from 'got';
+import * as Redis from 'ioredis';
+import type { Config } from '@/config.js';
 import { Endpoint } from '@/server/api/endpoint-base.js';
-import type { NotesRepository, ClipsRepository, ClipNotesRepository } from '@/models/_.js';
+import type { NotesRepository, ClipsRepository, ClipNotesRepository, MiNote } from '@/models/_.js';
 import { QueryService } from '@/core/QueryService.js';
 import { NoteEntityService } from '@/core/entities/NoteEntityService.js';
 import { DI } from '@/di-symbols.js';
+import { HttpRequestService } from '@/core/HttpRequestService.js';
+import { UserEntityService } from '@/core/entities/UserEntityService.js';
+import { awaitAll } from '@/misc/prelude/await-all.js';
+import { RemoteUserResolveService } from '@/core/RemoteUserResolveService.js';
+import { ApNoteService } from '@/core/activitypub/models/ApNoteService.js';
+import { IObject } from '@/core/activitypub/type.js';
 import { ApiError } from '../../error.js';
 
 export const meta = {
@@ -23,6 +32,16 @@ export const meta = {
 			message: 'No such clip.',
 			code: 'NO_SUCH_CLIP',
 			id: '1d7645e6-2b6d-4635-b0fe-fe22b0e72e00',
+		},
+		invalidIdFormat: {
+			message: 'Invalid id format.',
+			code: 'INVALID_ID_FORMAT',
+			id: '42d11fe5-686e-41ee-9e7f-e804ec3a388d',
+		},
+		failedToResolveRemoteUser: {
+			message: 'failedToResolveRemoteUser.',
+			code: 'FAILED_TO_RESOLVE_REMOTE_USER',
+			id: 'af0ecffc-8717-409e-a8d4-e1e3a5d2497f',
 		},
 	},
 
@@ -40,7 +59,7 @@ export const meta = {
 export const paramDef = {
 	type: 'object',
 	properties: {
-		clipId: { type: 'string', format: 'misskey:id' },
+		clipId: { type: 'string' },
 		limit: { type: 'integer', minimum: 1, maximum: 100, default: 10 },
 		sinceId: { type: 'string', format: 'misskey:id' },
 		untilId: { type: 'string', format: 'misskey:id' },
@@ -51,6 +70,8 @@ export const paramDef = {
 @Injectable()
 export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-disable-line import/no-default-export
 	constructor(
+		@Inject(DI.config)
+		private config: Config,
 		@Inject(DI.clipsRepository)
 		private clipsRepository: ClipsRepository,
 
@@ -59,43 +80,128 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 
 		@Inject(DI.clipNotesRepository)
 		private clipNotesRepository: ClipNotesRepository,
+		@Inject(DI.redisForRemoteClips)
+		private redisForRemoteClips: Redis.Redis,
+
+		private httpRequestService: HttpRequestService,
+		private userEntityService: UserEntityService,
+		private remoteUserResolveService: RemoteUserResolveService,
+		private apNoteService: ApNoteService,
 
 		private noteEntityService: NoteEntityService,
 		private queryService: QueryService,
 	) {
 		super(meta, paramDef, async (ps, me) => {
-			const clip = await this.clipsRepository.findOneBy({
-				id: ps.clipId,
-			});
+			const parsed_id = ps.clipId.split('@');
+			let notes = [];
+			if (parsed_id.length === 2 ) {//is remote
+				const url = 'https://' + parsed_id[1] + '/api/clips/notes';
+				console.log(url);
+				notes = await remote(config, httpRequestService, userEntityService, remoteUserResolveService, redisForRemoteClips, apNoteService, url, parsed_id[0], parsed_id[1], ps.clipId);
+			} else if (parsed_id.length === 1 ) {//is not local
+				const clip = await this.clipsRepository.findOneBy({
+					id: ps.clipId,
+				});
 
-			if (clip == null) {
-				throw new ApiError(meta.errors.noSuchClip);
+				if (clip == null) {
+					throw new ApiError(meta.errors.noSuchClip);
+				}
+
+				if (!clip.isPublic && (me == null || (clip.userId !== me.id))) {
+					throw new ApiError(meta.errors.noSuchClip);
+				}
+
+				const query = this.queryService.makePaginationQuery(this.notesRepository.createQueryBuilder('note'), ps.sinceId, ps.untilId)
+					.innerJoin(this.clipNotesRepository.metadata.targetName, 'clipNote', 'clipNote.noteId = note.id')
+					.innerJoinAndSelect('note.user', 'user')
+					.leftJoinAndSelect('note.reply', 'reply')
+					.leftJoinAndSelect('note.renote', 'renote')
+					.leftJoinAndSelect('reply.user', 'replyUser')
+					.leftJoinAndSelect('renote.user', 'renoteUser')
+					.andWhere('clipNote.clipId = :clipId', { clipId: clip.id });
+
+				if (me) {
+					this.queryService.generateVisibilityQuery(query, me);
+					this.queryService.generateMutedUserQuery(query, me);
+					this.queryService.generateBlockedUserQuery(query, me);
+				}
+
+				notes = await query
+					.limit(ps.limit)
+					.getMany();
+			} else {
+				throw new ApiError(meta.errors.invalidIdFormat);
 			}
-
-			if (!clip.isPublic && (me == null || (clip.userId !== me.id))) {
-				throw new ApiError(meta.errors.noSuchClip);
-			}
-
-			const query = this.queryService.makePaginationQuery(this.notesRepository.createQueryBuilder('note'), ps.sinceId, ps.untilId)
-				.innerJoin(this.clipNotesRepository.metadata.targetName, 'clipNote', 'clipNote.noteId = note.id')
-				.innerJoinAndSelect('note.user', 'user')
-				.leftJoinAndSelect('note.reply', 'reply')
-				.leftJoinAndSelect('note.renote', 'renote')
-				.leftJoinAndSelect('reply.user', 'replyUser')
-				.leftJoinAndSelect('renote.user', 'renoteUser')
-				.andWhere('clipNote.clipId = :clipId', { clipId: clip.id });
-
-			if (me) {
-				this.queryService.generateVisibilityQuery(query, me);
-				this.queryService.generateMutedUserQuery(query, me);
-				this.queryService.generateBlockedUserQuery(query, me);
-			}
-
-			const notes = await query
-				.limit(ps.limit)
-				.getMany();
 
 			return await this.noteEntityService.packMany(notes, me);
 		});
 	}
+}
+
+async function remote(
+	config:Config,
+	httpRequestService: HttpRequestService,
+	userEntityService: UserEntityService,
+	remoteUserResolveService: RemoteUserResolveService,
+	redisForRemoteClips: Redis.Redis,
+	apNoteService: ApNoteService,
+	url:string,
+	clipId:string,
+	host:string,
+	local_id:string,
+) {
+	const cache_value = await redisForRemoteClips.get(local_id);
+	let remote_json = null;
+	if (cache_value === null) {
+		const timeout = 30 * 1000;
+		const operationTimeout = 60 * 1000;
+		const res = got.post(url, {
+			headers: {
+				'User-Agent': config.userAgent,
+				'Content-Type': 'application/json; charset=utf-8',
+			},
+			timeout: {
+				lookup: timeout,
+				connect: timeout,
+				secureConnect: timeout,
+				socket: timeout,	// read timeout
+				response: timeout,
+				send: timeout,
+				request: operationTimeout,	// whole operation timeout
+			},
+			agent: {
+				http: httpRequestService.httpAgent,
+				https: httpRequestService.httpsAgent,
+			},
+			http2: true,
+			retry: {
+				limit: 1,
+			},
+			enableUnixSockets: false,
+			body: JSON.stringify({
+				clipId,
+			}),
+		});
+		remote_json = await res.text();
+	}
+	if (remote_json === null) {
+		throw new ApiError(meta.errors.noSuchClip);
+	}
+	const remote_notes = JSON.parse(remote_json);
+	const notes_or_null = [];
+	for (const note of remote_notes) {
+		if (note.uri !== null) {
+			notes_or_null.push(remoteNote(apNoteService, note.uri));
+		}
+	}
+	const some_notes = [];
+	for (const note of await awaitAll(notes_or_null)) {
+		if (note !== null)some_notes.push(note);
+	}
+	return some_notes;
+}
+
+async function remoteNote(apNoteService: ApNoteService, object: string | IObject): Promise<MiNote | null> {
+	//取得or null
+	return await apNoteService.fetchNote(object);
 }

--- a/packages/backend/src/server/api/endpoints/clips/notes.ts
+++ b/packages/backend/src/server/api/endpoints/clips/notes.ts
@@ -227,9 +227,9 @@ async function remoteNote(
 	remote_note_id:string,
 ): Promise<MiNote | null> {
 	const fetchedMeta = await metaService.fetch();
+	console.log(uri);
 	if (utilityService.isBlockedHost(fetchedMeta.blockedHosts, utilityService.extractDbHost(uri))) return null;
 	//取得or null
-	console.log(uri);
 	let note = await apNoteService.fetchNote(uri);
 	if (note == null) {
 		note = await apNoteService.createNote(uri, undefined, true);

--- a/packages/backend/src/server/api/endpoints/clips/notes.ts
+++ b/packages/backend/src/server/api/endpoints/clips/notes.ts
@@ -207,7 +207,7 @@ async function remote(
 	}
 	const remote_notes = JSON.parse(remote_json);
 	//リモートに照会する回数の上限
-	const create_limit = 10;
+	const create_limit = 5;
 	let create_count = 0;
 	const notes = [];
 	for (const note of remote_notes) {
@@ -243,7 +243,7 @@ async function remoteNote(
 	remote_note_id:string,
 ): Promise<RemoteNote | null> {
 	const fetchedMeta = await metaService.fetch();
-	apLoggerService.logger.debug(uri);
+	apLoggerService.logger.debug('remote clip note fetch ' + uri);
 	let note;
 	let is_create = false;
 	try {

--- a/packages/backend/src/server/api/endpoints/clips/notes.ts
+++ b/packages/backend/src/server/api/endpoints/clips/notes.ts
@@ -213,6 +213,7 @@ async function remoteNote(
 	remote_note_id:string,
 ): Promise<MiNote | null> {
 	//取得or null
+	console.log(object);
 	const note = await apNoteService.fetchNote(object);
 	if (note !== null) {
 		redisForRemoteClips.sadd(note.id + '@' + host, remote_note_id);

--- a/packages/backend/src/server/api/endpoints/clips/notes.ts
+++ b/packages/backend/src/server/api/endpoints/clips/notes.ts
@@ -208,11 +208,12 @@ async function remote(
 	let create_count = 0;
 	const notes = [];
 	for (const note of remote_notes) {
-		if (note.uri !== null) {
+		const uri = note.uri ? note.uri : 'https://' + host + '/notes/' + note.id;
+		if (uri !== null) {
 			if (create_count > create_limit) {
 				break;
 			}
-			const local_note = await remoteNote(apNoteService, note.uri, redisForRemoteClips, metaService, utilityService, apLoggerService, host, note.id);
+			const local_note = await remoteNote(apNoteService, uri, redisForRemoteClips, metaService, utilityService, apLoggerService, host, note.id);
 			if (local_note !== null) {
 				if (local_note.is_create) {
 					create_count++;

--- a/packages/backend/src/server/api/endpoints/clips/notes.ts
+++ b/packages/backend/src/server/api/endpoints/clips/notes.ts
@@ -198,8 +198,9 @@ async function remote(
 			notes_or_null.push(remoteNote(apNoteService, note.uri, redisForRemoteClips, host, note.id));
 		}
 	}
+	const notes = await awaitAll(notes_or_null);
 	const some_notes = [];
-	for (const note of await awaitAll(notes_or_null)) {
+	for (const note of notes) {
 		if (note !== null)some_notes.push(note);
 	}
 	return some_notes;

--- a/packages/backend/src/server/api/endpoints/clips/notes.ts
+++ b/packages/backend/src/server/api/endpoints/clips/notes.ts
@@ -87,8 +87,6 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 		private redisForRemoteClips: Redis.Redis,
 
 		private httpRequestService: HttpRequestService,
-		private userEntityService: UserEntityService,
-		private remoteUserResolveService: RemoteUserResolveService,
 		private apNoteService: ApNoteService,
 		private metaService: MetaService,
 		private utilityService: UtilityService,
@@ -103,7 +101,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 			if (parsed_id.length === 2 ) {//is remote
 				const url = 'https://' + parsed_id[1] + '/api/clips/notes';
 				apLoggerService.logger.debug('remote clip ' + url);
-				notes = await remote(config, httpRequestService, userEntityService, remoteUserResolveService, redisForRemoteClips, apNoteService, metaService, utilityService, apLoggerService, url, parsed_id[0], parsed_id[1], ps.clipId, ps.limit, ps.sinceId, ps.untilId);
+				notes = await remote(config, httpRequestService, redisForRemoteClips, apNoteService, metaService, utilityService, apLoggerService, url, parsed_id[0], parsed_id[1], ps.clipId, ps.limit, ps.sinceId, ps.untilId);
 			} else if (parsed_id.length === 1 ) {//is not local
 				const clip = await this.clipsRepository.findOneBy({
 					id: ps.clipId,
@@ -147,8 +145,6 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 async function remote(
 	config:Config,
 	httpRequestService: HttpRequestService,
-	userEntityService: UserEntityService,
-	remoteUserResolveService: RemoteUserResolveService,
 	redisForRemoteClips: Redis.Redis,
 	apNoteService: ApNoteService,
 	metaService: MetaService,

--- a/packages/backend/src/server/api/endpoints/clips/show.ts
+++ b/packages/backend/src/server/api/endpoints/clips/show.ts
@@ -5,12 +5,16 @@
 
 import { Inject, Injectable } from '@nestjs/common';
 import got, * as Got from 'got';
+import * as Redis from 'ioredis';
 import { Endpoint } from '@/server/api/endpoint-base.js';
 import type { ClipsRepository } from '@/models/_.js';
 import { ClipEntityService } from '@/core/entities/ClipEntityService.js';
 import { DI } from '@/di-symbols.js';
 import type { Config } from '@/config.js';
 import { HttpRequestService } from '@/core/HttpRequestService.js';
+import { UserEntityService } from '@/core/entities/UserEntityService.js';
+import { awaitAll } from '@/misc/prelude/await-all.js';
+import { RemoteUserResolveService } from '@/core/RemoteUserResolveService.js';
 import { ApiError } from '../../error.js';
 
 export const meta = {
@@ -30,6 +34,11 @@ export const meta = {
 			message: 'Invalid id format.',
 			code: 'INVALID_ID_FORMAT',
 			id: 'df45c7d1-cd15-4a35-b3e1-8c9f987c4f5c',
+		},
+		failedToResolveRemoteUser: {
+			message: 'failedToResolveRemoteUser.',
+			code: 'FAILED_TO_RESOLVE_REMOTE_USER',
+			id: '56d5e552-d55a-47e3-9f37-6dc85a93ecf9',
 		},
 	},
 
@@ -55,16 +64,20 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 		private config: Config,
 		@Inject(DI.clipsRepository)
 		private clipsRepository: ClipsRepository,
+		@Inject(DI.redisForRemoteClips)
+		private redisForRemoteClips: Redis.Redis,
 
 		private httpRequestService: HttpRequestService,
+		private userEntityService: UserEntityService,
+		private remoteUserResolveService: RemoteUserResolveService,
 		private clipEntityService: ClipEntityService,
 	) {
 		super(meta, paramDef, async (ps, me) => {
 			const parsed_id = ps.clipId.split('@');
 			if (parsed_id.length === 2 ) {//is remote
-				const url = 'https://' + parsed_id[1] + '/clips/' + parsed_id[0];
+				const url = 'https://' + parsed_id[1] + '/api/clips/show';
 				console.log(url);
-				throw new ApiError(meta.errors.invalidIdFormat);
+				return remote(config, httpRequestService, userEntityService, remoteUserResolveService, redisForRemoteClips, url, parsed_id[0], parsed_id[1], ps.clipId);
 			}
 			if (parsed_id.length !== 1 ) {//is not local
 				throw new ApiError(meta.errors.invalidIdFormat);
@@ -87,30 +100,68 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 	}
 }
 
-async function remote(config:Config, httpRequestService: HttpRequestService, url:string) {
-	const timeout = 30 * 1000;
-	const operationTimeout = 60 * 1000;
-	const req = got.stream(url, {
-		headers: {
-			'User-Agent': config.userAgent,
-		},
-		timeout: {
-			lookup: timeout,
-			connect: timeout,
-			secureConnect: timeout,
-			socket: timeout,	// read timeout
-			response: timeout,
-			send: timeout,
-			request: operationTimeout,	// whole operation timeout
-		},
-		agent: {
-			http: httpRequestService.httpAgent,
-			https: httpRequestService.httpsAgent,
-		},
-		http2: true,
-		retry: {
-			limit: 1,
-		},
-		enableUnixSockets: false,
+async function remote(
+	config:Config,
+	httpRequestService: HttpRequestService,
+	userEntityService: UserEntityService,
+	remoteUserResolveService: RemoteUserResolveService,
+	redisForRemoteClips: Redis.Redis,
+	url:string,
+	clipId:string,
+	host:string,
+	local_id:string,
+) {
+	const cache_value = await redisForRemoteClips.get(local_id);
+	let remote_json = null;
+	if (cache_value === null) {
+		const timeout = 30 * 1000;
+		const operationTimeout = 60 * 1000;
+		const res = got.post(url, {
+			headers: {
+				'User-Agent': config.userAgent,
+			},
+			timeout: {
+				lookup: timeout,
+				connect: timeout,
+				secureConnect: timeout,
+				socket: timeout,	// read timeout
+				response: timeout,
+				send: timeout,
+				request: operationTimeout,	// whole operation timeout
+			},
+			agent: {
+				http: httpRequestService.httpAgent,
+				https: httpRequestService.httpsAgent,
+			},
+			http2: true,
+			retry: {
+				limit: 1,
+			},
+			enableUnixSockets: false,
+			body: JSON.stringify({
+				clipId,
+			}),
+		});
+		remote_json = await res.text();
+	}
+	if (remote_json === null) {
+		throw new ApiError(meta.errors.noSuchClip);
+	}
+	const remote_clip = JSON.parse(remote_json);
+	const user = await remoteUserResolveService.resolveUser(remote_clip.username, host).catch(err => {
+		throw new ApiError(meta.errors.failedToResolveRemoteUser);
+	});
+	return await awaitAll({
+		id: local_id,
+		createdAt: remote_clip.createdAt ? remote_clip.createdAt : null,
+		lastClippedAt: remote_clip.lastClippedAt ? remote_clip.lastClippedAt : null,
+		userId: user.id,
+		user: userEntityService.pack(user),
+		name: remote_clip.name,
+		description: remote_clip.description,
+		isPublic: true,
+		favoritedCount: remote_clip.favoritedCount,
+		isFavorited: false,
+		notesCount: remote_clip.notesCount,
 	});
 }

--- a/packages/backend/src/server/api/endpoints/clips/show.ts
+++ b/packages/backend/src/server/api/endpoints/clips/show.ts
@@ -4,10 +4,13 @@
  */
 
 import { Inject, Injectable } from '@nestjs/common';
+import got, * as Got from 'got';
 import { Endpoint } from '@/server/api/endpoint-base.js';
 import type { ClipsRepository } from '@/models/_.js';
 import { ClipEntityService } from '@/core/entities/ClipEntityService.js';
 import { DI } from '@/di-symbols.js';
+import type { Config } from '@/config.js';
+import { HttpRequestService } from '@/core/HttpRequestService.js';
 import { ApiError } from '../../error.js';
 
 export const meta = {
@@ -23,6 +26,11 @@ export const meta = {
 			code: 'NO_SUCH_CLIP',
 			id: 'c3c5fe33-d62c-44d2-9ea5-d997703f5c20',
 		},
+		invalidIdFormat: {
+			message: 'Invalid id format.',
+			code: 'INVALID_ID_FORMAT',
+			id: 'df45c7d1-cd15-4a35-b3e1-8c9f987c4f5c',
+		},
 	},
 
 	res: {
@@ -35,7 +43,7 @@ export const meta = {
 export const paramDef = {
 	type: 'object',
 	properties: {
-		clipId: { type: 'string', format: 'misskey:id' },
+		clipId: { type: 'string' },
 	},
 	required: ['clipId'],
 } as const;
@@ -43,12 +51,24 @@ export const paramDef = {
 @Injectable()
 export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-disable-line import/no-default-export
 	constructor(
+		@Inject(DI.config)
+		private config: Config,
 		@Inject(DI.clipsRepository)
 		private clipsRepository: ClipsRepository,
 
+		private httpRequestService: HttpRequestService,
 		private clipEntityService: ClipEntityService,
 	) {
 		super(meta, paramDef, async (ps, me) => {
+			const parsed_id = ps.clipId.split('@');
+			if (parsed_id.length === 2 ) {//is remote
+				const url = 'https://' + parsed_id[1] + '/clips/' + parsed_id[0];
+				console.log(url);
+				throw new ApiError(meta.errors.invalidIdFormat);
+			}
+			if (parsed_id.length !== 1 ) {//is not local
+				throw new ApiError(meta.errors.invalidIdFormat);
+			}
 			// Fetch the clip
 			const clip = await this.clipsRepository.findOneBy({
 				id: ps.clipId,
@@ -65,4 +85,32 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 			return await this.clipEntityService.pack(clip, me);
 		});
 	}
+}
+
+async function remote(config:Config, httpRequestService: HttpRequestService, url:string) {
+	const timeout = 30 * 1000;
+	const operationTimeout = 60 * 1000;
+	const req = got.stream(url, {
+		headers: {
+			'User-Agent': config.userAgent,
+		},
+		timeout: {
+			lookup: timeout,
+			connect: timeout,
+			secureConnect: timeout,
+			socket: timeout,	// read timeout
+			response: timeout,
+			send: timeout,
+			request: operationTimeout,	// whole operation timeout
+		},
+		agent: {
+			http: httpRequestService.httpAgent,
+			https: httpRequestService.httpsAgent,
+		},
+		http2: true,
+		retry: {
+			limit: 1,
+		},
+		enableUnixSockets: false,
+	});
 }

--- a/packages/backend/src/server/api/endpoints/clips/show.ts
+++ b/packages/backend/src/server/api/endpoints/clips/show.ts
@@ -149,7 +149,10 @@ async function remote(
 		throw new ApiError(meta.errors.noSuchClip);
 	}
 	const remote_clip = JSON.parse(remote_json);
-	const user = await remoteUserResolveService.resolveUser(remote_clip.username, host).catch(err => {
+	if (remote_clip.user == null || remote_clip.user.username == null) {
+		throw new ApiError(meta.errors.failedToResolveRemoteUser);
+	}
+	const user = await remoteUserResolveService.resolveUser(remote_clip.user.username, host).catch(err => {
 		throw new ApiError(meta.errors.failedToResolveRemoteUser);
 	});
 	return await awaitAll({

--- a/packages/backend/src/server/api/endpoints/clips/show.ts
+++ b/packages/backend/src/server/api/endpoints/clips/show.ts
@@ -119,6 +119,7 @@ async function remote(
 		const res = got.post(url, {
 			headers: {
 				'User-Agent': config.userAgent,
+				'Content-Type': 'application/json; charset=utf-8',
 			},
 			timeout: {
 				lookup: timeout,

--- a/packages/backend/src/server/api/endpoints/users/clips.ts
+++ b/packages/backend/src/server/api/endpoints/users/clips.ts
@@ -38,8 +38,8 @@ export const paramDef = {
 	properties: {
 		userId: { type: 'string', format: 'misskey:id' },
 		limit: { type: 'integer', minimum: 1, maximum: 100, default: 10 },
-		sinceId: { type: 'string', format: 'misskey:id' },
-		untilId: { type: 'string', format: 'misskey:id' },
+		sinceId: { type: 'string' },
+		untilId: { type: 'string' },
 	},
 	required: ['userId'],
 } as const;

--- a/packages/backend/src/server/api/endpoints/users/clips.ts
+++ b/packages/backend/src/server/api/endpoints/users/clips.ts
@@ -92,7 +92,7 @@ async function remote(
 	sinceId:string|undefined,
 	untilId:string|undefined,
 ) {
-	const cache_key = user.id + '-clips';
+	const cache_key = user.id + '-' + sinceId + '-' + untilId + '-clips';
 	const cache_value = await redisForRemoteClips.get(cache_key);
 	if (cache_value !== null) {
 		//ステータス格納

--- a/packages/backend/src/server/api/endpoints/users/clips.ts
+++ b/packages/backend/src/server/api/endpoints/users/clips.ts
@@ -4,11 +4,18 @@
  */
 
 import { Inject, Injectable } from '@nestjs/common';
-import type { ClipsRepository } from '@/models/_.js';
+import Redis from 'ioredis';
+import got, * as Got from 'got';
+import type { ClipsRepository, MiUser, UsersRepository } from '@/models/_.js';
 import { Endpoint } from '@/server/api/endpoint-base.js';
 import { QueryService } from '@/core/QueryService.js';
 import { ClipEntityService } from '@/core/entities/ClipEntityService.js';
 import { DI } from '@/di-symbols.js';
+import { UserEntityService } from '@/core/entities/UserEntityService.js';
+import type { Config } from '@/config.js';
+import { HttpRequestService } from '@/core/HttpRequestService.js';
+import { awaitAll } from '@/misc/prelude/await-all.js';
+import type { FindOptionsWhere } from 'typeorm';
 
 export const meta = {
 	tags: ['users', 'clips'],
@@ -40,13 +47,28 @@ export const paramDef = {
 @Injectable()
 export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-disable-line import/no-default-export
 	constructor(
+		@Inject(DI.config)
+		private config: Config,
 		@Inject(DI.clipsRepository)
 		private clipsRepository: ClipsRepository,
+		@Inject(DI.usersRepository)
+		private usersRepository: UsersRepository,
+		@Inject(DI.redisForRemoteClips)
+		private redisForRemoteClips: Redis.Redis,
 
+		private httpRequestService: HttpRequestService,
+		private userEntityService: UserEntityService,
 		private clipEntityService: ClipEntityService,
 		private queryService: QueryService,
 	) {
 		super(meta, paramDef, async (ps, me) => {
+			const q: FindOptionsWhere<MiUser> = { id: ps.userId };
+
+			const user = await this.usersRepository.findOneBy(q);
+			if (user === null) return [];
+			if (userEntityService.isRemoteUser(user)) {
+				return remote(config, httpRequestService, redisForRemoteClips, userEntityService, user, ps.limit, ps.sinceId, ps.untilId);
+			}
 			const query = this.queryService.makePaginationQuery(this.clipsRepository.createQueryBuilder('clip'), ps.sinceId, ps.untilId)
 				.andWhere('clip.userId = :userId', { userId: ps.userId })
 				.andWhere('clip.isPublic = true');
@@ -58,4 +80,166 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 			return await this.clipEntityService.packMany(clips, me);
 		});
 	}
+}
+
+async function remote(
+	config:Config,
+	httpRequestService: HttpRequestService,
+	redisForRemoteClips: Redis.Redis,
+	userEntityService: UserEntityService,
+	user:MiUser,
+	limit:number,
+	sinceId:string|undefined,
+	untilId:string|undefined,
+) {
+	const cache_key = user.id + '-clips';
+	const cache_value = await redisForRemoteClips.get(cache_key);
+	if (cache_value !== null) {
+		//ステータス格納
+		if (cache_value.startsWith('__')) {
+			if (cache_value === '__SKIP_FETCH') return [];
+			//未定義のステータス
+			return [];
+		}
+		return JSON.parse(cache_value);
+	}
+	if (user.host == null) {
+		//ローカルユーザーではない
+		return [];
+	}
+	const remote_user_id = await fetch_remote_user(config, httpRequestService, redisForRemoteClips, user.username, user.host);
+	if (remote_user_id === null) {
+		return [];
+	}
+	const remote_json = await fetch_remote_clip(config, httpRequestService, remote_user_id, user.host, limit, sinceId, untilId);
+	const json = JSON.parse(remote_json);
+	const clips = [];
+	for (const remote_clip of json) {
+		const clip = await awaitAll({
+			id: remote_clip.id + '@' + user.host,
+			createdAt: remote_clip.createdAt ? remote_clip.createdAt : null,
+			lastClippedAt: remote_clip.lastClippedAt ? remote_clip.lastClippedAt : null,
+			userId: user.id,
+			user: userEntityService.pack(user),
+			name: remote_clip.name,
+			description: remote_clip.description,
+			isPublic: true,
+			favoritedCount: remote_clip.favoritedCount,
+			isFavorited: false,
+			notesCount: remote_clip.notesCount,
+		});
+		clips.push(clip);
+	}
+	await redisForRemoteClips.set(cache_key, JSON.stringify(clips));
+	await redisForRemoteClips.expire(cache_key, 10 * 60);
+	return clips;
+}
+
+async function fetch_remote_user(
+	config:Config,
+	httpRequestService: HttpRequestService,
+	redisForRemoteClips: Redis.Redis,
+	username:string,
+	host:string,
+) {
+	const cache_key = username + '@' + host + '-userid';
+	const id = await redisForRemoteClips.get(cache_key);
+	if (id !== null) {
+		if (id === '__NOT_MISSKEY') {
+			return null;
+		}
+		if (id === '__INTERVAL') {
+			return null;
+		}
+		return id;
+	}
+	try {
+		const url = 'https://' + host + '/api/users/show';
+		const timeout = 30 * 1000;
+		const operationTimeout = 60 * 1000;
+		const res = got.post(url, {
+			headers: {
+				'User-Agent': config.userAgent,
+				'Content-Type': 'application/json; charset=utf-8',
+			},
+			timeout: {
+				lookup: timeout,
+				connect: timeout,
+				secureConnect: timeout,
+				socket: timeout,	// read timeout
+				response: timeout,
+				send: timeout,
+				request: operationTimeout,	// whole operation timeout
+			},
+			agent: {
+				http: httpRequestService.httpAgent,
+				https: httpRequestService.httpsAgent,
+			},
+			http2: true,
+			retry: {
+				limit: 1,
+			},
+			enableUnixSockets: false,
+			body: JSON.stringify({
+				username,
+			}),
+		});
+		const text = await res.text();
+		const json = JSON.parse(text);
+		if (json.id != null) {
+			redisForRemoteClips.set(cache_key, json.id);
+			return json.id as string;
+		}
+	} catch {
+		redisForRemoteClips.set(cache_key, '__INTERVAL');
+		await redisForRemoteClips.expire(cache_key, 60 * 60);
+	}
+	return null;
+}
+
+async function fetch_remote_clip(
+	config:Config,
+	httpRequestService: HttpRequestService,
+	userId:string,
+	host:string,
+	limit:number,
+	sinceId:string|undefined,
+	untilId:string|undefined,
+) {
+	const url = 'https://' + host + '/api/users/clips';
+	const sinceIdRemote = sinceId ? sinceId.split('@')[0] : undefined;
+	const untilIdRemote = untilId ? untilId.split('@')[0] : undefined;
+	const timeout = 30 * 1000;
+	const operationTimeout = 60 * 1000;
+	const res = got.post(url, {
+		headers: {
+			'User-Agent': config.userAgent,
+			'Content-Type': 'application/json; charset=utf-8',
+		},
+		timeout: {
+			lookup: timeout,
+			connect: timeout,
+			secureConnect: timeout,
+			socket: timeout,	// read timeout
+			response: timeout,
+			send: timeout,
+			request: operationTimeout,	// whole operation timeout
+		},
+		agent: {
+			http: httpRequestService.httpAgent,
+			https: httpRequestService.httpsAgent,
+		},
+		http2: true,
+		retry: {
+			limit: 1,
+		},
+		enableUnixSockets: false,
+		body: JSON.stringify({
+			userId,
+			limit,
+			sinceId: sinceIdRemote,
+			untilId: untilIdRemote,
+		}),
+	});
+	return await res.text();
 }

--- a/packages/cherrypick-js/src/autogen/types.ts
+++ b/packages/cherrypick-js/src/autogen/types.ts
@@ -13351,7 +13351,6 @@ export type operations = {
     requestBody: {
       content: {
         'application/json': {
-          /** Format: misskey:id */
           clipId: string;
         };
       };


### PR DESCRIPTION
close: #11 
リモートユーザーのクリップが見れるだけ。非ログインでの閲覧が制限されてるクリップとノートは見れない。
お気に入りとか未実装
## Checklist
- [ ] Read the [contribution guide](https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Update CHANGELOG_CHERRYPICK.md
- [ ] (If possible) Add tests
