### PR TITLE
絵文字インポート時に編集ダイアログを出す

### DIFF
--- a/packages/frontend/src/components/global/MkCustomEmoji.vue
+++ b/packages/frontend/src/components/global/MkCustomEmoji.vue
@@ -110,6 +110,11 @@ function onClick(ev: MouseEvent) {
 				os.apiWithDialog('admin/emoji/steal', {
 					name: customEmojiName.value,
 					host: props.host,
+				}).then(_res => {
+					os.alert({
+						type: 'success',
+						text: i18n.ts.emoji,
+					});
 				});
 			},
 		}] : []), ...(props.menuReaction && react ? [{

--- a/packages/frontend/src/components/global/MkCustomEmoji.vue
+++ b/packages/frontend/src/components/global/MkCustomEmoji.vue
@@ -112,7 +112,7 @@ function onClick(ev: MouseEvent) {
 					name: customEmojiName.value,
 					host: props.host,
 				});
-				emoji = await importEmojiMeta(emoji);
+				emoji = await importEmojiMeta(emoji, props.host);
 				os.popup(defineAsyncComponent(() => import('@/pages/emoji-edit-dialog.vue')), {
 					emoji: emoji,
 				});

--- a/packages/frontend/src/components/global/MkCustomEmoji.vue
+++ b/packages/frontend/src/components/global/MkCustomEmoji.vue
@@ -110,11 +110,6 @@ function onClick(ev: MouseEvent) {
 				os.apiWithDialog('admin/emoji/steal', {
 					name: customEmojiName.value,
 					host: props.host,
-				}).then(_res => {
-					os.alert({
-						type: 'success',
-						text: i18n.ts.emoji,
-					});
 				});
 			},
 		}] : []), ...(props.menuReaction && react ? [{

--- a/packages/frontend/src/components/global/MkCustomEmoji.vue
+++ b/packages/frontend/src/components/global/MkCustomEmoji.vue
@@ -113,7 +113,7 @@ function onClick(ev: MouseEvent) {
 					host: props.host,
 				});
 				emoji = await importEmojiMeta(emoji);
-				os.popup(defineAsyncComponent(() => import('./emoji-edit-dialog.vue')), {
+				os.popup(defineAsyncComponent(() => import('@/pages/emoji-edit-dialog.vue')), {
 					emoji: emoji,
 				});
 			},

--- a/packages/frontend/src/pages/custom-emojis-manager.vue
+++ b/packages/frontend/src/pages/custom-emojis-manager.vue
@@ -85,6 +85,7 @@ import * as os from '@/os.js';
 import { misskeyApi } from '@/scripts/misskey-api.js';
 import { i18n } from '@/i18n.js';
 import { definePageMetadata } from '@/scripts/page-metadata.js';
+import { importEmojiMeta } from '@/scripts/import-emoji.js';
 
 const emojisPaginationComponent = shallowRef<InstanceType<typeof MkPagination>>();
 
@@ -160,26 +161,7 @@ const importEmoji = async(emoji) => {
 	let res = await os.apiWithDialog('admin/emoji/copy', {
 		emojiId: emoji.id,
 	});
-	try {
-		let json = await(await fetch('https://' + emoji.host + '/api/emoji?name=' + emoji.name)).json();
-		console.log(json);
-		let from_json = (key) => {
-			try {
-				if (json[key]) {
-					res[key] = json[key];
-				}
-			} catch {
-				//一部失敗したら転送せず空欄のままにしておく
-			}
-		};
-		from_json('license');
-		from_json('aliases');
-		from_json('category');
-		from_json('isSensitive');
-	} catch (err) {
-		console.log(err);
-		//リモートから取得に失敗
-	}
+	res = await importEmojiMeta(res);
 	edit(res);
 };
 

--- a/packages/frontend/src/pages/custom-emojis-manager.vue
+++ b/packages/frontend/src/pages/custom-emojis-manager.vue
@@ -160,10 +160,13 @@ const importEmoji = async(emoji) => {
 	await os.apiWithDialog('admin/emoji/copy', {
 		emojiId: emoji.id,
 	});
-	os.alert({
-		type: 'success',
-		text: i18n.ts.emoji,
-	});
+	try {
+		let json = (await fetch('https://misskey.kzkr.xyz/api/emoji?name=' + emoji.id)).json();
+		console.log(json);
+	} catch {
+		//リモートから取得に失敗
+	}
+	edit(emoji);
 };
 
 const remoteMenu = (emoji, ev: MouseEvent) => {

--- a/packages/frontend/src/pages/custom-emojis-manager.vue
+++ b/packages/frontend/src/pages/custom-emojis-manager.vue
@@ -157,30 +157,31 @@ const edit = (emoji) => {
 };
 
 const importEmoji = async(emoji) => {
-	await os.apiWithDialog('admin/emoji/copy', {
+	os.apiWithDialog('admin/emoji/copy', {
 		emojiId: emoji.id,
+	}).then(async res => {
+		try {
+			let json = await(await fetch('https://misskey.kzkr.xyz/api/emoji?name=' + emoji.name)).json();
+			console.log(json);
+			let from_json = (key) => {
+				try {
+					emoji[key] = json[key];
+				} catch {
+					//一部失敗したら転送せず空欄のままにしておく
+				}
+			};
+			from_json('license');
+			from_json('aliases');
+			from_json('category');
+			from_json('isSensitive');
+		} catch (err) {
+			console.log(err);
+			//リモートから取得に失敗
+		} finally {
+			console.log('edit');
+			edit(emoji);
+		}
 	});
-	try {
-		let json = await (await fetch('https://misskey.kzkr.xyz/api/emoji?name=' + emoji.name)).json();
-		console.log(json);
-		let from_json = (key) => {
-			try {
-				emoji[key] = json[key];
-			} catch {
-				//一部失敗したら転送せず空欄のままにしておく
-			}
-		};
-		from_json('license');
-		from_json('aliases');
-		from_json('category');
-		from_json('isSensitive');
-	} catch (err) {
-		console.log(err);
-		//リモートから取得に失敗
-	} finally {
-		console.log('edit');
-		edit(emoji);
-	}
 };
 
 const remoteMenu = (emoji, ev: MouseEvent) => {

--- a/packages/frontend/src/pages/custom-emojis-manager.vue
+++ b/packages/frontend/src/pages/custom-emojis-manager.vue
@@ -161,7 +161,7 @@ const importEmoji = async(emoji) => {
 		emojiId: emoji.id,
 	}).then(async res => {
 		try {
-			let json = await(await fetch('https://misskey.kzkr.xyz/api/emoji?name=' + emoji.name)).json();
+			let json = await(await fetch('https://' + emoji.host + '/api/emoji?name=' + emoji.name)).json();
 			console.log(json);
 			let from_json = (key) => {
 				try {

--- a/packages/frontend/src/pages/custom-emojis-manager.vue
+++ b/packages/frontend/src/pages/custom-emojis-manager.vue
@@ -165,7 +165,7 @@ const importEmoji = async(emoji) => {
 			console.log(json);
 			let from_json = (key) => {
 				try {
-					emoji[key] = json[key];
+					res[key] = json[key];
 				} catch {
 					//一部失敗したら転送せず空欄のままにしておく
 				}
@@ -179,7 +179,7 @@ const importEmoji = async(emoji) => {
 			//リモートから取得に失敗
 		} finally {
 			console.log('edit');
-			edit(emoji);
+			edit(res);
 		}
 	});
 };

--- a/packages/frontend/src/pages/custom-emojis-manager.vue
+++ b/packages/frontend/src/pages/custom-emojis-manager.vue
@@ -161,8 +161,19 @@ const importEmoji = async(emoji) => {
 		emojiId: emoji.id,
 	});
 	try {
-		let json = (await fetch('https://misskey.kzkr.xyz/api/emoji?name=' + emoji.id)).json();
+		let json = await (await fetch('https://misskey.kzkr.xyz/api/emoji?name=' + emoji.name)).json();
 		console.log(json);
+		let from_json = (key) => {
+			try {
+				emoji[key] = json[key];
+			} catch {
+
+			}
+		};
+		from_json('license');
+		from_json('aliases');
+		from_json('category');
+		from_json('isSensitive');
 	} catch {
 		//リモートから取得に失敗
 	}

--- a/packages/frontend/src/pages/custom-emojis-manager.vue
+++ b/packages/frontend/src/pages/custom-emojis-manager.vue
@@ -165,7 +165,9 @@ const importEmoji = async(emoji) => {
 		console.log(json);
 		let from_json = (key) => {
 			try {
-				res[key] = json[key];
+				if (json[key]) {
+					res[key] = json[key];
+				}
 			} catch {
 				//一部失敗したら転送せず空欄のままにしておく
 			}

--- a/packages/frontend/src/pages/custom-emojis-manager.vue
+++ b/packages/frontend/src/pages/custom-emojis-manager.vue
@@ -174,9 +174,11 @@ const importEmoji = async(emoji) => {
 		from_json('aliases');
 		from_json('category');
 		from_json('isSensitive');
-	} catch {
+	} catch (err) {
+		console.log(err);
 		//リモートから取得に失敗
 	} finally {
+		console.log('edit');
 		edit(emoji);
 	}
 };

--- a/packages/frontend/src/pages/custom-emojis-manager.vue
+++ b/packages/frontend/src/pages/custom-emojis-manager.vue
@@ -167,7 +167,7 @@ const importEmoji = async(emoji) => {
 			try {
 				emoji[key] = json[key];
 			} catch {
-
+				//一部失敗したら転送せず空欄のままにしておく
 			}
 		};
 		from_json('license');
@@ -176,8 +176,9 @@ const importEmoji = async(emoji) => {
 		from_json('isSensitive');
 	} catch {
 		//リモートから取得に失敗
+	} finally {
+		edit(emoji);
 	}
-	edit(emoji);
 };
 
 const remoteMenu = (emoji, ev: MouseEvent) => {

--- a/packages/frontend/src/pages/custom-emojis-manager.vue
+++ b/packages/frontend/src/pages/custom-emojis-manager.vue
@@ -161,7 +161,7 @@ const importEmoji = async(emoji) => {
 	let res = await os.apiWithDialog('admin/emoji/copy', {
 		emojiId: emoji.id,
 	});
-	res = await importEmojiMeta(res);
+	res = await importEmojiMeta(res, emoji.host);
 	edit(res);
 };
 

--- a/packages/frontend/src/pages/custom-emojis-manager.vue
+++ b/packages/frontend/src/pages/custom-emojis-manager.vue
@@ -157,31 +157,28 @@ const edit = (emoji) => {
 };
 
 const importEmoji = async(emoji) => {
-	os.apiWithDialog('admin/emoji/copy', {
+	let res = await os.apiWithDialog('admin/emoji/copy', {
 		emojiId: emoji.id,
-	}).then(async res => {
-		try {
-			let json = await(await fetch('https://' + emoji.host + '/api/emoji?name=' + emoji.name)).json();
-			console.log(json);
-			let from_json = (key) => {
-				try {
-					res[key] = json[key];
-				} catch {
-					//一部失敗したら転送せず空欄のままにしておく
-				}
-			};
-			from_json('license');
-			from_json('aliases');
-			from_json('category');
-			from_json('isSensitive');
-		} catch (err) {
-			console.log(err);
-			//リモートから取得に失敗
-		} finally {
-			console.log('edit');
-			edit(res);
-		}
 	});
+	try {
+		let json = await(await fetch('https://' + emoji.host + '/api/emoji?name=' + emoji.name)).json();
+		console.log(json);
+		let from_json = (key) => {
+			try {
+				res[key] = json[key];
+			} catch {
+				//一部失敗したら転送せず空欄のままにしておく
+			}
+		};
+		from_json('license');
+		from_json('aliases');
+		from_json('category');
+		from_json('isSensitive');
+	} catch (err) {
+		console.log(err);
+		//リモートから取得に失敗
+	}
+	edit(res);
 };
 
 const remoteMenu = (emoji, ev: MouseEvent) => {

--- a/packages/frontend/src/pages/custom-emojis-manager.vue
+++ b/packages/frontend/src/pages/custom-emojis-manager.vue
@@ -156,9 +156,13 @@ const edit = (emoji) => {
 	}, 'closed');
 };
 
-const importEmoji = (emoji) => {
-	os.apiWithDialog('admin/emoji/copy', {
+const importEmoji = async(emoji) => {
+	await os.apiWithDialog('admin/emoji/copy', {
 		emojiId: emoji.id,
+	});
+	os.alert({
+		type: 'success',
+		text: i18n.ts.emoji,
 	});
 };
 

--- a/packages/frontend/src/scripts/import-emoji.ts
+++ b/packages/frontend/src/scripts/import-emoji.ts
@@ -1,0 +1,23 @@
+export async function importEmojiMeta(emoji) {
+	try {
+		const json = await(await fetch('https://' + emoji.host + '/api/emoji?name=' + emoji.name)).json();
+		console.log(json);
+		const from_json = (key) => {
+			try {
+				if (json[key]) {
+					emoji[key] = json[key];
+				}
+			} catch {
+				//一部失敗したら転送せず空欄のままにしておく
+			}
+		};
+		from_json('license');
+		from_json('aliases');
+		from_json('category');
+		from_json('isSensitive');
+	} catch (err) {
+		console.log(err);
+		//リモートから取得に失敗
+	}
+	return emoji;
+}

--- a/packages/frontend/src/scripts/import-emoji.ts
+++ b/packages/frontend/src/scripts/import-emoji.ts
@@ -1,7 +1,8 @@
 export async function importEmojiMeta(emoji, host:string) {
+	emoji.category = '取得失敗';
 	try {
 		const json = await(await fetch('https://' + host + '/api/emoji?name=' + emoji.name)).json();
-		console.log(json);
+		emoji.category = '';
 		const from_json = (key) => {
 			try {
 				if (json[key]) {

--- a/packages/frontend/src/scripts/import-emoji.ts
+++ b/packages/frontend/src/scripts/import-emoji.ts
@@ -1,6 +1,6 @@
-export async function importEmojiMeta(emoji) {
+export async function importEmojiMeta(emoji, host:string) {
 	try {
-		const json = await(await fetch('https://' + emoji.host + '/api/emoji?name=' + emoji.name)).json();
+		const json = await(await fetch('https://' + host + '/api/emoji?name=' + emoji.name)).json();
 		console.log(json);
 		const from_json = (key) => {
 			try {

--- a/packages/frontend/src/scripts/import-emoji.ts
+++ b/packages/frontend/src/scripts/import-emoji.ts
@@ -3,7 +3,7 @@ export async function importEmojiMeta(emoji, host:string) {
 	try {
 		const json = await(await fetch('https://' + host + '/api/emoji?name=' + emoji.name)).json();
 		emoji.category = '';
-		const from_json = (key) => {
+		const from_json = (key: string) => {
 			try {
 				if (json[key]) {
 					emoji[key] = json[key];


### PR DESCRIPTION
close:#242
デフォルト値リモートから取得した値で埋めた編集ダイアログをインポート直後に表示する
更新せずダイアログを閉じるとリモートの値を無視した従来通りの動作になる
## Checklist
- [ ] Read the [contribution guide](https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [x] (If needed) Update CHANGELOG_CHERRYPICK.md
- [ ] (If possible) Add tests
