### PR TITLE
リバーシ連合

### DIFF
--- a/CHANGELOG_yojo.md
+++ b/CHANGELOG_yojo.md
@@ -20,7 +20,7 @@
 ### Release Date
 
 ### General
--
+- Enhance: リバーシをリモートユーザーと対戦できるように [#271](https://github.com/yojo-art/cherrypick/pull/271)
 
 ### Client
 -

--- a/packages/backend/migration/1722327455736-AddReversifederationId.js
+++ b/packages/backend/migration/1722327455736-AddReversifederationId.js
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project, noridev, cherrypick-project, kozakura, yojo-art team
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export class AddReversifederationId1722327455736 {
+	name = 'AddReversifederationId1722327455736'
+
+	async up(queryRunner) {
+			await queryRunner.query(`ALTER TABLE "reversi_game" ADD "federationId" varchar`);
+	}
+	async down(queryRunner) {
+			await queryRunner.query(`ALTER TABLE "reversi_game" DROP COLUMN "federationId"`);
+	}
+}
+

--- a/packages/backend/src/core/CoreModule.ts
+++ b/packages/backend/src/core/CoreModule.ts
@@ -151,6 +151,7 @@ import { ApNoteService } from './activitypub/models/ApNoteService.js';
 import { ApPersonService } from './activitypub/models/ApPersonService.js';
 import { ApQuestionService } from './activitypub/models/ApQuestionService.js';
 import { ApEventService } from './activitypub/models/ApEventService.js';
+import { ApGameService } from './activitypub/models/ApGameService.js';
 import { QueueModule } from './QueueModule.js';
 import { QueueService } from './QueueService.js';
 import { LoggerService } from './LoggerService.js';
@@ -303,6 +304,7 @@ const $ApNoteService: Provider = { provide: 'ApNoteService', useExisting: ApNote
 const $ApPersonService: Provider = { provide: 'ApPersonService', useExisting: ApPersonService };
 const $ApQuestionService: Provider = { provide: 'ApQuestionService', useExisting: ApQuestionService };
 const $ApEventService: Provider = { provide: 'ApEventService', useExisting: ApEventService };
+const $ApGameService: Provider = { provide: 'ApGameService', useExisting: ApGameService };
 //#endregion
 
 @Module({
@@ -456,6 +458,7 @@ const $ApEventService: Provider = { provide: 'ApEventService', useExisting: ApEv
 		ApPersonService,
 		ApQuestionService,
 		ApEventService,
+		ApGameService,
 		QueueService,
 
 		//#region 文字列ベースでのinjection用(循環参照対応のため)
@@ -605,6 +608,7 @@ const $ApEventService: Provider = { provide: 'ApEventService', useExisting: ApEv
 		$ApPersonService,
 		$ApQuestionService,
 		$ApEventService,
+		ApGameService,
 		//#endregion
 	],
 	exports: [
@@ -754,6 +758,7 @@ const $ApEventService: Provider = { provide: 'ApEventService', useExisting: ApEv
 		ApPersonService,
 		ApQuestionService,
 		ApEventService,
+		ApGameService,
 		QueueService,
 
 		//#region 文字列ベースでのinjection用(循環参照対応のため)
@@ -902,6 +907,7 @@ const $ApEventService: Provider = { provide: 'ApEventService', useExisting: ApEv
 		$ApPersonService,
 		$ApQuestionService,
 		$ApEventService,
+		$ApGameService,
 		//#endregion
 	],
 })

--- a/packages/backend/src/core/CoreModule.ts
+++ b/packages/backend/src/core/CoreModule.ts
@@ -608,7 +608,7 @@ const $ApGameService: Provider = { provide: 'ApGameService', useExisting: ApGame
 		$ApPersonService,
 		$ApQuestionService,
 		$ApEventService,
-		ApGameService,
+		$ApGameService,
 		//#endregion
 	],
 	exports: [

--- a/packages/backend/src/core/GlobalEventService.ts
+++ b/packages/backend/src/core/GlobalEventService.ts
@@ -203,6 +203,9 @@ export interface ReversiEventTypes {
 	invited: {
 		user: Packed<'User'>;
 	};
+	uninvited: {
+		user: Packed<'User'>;
+	};
 }
 
 export interface ReversiGameEventTypes {

--- a/packages/backend/src/core/GlobalEventService.ts
+++ b/packages/backend/src/core/GlobalEventService.ts
@@ -203,9 +203,6 @@ export interface ReversiEventTypes {
 	invited: {
 		user: Packed<'User'>;
 	};
-	uninvited: {
-		user: Packed<'User'>;
-	};
 }
 
 export interface ReversiGameEventTypes {

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -565,7 +565,10 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 		if (game == null) throw new Error('game not found');
 		if (!game.isStarted) return;
 		if (game.isEnded) return;
-		if ((game.user1Id !== user.id) && (game.user2Id !== user.id)) return;
+		if ((game.user1Id !== user.id) && (game.user2Id !== user.id)) {
+			console.log('Reversi:putStoneToGame user is not player');
+			return;
+		}
 
 		const myColor =
 			((game.user1Id === user.id) && game.black === 1) || ((game.user2Id === user.id) && game.black === 2)
@@ -580,8 +583,14 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 			logs: game.logs,
 		});
 
-		if (engine.turn !== myColor) return;
-		if (!engine.canPut(myColor, pos)) return;
+		if (engine.turn !== myColor) {
+			console.log('Reversi:putStoneToGame bad turn');
+			return;
+		}
+		if (!engine.canPut(myColor, pos)) {
+			console.log('Reversi:putStoneToGame can not Putable');
+			return;
+		}
 
 		engine.putStone(pos);
 

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -509,7 +509,7 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 	}
 
 	@bindThis
-	public async updateSettings(gameId: MiReversiGame['id'], user: MiUser, key: string, value: any, required_old_value:any = undefined) {
+	public async updateSettings(gameId: MiReversiGame['id'], user: MiUser, key: string, value: any) {
 		const game = await this.get(gameId);
 		if (game == null) throw new Error('game not found');
 		if (game.isStarted) return;
@@ -519,10 +519,6 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 
 		if (!['map', 'bw', 'isLlotheo', 'canPutEverywhere', 'loopedBoard', 'timeLimitForEachTurn'].includes(key)) return;
 
-		if (required_old_value !== undefined) {
-			const old_value:any = (game as any)[key];//強引に持ってきてる
-			if (old_value !== required_old_value) return;
-		}
 		// TODO: より厳格なバリデーション
 
 		const updatedGame = {
@@ -541,13 +537,11 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 
 		if (user.host === null && remote_user && remote_user.host !== null) {
 			if (game.federationId === null) throw new Error('game.federationId===null');
-			const old_value:any = (game as any)[key];//強引に持ってきてる
 			const update = await this.apRendererService.renderReversiUpdate(user, remote_user as MiRemoteUser, {
 				game_session_id: game.federationId,
 				type: 'settings',
 				key,
 				value,
-				old_value,
 			});
 			const content = this.apRendererService.addContext(update);
 			const dm = this.apDeliverManagerService.createDeliverManager({

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -162,6 +162,7 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 		}
 		return null;
 	}
+	@bindThis
 	public async inviteFromRemoteUser(fromUser:MiRemoteUser, targetUser:MiUser) {
 		const redisPipeline = this.redisClient.pipeline();
 		redisPipeline.zadd(`reversi:matchSpecific:${targetUser.id}`, Date.now(), fromUser.id);

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -159,7 +159,7 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 				throw new Error('WIP');
 			}
 			const remote_user : MiRemoteUser = targetUser as MiRemoteUser;
-			let game_session_id = randomUUID().toString();
+			const game_session_id = randomUUID().toString();
 			//有効な招待を列挙
 			const invitations = (await this.redisClient.zrange(
 				`reversi:matchSpecific:${targetUser.id}`,
@@ -170,8 +170,9 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 			for (const invite of invitations) {
 				if (invite.actor === me_uri) {
 					//招待がすでに発行されていた場合には初期IDを使う
-					game_session_id = invite.object.game_state.game_session_id;
-					console.log('reversi:TTL延長 ' + game_session_id);
+					//game_session_id = invite.object.game_state.game_session_id;
+					//console.log('reversi:TTL延長 ' + game_session_id);
+					break;
 				}
 			}
 			const invite = await this.apGameService.renderReversiInvite(game_session_id, me, remote_user, new Date());

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -142,7 +142,7 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 			}
 			const remote_user : MiRemoteUser = targetUser as MiRemoteUser;
 			const game_session_id = 'b5faaae6-45fc-474d-925d-310b2867b66c';
-			const content = this.apRendererService.addContext(await this.apGameService.renderReversiInvite(game_session_id, me, remote_user, new Date()));
+			const content = this.apRendererService.addContext(await this.apRendererService.renderReversiInvite(game_session_id, me, remote_user, new Date()));
 			const dm = this.apDeliverManagerService.createDeliverManager({
 				id: me.id,
 				host: null,

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -140,8 +140,15 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 			if (targetUser.uri === null) {
 				throw new Error('WIP');
 			}
-			const found = await this.redisClient.get(`reversi:matchSpecific:${targetUser.id}`) !== null;
-			if (found) {
+			//有効な招待を列挙
+			const invitations = await this.redisClient.zrange(
+				`reversi:matchSpecific:${targetUser.id}`,
+				Date.now() - INVITATION_TIMEOUT_MS,
+				'+inf',
+				'BYSCORE');
+
+			if (invitations.includes(targetUser.id)) {
+				//何らかの招待が有効であるのでこれ以上配送をしない
 				return null;
 			}
 			const remote_user : MiRemoteUser = targetUser as MiRemoteUser;

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -495,6 +495,23 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 		};
 		this.cacheGame(updatedGame);
 
+		const remote_user = user.id === game.user1Id ? game.user2 : game.user1;
+
+		if (remote_user && remote_user.host != null) {
+			const update = await this.apGameService.renderReversiUpdate(user, remote_user as MiRemoteUser, {
+				type: 'settings',
+				key,
+				value,
+			});
+			const content = this.apRendererService.addContext(update);
+			const dm = this.apDeliverManagerService.createDeliverManager({
+				id: user.id,
+				host: null,
+			}, content);
+			dm.addDirectRecipe(remote_user as MiRemoteUser);
+			trackPromise(dm.execute());
+		}
+
 		this.globalEventService.publishReversiGameStream(game.id, 'updateSettings', {
 			userId: user.id,
 			key: key,

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -129,7 +129,9 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 				console.log('ゲーム開始 共通セッションid=' + game_session_id);
 				await this.redisClient.zrem(`reversi:matchSpecific:${me.id}`, JSON.stringify(invite));
 
-				const game = await this.matched(targetUser.id, me.id, {
+				const parentId = invite.host_user_id ? invite.host_user_id : targetUser.id;
+				const childId = parentId === me.id ? targetUser.id : me.id;
+				const game = await this.matched(parentId, childId, {
 					noIrregularRules: false,
 				}, game_session_id);
 				if (targetUser.host !== null) {

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -169,23 +169,6 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 			}
 			const remote_user : MiRemoteUser = targetUser as MiRemoteUser;
 			const game_session_id = randomUUID().toString();
-			/*
-			//有効な招待を列挙
-			const invitations = (await this.redisClient.zrange(
-				`reversi:matchSpecific:${targetUser.id}`,
-				Date.now() - INVITATION_TIMEOUT_MS,
-				'+inf',
-				'BYSCORE')).map(raw => JSON.parse(raw));
-			const me_uri = this.userEntityService.genLocalUserUri(me.id);
-			for (const invite of invitations) {
-				if (invite.actor === me_uri) {
-					//招待がすでに発行されていた場合には初期IDを使う
-					//game_session_id = invite.object.game_state.game_session_id;
-					//console.log('reversi:TTL延長 ' + game_session_id);
-					break;
-				}
-			}
-			*/
 			const invite = await this.apRendererService.renderReversiInvite(game_session_id, me, remote_user, new Date());
 			const content = this.apRendererService.addContext(invite);
 

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -96,7 +96,7 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 	}
 
 	@bindThis
-	public async matchSpecificUser(me: MiUser, targetUser: MiUser, multiple = false): Promise<MiReversiGame | null> {
+	public async matchSpecificUser(me: MiUser, targetUser: MiUser, multiple = false, accept_only = false): Promise<MiReversiGame | null> {
 		if (targetUser.id === me.id) {
 			throw new Error('You cannot match yourself.');
 		}
@@ -158,7 +158,10 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 			}
 		}
 		//#endregion
-
+		//参加のみフラグが付いていた場合は招待を確認するだけ
+		if (accept_only) {
+			return null;
+		}
 		if (targetUser.host !== null) {
 			//リモートユーザーに招待を飛ばす
 			if (targetUser.uri === null) {

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -346,6 +346,21 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 		} else {
 			return;
 		}
+		if (user.host === null) {
+			const remote_user = user.id === game.user1Id ? game.user2 : game.user1;
+			const update = await this.apRendererService.renderReversiUpdate(user, remote_user as MiRemoteUser, {
+				game_session_id: game.federationId,
+				type: 'ready_states',
+				ready,
+			});
+			const content = this.apRendererService.addContext(update);
+			const dm = this.apDeliverManagerService.createDeliverManager({
+				id: user.id,
+				host: null,
+			}, content);
+			dm.addDirectRecipe(remote_user as MiRemoteUser);
+			trackPromise(dm.execute());
+		}
 
 		if (isBothReady) {
 			// 3秒後、両者readyならゲーム開始

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -111,15 +111,16 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 			const game_state = {
 				state: 'match',
 			};
+			console.log('A');
 			const content = this.apRendererService.addContext(await this.apRendererService.renderGame(local_user_id, remote_user_uri, game_id, game_state));
+			console.log('B');
 			const dm = this.apDeliverManagerService.createDeliverManager({
 				id: me.id,
 				host: null,
 			}, content);
-			dm.addDirectRecipe({
-				host: targetUser.host,
-				uri: targetUser.uri,
-			} as MiRemoteUser);
+			console.log('C');
+			dm.addDirectRecipe(targetUser as MiRemoteUser);
+			console.log('D');
 			trackPromise(dm.execute());
 		}
 

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -48,7 +48,6 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 		private globalEventService: GlobalEventService,
 		private reversiGameEntityService: ReversiGameEntityService,
 		private apRendererService: ApRendererService,
-		private apGameService: ApGameService,
 		private apDeliverManagerService: ApDeliverManagerService,
 		private idService: IdService,
 	) {

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -25,6 +25,7 @@ import { trackPromise } from '@/misc/promise-tracker.js';
 import { ReversiGameEntityService } from './entities/ReversiGameEntityService.js';
 import { ApRendererService } from './activitypub/ApRendererService.js';
 import { ApDeliverManagerService } from './activitypub/ApDeliverManagerService.js';
+import { ApGameService } from './activitypub/models/ApGameService.js';
 import type { OnApplicationShutdown, OnModuleInit } from '@nestjs/common';
 
 const INVITATION_TIMEOUT_MS = 1000 * 20; // 20sec
@@ -47,6 +48,7 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 		private globalEventService: GlobalEventService,
 		private reversiGameEntityService: ReversiGameEntityService,
 		private apRendererService: ApRendererService,
+		private apGameService: ApGameService,
 		private apDeliverManagerService: ApDeliverManagerService,
 		private idService: IdService,
 	) {
@@ -102,16 +104,12 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 
 		if (targetUser.host !== null) {
 			//超暫定的な処理
-			const local_user_id = me.id;
-			const remote_user_uri = targetUser.uri;
-			if (remote_user_uri === null) {
+			if (targetUser.uri === null) {
 				throw new Error('WIP');
 			}
-			const game_id = '1c086295-25e3-4b82-b31e-3e3959906312';
-			const game_state = {
-				state: 'match',
-			};
-			const content = this.apRendererService.addContext(await this.apRendererService.renderGame(local_user_id, remote_user_uri, game_id, game_state));
+			const remote_user : MiRemoteUser = targetUser as MiRemoteUser;
+			const invite_id = 'b5faaae6-45fc-474d-925d-310b2867b66c';
+			const content = this.apRendererService.addContext(await this.apGameService.renderReversiInvite(invite_id, me, remote_user, new Date()));
 			const dm = this.apDeliverManagerService.createDeliverManager({
 				id: me.id,
 				host: null,

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -131,8 +131,7 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 
 				const game = await this.matched(targetUser.id, me.id, {
 					noIrregularRules: false,
-					federationId: game_session_id,
-				});
+				}, game_session_id);
 				if (targetUser.host !== null) {
 					//重要。リモートユーザーが送ってきたIDの解決に使う
 					const redisPipeline = this.redisClient.pipeline();
@@ -249,7 +248,6 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 
 			const game = await this.matched(invitorId, me.id, {
 				noIrregularRules: false,
-				federationId: null, //ランダムマッチは連合非対応
 			});
 
 			return game;
@@ -275,7 +273,6 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 
 			const game = await this.matched(matchedUserId, me.id, {
 				noIrregularRules: options.noIrregularRules || option === 'noIrregularRules',
-				federationId: null, //ランダムマッチは連合非対応
 			});
 
 			return game;
@@ -376,7 +373,7 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 	}
 
 	@bindThis
-	private async matched(parentId: MiUser['id'], childId: MiUser['id'], options: { noIrregularRules: boolean;federationId:string|null; }): Promise<MiReversiGame> {
+	private async matched(parentId: MiUser['id'], childId: MiUser['id'], options: { noIrregularRules: boolean;}, federationId:string|null = null): Promise<MiReversiGame> {
 		const game = await this.reversiGamesRepository.insertOne({
 			id: this.idService.gen(),
 			user1Id: parentId,
@@ -390,6 +387,7 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 			bw: 'random',
 			isLlotheo: false,
 			noIrregularRules: options.noIrregularRules,
+			federationId,
 		}, { relations: ['user1', 'user2'] });
 		this.cacheGame(game);
 

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -295,8 +295,11 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 	}
 
 	@bindThis
-	public async matchSpecificUserCancel(user: MiUser, targetUser: MiUser) {
-		await this.redisClient.zrem(`reversi:matchSpecific:${targetUser.id}`, user.id);
+	public async matchSpecificUserCancel(user: MiUser, targetUser: MiUser, game_session_id:string|undefined = undefined) {
+		await this.redisClient.zrem(`reversi:matchSpecific:${targetUser.id}`, JSON.stringify({
+			from_user_id: user.id,
+			game_session_id,
+		}));
 		this.globalEventService.publishReversiStream(targetUser.id, 'uninvited', {
 			user: await this.userEntityService.pack(user, targetUser),
 		});

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -8,7 +8,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import * as Redis from 'ioredis';
 import { ModuleRef } from '@nestjs/core';
 import * as Reversi from 'misskey-reversi';
-import { IsNull, LessThan, MoreThan } from 'typeorm';
+import { LessThan, MoreThan } from 'typeorm';
 import type {
 	MiReversiGame,
 	ReversiGamesRepository,

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -111,16 +111,12 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 			const game_state = {
 				state: 'match',
 			};
-			console.log('A');
 			const content = this.apRendererService.addContext(await this.apRendererService.renderGame(local_user_id, remote_user_uri, game_id, game_state));
-			console.log('B');
 			const dm = this.apDeliverManagerService.createDeliverManager({
 				id: me.id,
 				host: null,
 			}, content);
-			console.log('C');
 			dm.addDirectRecipe(targetUser as MiRemoteUser);
-			console.log('D');
 			trackPromise(dm.execute());
 		}
 

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -108,8 +108,8 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 				throw new Error('WIP');
 			}
 			const remote_user : MiRemoteUser = targetUser as MiRemoteUser;
-			const invite_id = 'b5faaae6-45fc-474d-925d-310b2867b66c';
-			const content = this.apRendererService.addContext(await this.apGameService.renderReversiInvite(invite_id, me, remote_user, new Date()));
+			const game_session_id = 'b5faaae6-45fc-474d-925d-310b2867b66c';
+			const content = this.apRendererService.addContext(await this.apGameService.renderReversiInvite(game_session_id, me, remote_user, new Date()));
 			const dm = this.apDeliverManagerService.createDeliverManager({
 				id: me.id,
 				host: null,

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -134,7 +134,7 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 					noIrregularRules: false,
 				});
 				if (targetUser.host !== null) {
-				//リモートユーザーに招待を飛ばす
+					//リモートユーザーに参加を飛ばす
 					if (targetUser.uri === null) {
 						throw new Error('WIP');
 					}
@@ -160,6 +160,7 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 			}
 			const remote_user : MiRemoteUser = targetUser as MiRemoteUser;
 			const game_session_id = randomUUID().toString();
+			/*
 			//有効な招待を列挙
 			const invitations = (await this.redisClient.zrange(
 				`reversi:matchSpecific:${targetUser.id}`,
@@ -175,6 +176,7 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 					break;
 				}
 			}
+			*/
 			const invite = await this.apGameService.renderReversiInvite(game_session_id, me, remote_user, new Date());
 			const content = this.apRendererService.addContext(invite);
 

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -297,6 +297,9 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 	@bindThis
 	public async matchSpecificUserCancel(user: MiUser, targetUser: MiUser) {
 		await this.redisClient.zrem(`reversi:matchSpecific:${targetUser.id}`, user.id);
+		this.globalEventService.publishReversiStream(targetUser.id, 'uninvited', {
+			user: await this.userEntityService.pack(user, targetUser),
+		});
 	}
 
 	@bindThis

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -352,8 +352,8 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 		} else {
 			return;
 		}
-		if (user.host === null) {
-			const remote_user = user.id === game.user1Id ? game.user2 : game.user1;
+		const remote_user = user.id === game.user1Id ? game.user2 : game.user1;
+		if (user.host === null && remote_user && remote_user.host) {
 			if (game.federationId === null) throw new Error('game.federationId===null');
 			const update = await this.apRendererService.renderReversiUpdate(user, remote_user as MiRemoteUser, {
 				game_session_id: game.federationId,

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -48,6 +48,7 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 		private globalEventService: GlobalEventService,
 		private reversiGameEntityService: ReversiGameEntityService,
 		private apRendererService: ApRendererService,
+		private apGameService: ApGameService,
 		private apDeliverManagerService: ApDeliverManagerService,
 		private idService: IdService,
 	) {
@@ -141,7 +142,7 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 			}
 			const remote_user : MiRemoteUser = targetUser as MiRemoteUser;
 			const game_session_id = 'b5faaae6-45fc-474d-925d-310b2867b66c';
-			const content = this.apRendererService.addContext(await this.apRendererService.renderReversiInvite(game_session_id, me, remote_user, new Date()));
+			const content = this.apRendererService.addContext(await this.apGameService.renderReversiInvite(game_session_id, me, remote_user, new Date()));
 			const dm = this.apDeliverManagerService.createDeliverManager({
 				id: me.id,
 				host: null,
@@ -160,17 +161,6 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 			});
 		}
 		return null;
-	}
-	@bindThis
-	public async inviteFromRemoteUser(fromUser:MiRemoteUser, targetUser:MiUser) {
-		const redisPipeline = this.redisClient.pipeline();
-		redisPipeline.zadd(`reversi:matchSpecific:${targetUser.id}`, Date.now(), fromUser.id);
-		redisPipeline.expire(`reversi:matchSpecific:${targetUser.id}`, 120, 'NX');
-		await redisPipeline.exec();
-
-		this.globalEventService.publishReversiStream(targetUser.id, 'invited', {
-			user: await this.userEntityService.pack(fromUser, targetUser),
-		});
 	}
 	@bindThis
 	public async matchAnyUser(me: MiUser, options: { noIrregularRules: boolean }, multiple = false): Promise<MiReversiGame | null> {

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -300,9 +300,6 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 			from_user_id: user.id,
 			game_session_id,
 		}));
-		this.globalEventService.publishReversiStream(targetUser.id, 'uninvited', {
-			user: await this.userEntityService.pack(user, targetUser),
-		});
 	}
 
 	@bindThis

--- a/packages/backend/src/core/activitypub/ApInboxService.ts
+++ b/packages/backend/src/core/activitypub/ApInboxService.ts
@@ -874,7 +874,7 @@ export class ApInboxService {
 		if (target_user === null || target_user.host !== null) {
 			return 'skip: unknown target user';
 		}
-		await this.apgameService.reversiInboxUpdate(game);
+		await this.apgameService.reversiInboxUpdate(target_user, actor, game);
 		return 'ok';
 	}
 

--- a/packages/backend/src/core/activitypub/ApInboxService.ts
+++ b/packages/backend/src/core/activitypub/ApInboxService.ts
@@ -334,14 +334,11 @@ export class ApInboxService {
 		const meta = await this.metaService.fetch();
 		if (this.utilityService.isBlockedHost(meta.blockedHosts, this.utilityService.extractDbHost(uri))) return;
 
-		const relays = await this.relayService.getAcceptedRelays();
-		const fromRelay = !!actor.inbox && relays.map(r => r.inbox).includes(actor.inbox);
-
 		const unlock = await this.appLockService.getApLock(uri);
 
 		try {
 			// 既に同じURIを持つものが登録されていないかチェック
-			const exist = await this.apNoteService.fetchNote(fromRelay ? targetUri : uri);
+			const exist = await this.apNoteService.fetchNote(uri);
 			if (exist) {
 				return;
 			}
@@ -364,12 +361,6 @@ export class ApInboxService {
 
 			if (!await this.noteEntityService.isVisibleForMe(renote, actor.id)) {
 				return 'skip: invalid actor for this activity';
-			}
-
-			if (fromRelay) {
-				const noteObj = await this.noteEntityService.pack(renote);
-				this.globalEventService.publishNotesStream(noteObj);
-				return;
 			}
 
 			this.logger.info(`Creating the (Re)Note: ${uri}`);

--- a/packages/backend/src/core/activitypub/ApInboxService.ts
+++ b/packages/backend/src/core/activitypub/ApInboxService.ts
@@ -42,7 +42,7 @@ import { ApPersonService } from './models/ApPersonService.js';
 import { ApQuestionService } from './models/ApQuestionService.js';
 import { ApGameService } from './models/ApGameService.js';
 import type { Resolver } from './ApResolverService.js';
-import type { IAccept, IAdd, IAnnounce, IBlock, ICreate, IDelete, IFlag, IFollow, ILike, IObject, IRead, IReject, IRemove, IUndo, IUpdate, IMove, IPost, IInvite, IApGame, IJoin } from './type.js';
+import type { IAccept, IAdd, IAnnounce, IBlock, ICreate, IDelete, IFlag, IFollow, ILike, IObject, IRead, IReject, IRemove, IUndo, IUpdate, IMove, IPost, IInvite, IApGame, IJoin, ILeave } from './type.js';
 
 @Injectable()
 export class ApInboxService {
@@ -977,7 +977,7 @@ export class ApInboxService {
 		return 'skip: unknown join type';
 	}
 	@bindThis
-	private async leave(actor: MiRemoteUser, activity: IJoin): Promise<string> {
+	private async leave(actor: MiRemoteUser, activity: ILeave): Promise<string> {
 		const resolver = this.apResolverService.createResolver();
 		const object = await resolver.resolve(activity.object).catch(e => {
 			this.logger.error(`Resolution failed: ${e}`);

--- a/packages/backend/src/core/activitypub/ApInboxService.ts
+++ b/packages/backend/src/core/activitypub/ApInboxService.ts
@@ -32,7 +32,7 @@ import type { MiRemoteUser } from '@/models/User.js';
 import { isNotNull } from '@/misc/is-not-null.js';
 import { GlobalEventService } from '@/core/GlobalEventService.js';
 import { AbuseReportService } from '@/core/AbuseReportService.js';
-import { getApHrefNullable, getApId, getApIds, getApType, isAccept, isActor, isAdd, isAnnounce, isBlock, isCollection, isCollectionOrOrderedCollection, isCreate, isDelete, isFlag, isFollow, isLike, isMove, isGame, isPost, isRead, isReject, isRemove, isTombstone, isUndo, isUpdate, validActor, validPost, isInvite, isJoin, isReversi, isLeave } from './type.js';
+import { getApHrefNullable, getApId, getApIds, getApType, isAccept, isActor, isAdd, isAnnounce, isBlock, isCollection, isCollectionOrOrderedCollection, isCreate, isDelete, isFlag, isFollow, isLike, isMove, isPost, isRead, isReject, isRemove, isTombstone, isUndo, isUpdate, validActor, validPost, isInvite, isJoin, isReversi, isLeave } from './type.js';
 import { ApNoteService } from './models/ApNoteService.js';
 import { ApLoggerService } from './ApLoggerService.js';
 import { ApDbResolverService } from './ApDbResolverService.js';

--- a/packages/backend/src/core/activitypub/ApInboxService.ts
+++ b/packages/backend/src/core/activitypub/ApInboxService.ts
@@ -32,7 +32,7 @@ import type { MiRemoteUser } from '@/models/User.js';
 import { isNotNull } from '@/misc/is-not-null.js';
 import { GlobalEventService } from '@/core/GlobalEventService.js';
 import { AbuseReportService } from '@/core/AbuseReportService.js';
-import { getApHrefNullable, getApId, getApIds, getApType, isAccept, isActor, isAdd, isAnnounce, isBlock, isCollection, isCollectionOrOrderedCollection, isCreate, isDelete, isFlag, isFollow, isLike, isMove, isPost, isRead, isReject, isRemove, isTombstone, isUndo, isUpdate, validActor, validPost } from './type.js';
+import { getApHrefNullable, getApId, getApIds, getApType, isAccept, isActor, isAdd, isAnnounce, isBlock, isCollection, isCollectionOrOrderedCollection, isCreate, isDelete, isFlag, isFollow, isLike, isMove, isGame, isPost, isRead, isReject, isRemove, isTombstone, isUndo, isUpdate, validActor, validPost } from './type.js';
 import { ApNoteService } from './models/ApNoteService.js';
 import { ApLoggerService } from './ApLoggerService.js';
 import { ApDbResolverService } from './ApDbResolverService.js';
@@ -41,7 +41,7 @@ import { ApAudienceService } from './ApAudienceService.js';
 import { ApPersonService } from './models/ApPersonService.js';
 import { ApQuestionService } from './models/ApQuestionService.js';
 import type { Resolver } from './ApResolverService.js';
-import type { IAccept, IAdd, IAnnounce, IBlock, ICreate, IDelete, IFlag, IFollow, ILike, IObject, IRead, IReject, IRemove, IUndo, IUpdate, IMove, IPost } from './type.js';
+import type { IAccept, IAdd, IAnnounce, IBlock, ICreate, IDelete, IFlag, IFollow, ILike, IObject, IRead, IReject, IRemove, IUndo, IUpdate, IMove, IGame, IPost } from './type.js';
 
 @Injectable()
 export class ApInboxService {
@@ -167,6 +167,8 @@ export class ApInboxService {
 			return await this.flag(actor, activity);
 		} else if (isMove(activity)) {
 			return await this.move(actor, activity);
+		} else if (isGame(activity)) {
+			return await this.game(actor, activity);
 		} else {
 			return `unrecognized activity type: ${activity.type}`;
 		}
@@ -872,5 +874,21 @@ export class ApInboxService {
 		if (!targetUri) return 'skip: invalid activity target';
 
 		return await this.apPersonService.updatePerson(actor.uri) ?? 'skip: nothing to do';
+	}
+	@bindThis
+	private async game(actor: MiRemoteUser, activity: IGame): Promise<string> {
+		if(activity.game_type_uuid !=="1c086295-25e3-4b82-b31e-3e3959906312"){
+			return 'skip: unknown game type';
+		}
+		const target_user = await this.apDbResolverService.getUserFromApId(activity.object);
+
+		if (target_user == null) {
+			return 'skip: target_user not found';
+		}
+		let remote_user=await this.usersRepository.findOneByOrFail({ id: actor.id });
+		let local_user=await this.usersRepository.findOneByOrFail({ id: target_user.id });
+		console.log(remote_user);
+		console.log(local_user);
+		return 'ok';
 	}
 }

--- a/packages/backend/src/core/activitypub/ApInboxService.ts
+++ b/packages/backend/src/core/activitypub/ApInboxService.ts
@@ -896,10 +896,10 @@ export class ApInboxService {
 			}
 			let remote_user=await this.usersRepository.findOneByOrFail({ id: actor.id });
 			let local_user=await this.usersRepository.findOneByOrFail({ id: target_user.id });
-			if (remote_user == null || local_user==null) {
+			if (remote_user == null || local_user==null || remote_user.host == null || remote_user.uri == null) {
 				return 'skip: user resolve error';
 			}
-			this.apgameService.reversiInboxInvite(local_user,remote_user,game);
+			this.apgameService.reversiInboxInvite(local_user,remote_user as MiRemoteUser,game);
 			return 'ok';
 		}
 		return 'skip: unknown invite type';

--- a/packages/backend/src/core/activitypub/ApInboxService.ts
+++ b/packages/backend/src/core/activitypub/ApInboxService.ts
@@ -32,7 +32,7 @@ import type { MiRemoteUser } from '@/models/User.js';
 import { isNotNull } from '@/misc/is-not-null.js';
 import { GlobalEventService } from '@/core/GlobalEventService.js';
 import { AbuseReportService } from '@/core/AbuseReportService.js';
-import { getApHrefNullable, getApId, getApIds, getApType, isAccept, isActor, isAdd, isAnnounce, isBlock, isCollection, isCollectionOrOrderedCollection, isCreate, isDelete, isFlag, isFollow, isLike, isMove, isGame, isPost, isRead, isReject, isRemove, isTombstone, isUndo, isUpdate, validActor, validPost, isInvite, isJoin } from './type.js';
+import { getApHrefNullable, getApId, getApIds, getApType, isAccept, isActor, isAdd, isAnnounce, isBlock, isCollection, isCollectionOrOrderedCollection, isCreate, isDelete, isFlag, isFollow, isLike, isMove, isGame, isPost, isRead, isReject, isRemove, isTombstone, isUndo, isUpdate, validActor, validPost, isInvite, isJoin, isReversi } from './type.js';
 import { ApNoteService } from './models/ApNoteService.js';
 import { ApLoggerService } from './ApLoggerService.js';
 import { ApDbResolverService } from './ApDbResolverService.js';
@@ -712,7 +712,7 @@ export class ApInboxService {
 			const to = toArray(activity.to);
 			const target_user = to.length > 0 ? await this.apDbResolverService.getUserFromApId(to[0]) : null;
 			const game = object as IApGame;
-			if (game.game_type_uuid !== ApGameService.reversiUUID) {
+			if (!isReversi(game)) {
 				return 'skip: unknown game type';
 			}
 			if (target_user === null || target_user.host !== null) {
@@ -868,7 +868,7 @@ export class ApInboxService {
 	private async updateGame(resolver: Resolver, actor: MiRemoteUser, game: IApGame, activity: IUpdate): Promise<string> {
 		const to = toArray(activity.to);
 		const target_user = to.length > 0 ? await this.apDbResolverService.getUserFromApId(to[0]) : null;
-		if (game.game_type_uuid !== ApGameService.reversiUUID) {
+		if (!isReversi(game)) {
 			return 'skip: unknown game type';
 		}
 		if (target_user === null || target_user.host !== null) {
@@ -931,7 +931,7 @@ export class ApInboxService {
 			const to = toArray(activity.to);
 			const target_user = to.length > 0 ? await this.apDbResolverService.getUserFromApId(to[0]) : null;
 			const game = object as IApGame;
-			if (game.game_type_uuid !== ApGameService.reversiUUID) {
+			if (!isReversi(game)) {
 				return 'skip: unknown game type';
 			}
 			if (target_user == null) {
@@ -958,7 +958,7 @@ export class ApInboxService {
 			const to = toArray(activity.to);
 			const target_user = to.length > 0 ? await this.apDbResolverService.getUserFromApId(to[0]) : null;
 			const game = object as IApGame;
-			if (game.game_type_uuid !== ApGameService.reversiUUID) {
+			if (!isReversi(game)) {
 				return 'skip: unknown game type';
 			}
 			if (target_user == null) {

--- a/packages/backend/src/core/activitypub/ApRendererService.ts
+++ b/packages/backend/src/core/activitypub/ApRendererService.ts
@@ -32,7 +32,7 @@ import { IdService } from '@/core/IdService.js';
 import { JsonLdService } from './JsonLdService.js';
 import { ApMfmService } from './ApMfmService.js';
 import { CONTEXT } from './misc/contexts.js';
-import type { IAccept, IActivity, IAdd, IAnnounce, IApDocument, IApEmoji, IApHashtag, IApImage, IApMention, IBlock, ICreate, IDelete, IFlag, IFollow, IKey, ILike, IMove, IObject, IPost, IQuestion, IRead, IReject, IRemove, ITombstone, IUndo, IUpdate } from './type.js';
+import type { IAccept, IActivity, IAdd, IAnnounce, IApDocument, IApEmoji, IApHashtag, IApImage, IApMention, IBlock, ICreate, IDelete, IFlag, IFollow, IGame, IKey, ILike, IMove, IObject, IPost, IQuestion, IRead, IReject, IRemove, ITombstone, IUndo, IUpdate } from './type.js';
 
 @Injectable()
 export class ApRendererService {
@@ -722,5 +722,18 @@ export class ApRendererService {
 		const emojis = names.map(name => allEmojis.get(name)).filter(isNotNull);
 
 		return emojis;
+	}
+
+	@bindThis
+	public renderGame(local_user_id:string, remote_user_uri:string, game_id:'1c086295-25e3-4b82-b31e-3e3959906312', game_state:any): IGame {
+		//ゲームIDに合わせたコマンドがgame_state内に入る。ゲームによって適切な値が違うからとりあえずanyにしとく
+		return {
+			type: 'Game',
+			id: `${this.config.url}/games/${game_id}`,
+			actor: this.userEntityService.genLocalUserUri(local_user_id),
+			object: remote_user_uri,
+			game_type_uuid: game_id,
+			game_state,
+		};
 	}
 }

--- a/packages/backend/src/core/activitypub/ApRendererService.ts
+++ b/packages/backend/src/core/activitypub/ApRendererService.ts
@@ -723,23 +723,4 @@ export class ApRendererService {
 
 		return emojis;
 	}
-	@bindThis
-	public async renderReversiInvite(game_session_id:string, invite_from:MiUser, invite_to:MiRemoteUser, invite_date:Date): Promise<IInvite> {
-		const game:IApGame = {
-			type: 'Game',
-			game_type_uuid: '1c086295-25e3-4b82-b31e-3e3959906312',
-			game_state: null,
-		};
-		const activity: IInvite = {
-			id: `${this.config.url}/games/${game.game_type_uuid}/${game_session_id}/activity`,
-			actor: this.userEntityService.genLocalUserUri(invite_from.id),
-			type: 'Invite',
-			published: invite_date.toISOString(),
-			object: game,
-		};
-		activity.to = invite_to.uri;//フォロワー限定に招待する場合は`${actor.uri}/followers`
-		activity.cc = [];//誰でも観戦が許可される場合はCCに"https://www.w3.org/ns/activitystreams#Public"を指定
-
-		return activity;
-	}
 }

--- a/packages/backend/src/core/activitypub/ApRendererService.ts
+++ b/packages/backend/src/core/activitypub/ApRendererService.ts
@@ -778,7 +778,6 @@ export class ApRendererService {
 			pos?:number;//石配置
 			key?:string;//設定変更
 			value?:any;//設定変更
-			old_value?:any;//設定変更
 			ready?:boolean;//ゲーム開始
 		},
 	) {

--- a/packages/backend/src/core/activitypub/ApRendererService.ts
+++ b/packages/backend/src/core/activitypub/ApRendererService.ts
@@ -32,7 +32,8 @@ import { IdService } from '@/core/IdService.js';
 import { JsonLdService } from './JsonLdService.js';
 import { ApMfmService } from './ApMfmService.js';
 import { CONTEXT } from './misc/contexts.js';
-import type { IAccept, IActivity, IAdd, IAnnounce, IApDocument, IApEmoji, IApGame, IApHashtag, IApImage, IApMention, IBlock, ICreate, IDelete, IFlag, IFollow, IGame, IInvite, IKey, ILike, IMove, IObject, IPost, IQuestion, IRead, IReject, IRemove, ITombstone, IUndo, IUpdate } from './type.js';
+import { ApGameService } from './models/ApGameService.js';
+import type { IAccept, IActivity, IAdd, IAnnounce, IApDocument, IApEmoji, IApGame, IApHashtag, IApImage, IApMention, IBlock, ICreate, IDelete, IFlag, IFollow, IGame, IInvite, IJoin, IKey, ILike, IMove, IObject, IPost, IQuestion, IRead, IReject, IRemove, ITombstone, IUndo, IUpdate } from './type.js';
 
 @Injectable()
 export class ApRendererService {
@@ -722,5 +723,67 @@ export class ApRendererService {
 		const emojis = names.map(name => allEmojis.get(name)).filter(isNotNull);
 
 		return emojis;
+	}
+
+	@bindThis
+	public async renderReversiInvite(game_session_id:string, invite_from:MiUser, invite_to:MiRemoteUser, invite_date:Date): Promise<IInvite> {
+		const game:IApGame = {
+			type: 'Game',
+			game_type_uuid: ApGameService.reversiUUID,
+			game_state: {
+				game_session_id,
+			},
+		};
+		const activity: IInvite = {
+			id: `${this.config.url}/games/${game.game_type_uuid}/${game_session_id}/activity`,
+			actor: this.userEntityService.genLocalUserUri(invite_from.id),
+			type: 'Invite',
+			published: invite_date.toISOString(),
+			object: game,
+		};
+		activity.to = invite_to.uri;//フォロワー限定に招待する場合は`${actor.uri}/followers`
+		activity.cc = [];//誰でも観戦が許可される場合はCCに"https://www.w3.org/ns/activitystreams#Public"を指定
+
+		return activity;
+	}
+
+	@bindThis
+	public async renderReversiJoin(game_session_id:string, join_user:MiUser, invite_from:MiRemoteUser, join_date:Date): Promise<IJoin> {
+		const game:IApGame = {
+			type: 'Game',
+			game_type_uuid: ApGameService.reversiUUID,
+			game_state: {
+				game_session_id,
+			},
+		};
+		const activity: IJoin = {
+			id: `${this.config.url}/games/${game.game_type_uuid}/${game_session_id}/activity`,
+			actor: this.userEntityService.genLocalUserUri(join_user.id),
+			type: 'Join',
+			published: join_date.toISOString(),
+			object: game,
+		};
+		activity.to = invite_from.uri;//フォロワー限定に招待する場合は`${actor.uri}/followers`
+		activity.cc = [];//誰でも観戦が許可される場合はCCに"https://www.w3.org/ns/activitystreams#Public"を指定
+
+		return activity;
+	}
+
+	@bindThis
+	public async renderReversiUpdate(local_user:MiUser, remote_user:MiRemoteUser, game_state:any) {
+		const game:IApGame = {
+			type: 'Game',
+			game_type_uuid: ApGameService.reversiUUID,
+			game_state,
+		};
+		const activity: IUpdate = {
+			type: 'Update',
+			actor: this.userEntityService.genLocalUserUri(local_user.id),
+			object: game,
+		};
+		activity.to = remote_user.uri;
+		activity.cc = [];
+
+		return activity;
 	}
 }

--- a/packages/backend/src/core/activitypub/ApRendererService.ts
+++ b/packages/backend/src/core/activitypub/ApRendererService.ts
@@ -32,7 +32,7 @@ import { IdService } from '@/core/IdService.js';
 import { JsonLdService } from './JsonLdService.js';
 import { ApMfmService } from './ApMfmService.js';
 import { CONTEXT } from './misc/contexts.js';
-import type { IAccept, IActivity, IAdd, IAnnounce, IApDocument, IApEmoji, IApHashtag, IApImage, IApMention, IBlock, ICreate, IDelete, IFlag, IFollow, IGame, IKey, ILike, IMove, IObject, IPost, IQuestion, IRead, IReject, IRemove, ITombstone, IUndo, IUpdate } from './type.js';
+import type { IAccept, IActivity, IAdd, IAnnounce, IApDocument, IApEmoji, IApGame, IApHashtag, IApImage, IApMention, IBlock, ICreate, IDelete, IFlag, IFollow, IGame, IInvite, IKey, ILike, IMove, IObject, IPost, IQuestion, IRead, IReject, IRemove, ITombstone, IUndo, IUpdate } from './type.js';
 
 @Injectable()
 export class ApRendererService {
@@ -723,17 +723,23 @@ export class ApRendererService {
 
 		return emojis;
 	}
-
 	@bindThis
-	public renderGame(local_user_id:string, remote_user_uri:string, game_id:'1c086295-25e3-4b82-b31e-3e3959906312', game_state:any): IGame {
-		//ゲームIDに合わせたコマンドがgame_state内に入る。ゲームによって適切な値が違うからとりあえずanyにしとく
-		return {
+	public async renderReversiInvite(game_session_id:string, invite_from:MiUser, invite_to:MiRemoteUser, invite_date:Date): Promise<IInvite> {
+		const game:IApGame = {
 			type: 'Game',
-			id: `${this.config.url}/games/${game_id}`,
-			actor: this.userEntityService.genLocalUserUri(local_user_id),
-			object: remote_user_uri,
-			game_type_uuid: game_id,
-			game_state: JSON.stringify(game_state),
+			game_type_uuid: '1c086295-25e3-4b82-b31e-3e3959906312',
+			game_state: null,
 		};
+		const activity: IInvite = {
+			id: `${this.config.url}/games/${game.game_type_uuid}/${game_session_id}/activity`,
+			actor: this.userEntityService.genLocalUserUri(invite_from.id),
+			type: 'Invite',
+			published: invite_date.toISOString(),
+			object: game,
+		};
+		activity.to = invite_to.uri;//フォロワー限定に招待する場合は`${actor.uri}/followers`
+		activity.cc = [];//誰でも観戦が許可される場合はCCに"https://www.w3.org/ns/activitystreams#Public"を指定
+
+		return activity;
 	}
 }

--- a/packages/backend/src/core/activitypub/ApRendererService.ts
+++ b/packages/backend/src/core/activitypub/ApRendererService.ts
@@ -741,8 +741,8 @@ export class ApRendererService {
 			published: invite_date.toISOString(),
 			object: game,
 		};
-		activity.to = invite_to.uri;//フォロワー限定に招待する場合は`${actor.uri}/followers`
-		activity.cc = [];//誰でも観戦が許可される場合はCCに"https://www.w3.org/ns/activitystreams#Public"を指定
+		activity.to = invite_to.uri;
+		activity.cc = [];
 
 		return activity;
 	}
@@ -764,8 +764,8 @@ export class ApRendererService {
 			published: join_date.toISOString(),
 			object: game,
 		};
-		activity.to = invite_from.uri;//フォロワー限定に招待する場合は`${actor.uri}/followers`
-		activity.cc = [];//誰でも観戦が許可される場合はCCに"https://www.w3.org/ns/activitystreams#Public"を指定
+		activity.to = invite_from.uri;
+		activity.cc = [];
 
 		return activity;
 	}

--- a/packages/backend/src/core/activitypub/ApRendererService.ts
+++ b/packages/backend/src/core/activitypub/ApRendererService.ts
@@ -733,7 +733,7 @@ export class ApRendererService {
 			actor: this.userEntityService.genLocalUserUri(local_user_id),
 			object: remote_user_uri,
 			game_type_uuid: game_id,
-			game_state,
+			game_state: JSON.stringify(game_state),
 		};
 	}
 }

--- a/packages/backend/src/core/activitypub/ApRendererService.ts
+++ b/packages/backend/src/core/activitypub/ApRendererService.ts
@@ -32,7 +32,7 @@ import { IdService } from '@/core/IdService.js';
 import { JsonLdService } from './JsonLdService.js';
 import { ApMfmService } from './ApMfmService.js';
 import { CONTEXT } from './misc/contexts.js';
-import type { IAccept, IActivity, IAdd, IAnnounce, IApDocument, IApEmoji, IApGame, IApHashtag, IApImage, IApMention, IApReversi, IBlock, ICreate, IDelete, IFlag, IFollow, IInvite, IJoin, IKey, ILike, IMove, IObject, IPost, IQuestion, IRead, IReject, IRemove, ITombstone, IUndo, IUpdate } from './type.js';
+import type { IAccept, IActivity, IAdd, IAnnounce, IApDocument, IApEmoji, IApGame, IApHashtag, IApImage, IApMention, IApReversi, IBlock, ICreate, IDelete, IFlag, IFollow, IInvite, IJoin, IKey, ILeave, ILike, IMove, IObject, IPost, IQuestion, IRead, IReject, IRemove, ITombstone, IUndo, IUpdate } from './type.js';
 
 @Injectable()
 export class ApRendererService {
@@ -777,6 +777,24 @@ export class ApRendererService {
 		};
 		const activity: IUpdate = {
 			type: 'Update',
+			actor: this.userEntityService.genLocalUserUri(local_user.id),
+			object: game,
+		};
+		activity.to = remote_user.uri;
+		activity.cc = [];
+
+		return activity;
+	}
+
+	@bindThis
+	public async renderReversiLeave(local_user: MiUser, remote_user: MiRemoteUser, game_state: { game_session_id: string; }) {
+		const game:IApReversi = {
+			type: 'Game',
+			game_type_uuid: '1c086295-25e3-4b82-b31e-3e3959906312',
+			game_state,
+		};
+		const activity: ILeave = {
+			type: 'Leave',
 			actor: this.userEntityService.genLocalUserUri(local_user.id),
 			object: game,
 		};

--- a/packages/backend/src/core/activitypub/ApRendererService.ts
+++ b/packages/backend/src/core/activitypub/ApRendererService.ts
@@ -32,8 +32,7 @@ import { IdService } from '@/core/IdService.js';
 import { JsonLdService } from './JsonLdService.js';
 import { ApMfmService } from './ApMfmService.js';
 import { CONTEXT } from './misc/contexts.js';
-import { ApGameService } from './models/ApGameService.js';
-import type { IAccept, IActivity, IAdd, IAnnounce, IApDocument, IApEmoji, IApGame, IApHashtag, IApImage, IApMention, IBlock, ICreate, IDelete, IFlag, IFollow, IGame, IInvite, IJoin, IKey, ILike, IMove, IObject, IPost, IQuestion, IRead, IReject, IRemove, ITombstone, IUndo, IUpdate } from './type.js';
+import type { IAccept, IActivity, IAdd, IAnnounce, IApDocument, IApEmoji, IApGame, IApHashtag, IApImage, IApMention, IApReversi, IBlock, ICreate, IDelete, IFlag, IFollow, IInvite, IJoin, IKey, ILike, IMove, IObject, IPost, IQuestion, IRead, IReject, IRemove, ITombstone, IUndo, IUpdate } from './type.js';
 
 @Injectable()
 export class ApRendererService {
@@ -727,9 +726,9 @@ export class ApRendererService {
 
 	@bindThis
 	public async renderReversiInvite(game_session_id:string, invite_from:MiUser, invite_to:MiRemoteUser, invite_date:Date): Promise<IInvite> {
-		const game:IApGame = {
+		const game:IApReversi = {
 			type: 'Game',
-			game_type_uuid: ApGameService.reversiUUID,
+			game_type_uuid: '1c086295-25e3-4b82-b31e-3e3959906312',
 			game_state: {
 				game_session_id,
 			},
@@ -749,9 +748,9 @@ export class ApRendererService {
 
 	@bindThis
 	public async renderReversiJoin(game_session_id:string, join_user:MiUser, invite_from:MiRemoteUser, join_date:Date): Promise<IJoin> {
-		const game:IApGame = {
+		const game:IApReversi = {
 			type: 'Game',
-			game_type_uuid: ApGameService.reversiUUID,
+			game_type_uuid: '1c086295-25e3-4b82-b31e-3e3959906312',
 			game_state: {
 				game_session_id,
 			},
@@ -771,9 +770,9 @@ export class ApRendererService {
 
 	@bindThis
 	public async renderReversiUpdate(local_user:MiUser, remote_user:MiRemoteUser, game_state:any) {
-		const game:IApGame = {
+		const game:IApReversi = {
 			type: 'Game',
-			game_type_uuid: ApGameService.reversiUUID,
+			game_type_uuid: '1c086295-25e3-4b82-b31e-3e3959906312',
 			game_state,
 		};
 		const activity: IUpdate = {

--- a/packages/backend/src/core/activitypub/ApRendererService.ts
+++ b/packages/backend/src/core/activitypub/ApRendererService.ts
@@ -32,7 +32,7 @@ import { IdService } from '@/core/IdService.js';
 import { JsonLdService } from './JsonLdService.js';
 import { ApMfmService } from './ApMfmService.js';
 import { CONTEXT } from './misc/contexts.js';
-import type { IAccept, IActivity, IAdd, IAnnounce, IApDocument, IApEmoji, IApGame, IApHashtag, IApImage, IApMention, IApReversi, IBlock, ICreate, IDelete, IFlag, IFollow, IInvite, IJoin, IKey, ILeave, ILike, IMove, IObject, IPost, IQuestion, IRead, IReject, IRemove, ITombstone, IUndo, IUpdate } from './type.js';
+import type { IAccept, IActivity, IAdd, IAnnounce, IApDocument, IApEmoji, IApHashtag, IApImage, IApMention, IApReversi, IBlock, ICreate, IDelete, IFlag, IFollow, IInvite, IJoin, IKey, ILeave, ILike, IMove, IObject, IPost, IQuestion, IRead, IReject, IRemove, ITombstone, IUndo, IUpdate } from './type.js';
 
 @Injectable()
 export class ApRendererService {

--- a/packages/backend/src/core/activitypub/ApRendererService.ts
+++ b/packages/backend/src/core/activitypub/ApRendererService.ts
@@ -729,6 +729,7 @@ export class ApRendererService {
 		const game:IApReversi = {
 			type: 'Game',
 			game_type_uuid: '1c086295-25e3-4b82-b31e-3e3959906312',
+			extent_flags: [],
 			game_state: {
 				game_session_id,
 			},
@@ -751,6 +752,7 @@ export class ApRendererService {
 		const game:IApReversi = {
 			type: 'Game',
 			game_type_uuid: '1c086295-25e3-4b82-b31e-3e3959906312',
+			extent_flags: [],
 			game_state: {
 				game_session_id,
 			},
@@ -769,10 +771,21 @@ export class ApRendererService {
 	}
 
 	@bindThis
-	public async renderReversiUpdate(local_user:MiUser, remote_user:MiRemoteUser, game_state:any) {
+	public async renderReversiUpdate(local_user:MiUser, remote_user:MiRemoteUser,
+		game_state: {
+			game_session_id: string;
+			type:string;
+			pos?:number;//石配置
+			key?:string;//設定変更
+			value?:any;//設定変更
+			old_value?:any;//設定変更
+			ready?:boolean;//ゲーム開始
+		},
+	) {
 		const game:IApReversi = {
 			type: 'Game',
 			game_type_uuid: '1c086295-25e3-4b82-b31e-3e3959906312',
+			extent_flags: [],
 			game_state,
 		};
 		const activity: IUpdate = {
@@ -791,6 +804,7 @@ export class ApRendererService {
 		const game:IApReversi = {
 			type: 'Game',
 			game_type_uuid: '1c086295-25e3-4b82-b31e-3e3959906312',
+			extent_flags: [],
 			game_state,
 		};
 		const activity: ILeave = {

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -52,7 +52,7 @@ export class ApGameService {
 		const targetUser = local_user;
 		const fromUser = remote_user;
 		const redisPipeline = this.redisClient.pipeline();
-		if (!game_state.game_session_id) throw Error('bad session');
+		if (!game_state.game_session_id) throw Error('bad session' + JSON.stringify(game_state));
 		redisPipeline.zadd(`reversi:matchSpecific:${targetUser.id}`, Date.now(), JSON.stringify( {
 			from_user_id: fromUser.id,
 			game_session_id: game_state.game_session_id,

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -46,19 +46,19 @@ export class ApGameService {
 	}
 	async reversiInboxUpdate(local_user: MiUser, remote_user: MiRemoteUser, apgame: IApGame) {
 		console.log('リバーシのUpdateが飛んできた' + JSON.stringify(apgame.game_state));
-		const key = apgame.game_state.key;
-		const value = apgame.game_state.value;
 		const id = await this.gameIdFromUUID(apgame.game_state.game_session_id);
 		if (id === null) {
 			console.error('Update reversi Id Solve error');
 			return;
 		}
-		const game = await this.reversiService.updateSettings(id, remote_user, key, value, false);
-		this.globalEventService.publishReversiGameStream(id, 'updateSettings', {
-			userId: remote_user.id,
-			key: key,
-			value: value,
-		});
+		if (apgame.game_state.type === 'settings') {
+			const key = apgame.game_state.key;
+			const value = apgame.game_state.value;
+			await this.reversiService.updateSettings(id, remote_user, key, value, false);
+		} else if (apgame.game_state.type === 'ready_states') {
+			const ready = apgame.game_state.ready;
+			await this.reversiService.gameReady(id, remote_user, ready);
+		}
 	}
 	async reversiInboxJoin(local_user: MiUser, remote_user: MiRemoteUser, game: IApGame) {
 		const targetUser = local_user;

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -45,7 +45,10 @@ export class ApGameService {
 		const fromUser = remote_user;
 		if (!game.game_state.game_session_id) throw Error('bad session' + JSON.stringify(game));
 		const redisPipeline = this.redisClient.pipeline();
-		redisPipeline.zadd(`reversi:matchSpecific:${targetUser.id}`, Date.now(), fromUser.id);
+		redisPipeline.zadd(`reversi:matchSpecific:${targetUser.id}`, Date.now(), JSON.stringify( {
+			from_user_id: fromUser.id,
+			game_session_id: game.game_state.game_session_id,
+		}));
 		redisPipeline.expire(`reversi:matchSpecific:${targetUser.id}`, 120, 'NX');
 		await redisPipeline.exec();
 	}

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -44,23 +44,4 @@ export class ApGameService {
 			appAccessTokenId: null,
 		});
 	}
-	@bindThis
-	public async renderReversiInvite(game_session_id:string, invite_from:MiUser, invite_to:MiRemoteUser, invite_date:Date): Promise<IInvite> {
-		const game:IApGame = {
-			type: 'Game',
-			game_type_uuid: '1c086295-25e3-4b82-b31e-3e3959906312',
-			game_state: null,
-		};
-		const activity: IInvite = {
-			id: `${this.config.url}/games/${game.game_type_uuid}/${game_session_id}/activity`,
-			actor: this.userEntityService.genLocalUserUri(invite_from.id),
-			type: 'Invite',
-			published: invite_date.toISOString(),
-			object: game,
-		};
-		activity.to = invite_to.uri;//フォロワー限定に招待する場合は`${actor.uri}/followers`
-		activity.cc = [];//誰でも観戦が許可される場合はCCに"https://www.w3.org/ns/activitystreams#Public"を指定
-
-		return activity;
-	}
 }

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -55,10 +55,19 @@ export class ApGameService {
 		if (apgame.game_state.type === 'settings') {
 			const key = apgame.game_state.key;
 			const value = apgame.game_state.value;
-			await this.reversiService.updateSettings(id, remote_user, key, value);
+			if (key && value) {
+				await this.reversiService.updateSettings(id, remote_user, key, value);
+			}
 		} else if (apgame.game_state.type === 'ready_states') {
 			const ready = apgame.game_state.ready;
-			await this.reversiService.gameReady(id, remote_user, ready);
+			if (ready !== undefined && ready !== null) {
+				await this.reversiService.gameReady(id, remote_user, ready);
+			}
+		} else if (apgame.game_state.type === 'putstone') {
+			const pos = apgame.game_state.pos;
+			if (pos !== undefined && pos !== null) {
+				await this.reversiService.putStoneToGame(id, remote_user, pos);
+			}
 		}
 	}
 	async reversiInboxLeave(local_user: MiUser, remote_user: MiRemoteUser, apgame: IApReversi) {

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -47,7 +47,7 @@ export class ApGameService {
 	}
 	async reversiInboxUpdate(local_user: MiUser, remote_user: MiRemoteUser, apgame: IApGame) {
 		console.log('リバーシのUpdateが飛んできた' + JSON.stringify(apgame.game_state));
-		const id = await this.gameIdFromUUID(apgame.game_state.game_session_id);
+		const id = await this.reversiIdFromUUID(apgame.game_state.game_session_id);
 		if (id === null) {
 			console.error('Update reversi Id Solve error');
 			return;
@@ -62,7 +62,7 @@ export class ApGameService {
 		}
 	}
 	async reversiInboxLeave(local_user: MiUser, remote_user: MiRemoteUser, apgame: IApReversi) {
-		const id = await this.gameIdFromUUID(apgame.game_state.game_session_id);
+		const id = await this.reversiIdFromUUID(apgame.game_state.game_session_id);
 		if (id === null) {
 			console.error('Update reversi Id Solve error');
 			return;
@@ -103,7 +103,7 @@ export class ApGameService {
 			user: await this.userEntityService.pack(fromUser, targetUser),
 		});
 	}
-	public async gameIdFromUUID(game_session_id:string) :Promise<string|null> {
+	public async reversiIdFromUUID(game_session_id:string) :Promise<string|null> {
 		//キャッシュにあればそれ
 		const cache = await this.redisClient.get(`reversi:federationId:${game_session_id}`);
 		if (cache) {

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -77,6 +77,7 @@ export class ApGameService {
 		redisPipeline.zadd(`reversi:matchSpecific:${targetUser.id}`, Date.now(), JSON.stringify( {
 			from_user_id: fromUser.id,
 			game_session_id: game.game_state.game_session_id,
+			host_user_id: local_user.id,
 		}));
 		redisPipeline.expire(`reversi:matchSpecific:${targetUser.id}`, 120, 'NX');
 		await redisPipeline.exec();
@@ -95,6 +96,7 @@ export class ApGameService {
 		redisPipeline.zadd(`reversi:matchSpecific:${targetUser.id}`, Date.now(), JSON.stringify( {
 			from_user_id: fromUser.id,
 			game_session_id: game.game_state.game_session_id,
+			host_user_id: remote_user.id,
 		}));
 		redisPipeline.expire(`reversi:matchSpecific:${targetUser.id}`, 120, 'NX');
 		await redisPipeline.exec();

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -85,7 +85,7 @@ export class ApGameService {
 			this.reversiService.cancelGame(id, remote_user);
 		}
 	}
-	async reversiInboxJoin(local_user: MiUser, remote_user: MiRemoteUser, game: IApGame) {
+	async reversiInboxJoin(local_user: MiUser, remote_user: MiRemoteUser, game: IApReversi) {
 		const targetUser = local_user;
 		const fromUser = remote_user;
 		if (!game.game_state.game_session_id) throw Error('bad session' + JSON.stringify(game));
@@ -98,13 +98,10 @@ export class ApGameService {
 		redisPipeline.expire(`reversi:matchSpecific:${targetUser.id}`, 120, 'NX');
 		await redisPipeline.exec();
 	}
-	async reversiInboxUndoInvite(actor: MiRemoteUser, target_user:MiLocalUser, game: IApGame) {
-		await this.redisClient.zrem(`reversi:matchSpecific:${target_user.id}`, JSON.stringify({
-			from_user_id: actor.id,
-			game_session_id: game.game_state.game_session_id,
-		}));
+	async reversiInboxUndoInvite(actor: MiRemoteUser, target_user:MiLocalUser, game: IApReversi) {
+		this.reversiService.matchSpecificUserCancel(actor, target_user, game.game_state.game_session_id);
 	}
-	async reversiInboxInvite(local_user: MiUser, remote_user: MiRemoteUser, game: IApGame) {
+	async reversiInboxInvite(local_user: MiUser, remote_user: MiRemoteUser, game: IApReversi) {
 		const targetUser = local_user;
 		const fromUser = remote_user;
 		if (!game.game_state.game_session_id) throw Error('bad session' + JSON.stringify(game));

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -99,7 +99,7 @@ export class ApGameService {
 		await redisPipeline.exec();
 	}
 	async reversiInboxUndoInvite(actor: MiRemoteUser, target_user:MiLocalUser, game: IApReversi) {
-		this.reversiService.matchSpecificUserCancel(actor, target_user, game.game_state.game_session_id);
+		await this.reversiService.matchSpecificUserCancel(actor, target_user, game.game_state.game_session_id);
 	}
 	async reversiInboxInvite(local_user: MiUser, remote_user: MiRemoteUser, game: IApReversi) {
 		const targetUser = local_user;

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -48,14 +48,14 @@ export class ApGameService {
 			game_session_id: game.game_state.game_session_id,
 		}));
 	}
-	async reversiInboxInvite(local_user: MiUser, remote_user: MiRemoteUser, game_state: any) {
+	async reversiInboxInvite(local_user: MiUser, remote_user: MiRemoteUser, game: IApGame) {
 		const targetUser = local_user;
 		const fromUser = remote_user;
 		const redisPipeline = this.redisClient.pipeline();
-		if (!game_state.game_session_id) throw Error('bad session' + JSON.stringify(game_state));
+		if (!game.game_state.game_session_id) throw Error('bad session' + JSON.stringify(game));
 		redisPipeline.zadd(`reversi:matchSpecific:${targetUser.id}`, Date.now(), JSON.stringify( {
 			from_user_id: fromUser.id,
-			game_session_id: game_state.game_session_id,
+			game_session_id: game.game_state.game_session_id,
 		}));
 		redisPipeline.expire(`reversi:matchSpecific:${targetUser.id}`, 120, 'NX');
 		await redisPipeline.exec();

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -7,7 +7,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import Redis from 'ioredis';
 import type Logger from '@/logger.js';
 import { bindThis } from '@/decorators.js';
-import type { MiRemoteUser, MiUser } from '@/models/User.js';
+import type { MiLocalUser, MiRemoteUser, MiUser } from '@/models/User.js';
 import type { Config } from '@/config.js';
 import { DI } from '@/di-symbols.js';
 import { NotificationService } from '@/core/NotificationService.js';
@@ -18,7 +18,7 @@ import { ApLoggerService } from '../ApLoggerService.js';
 import { ApResolverService } from '../ApResolverService.js';
 import { UserEntityService } from '../../entities/UserEntityService.js';
 import type { Resolver } from '../ApResolverService.js';
-import type { IApGame, ICreate, IInvite, IObject } from '../type.js';
+import type { IApGame, ICreate, IInvite, IObject, IUndo } from '../type.js';
 
 @Injectable()
 export class ApGameService {
@@ -38,6 +38,9 @@ export class ApGameService {
 		private apLoggerService: ApLoggerService,
 	) {
 		this.logger = this.apLoggerService.logger;
+	}
+	async reversiInboxUndoInvite(actor: MiRemoteUser, target_user:MiLocalUser, game: IApGame) {
+		await this.redisClient.zrem(`reversi:matchSpecific:${target_user.id}`, actor.id);
 	}
 	async reversiInboxInvite(local_user: MiUser, remote_user: MiRemoteUser, game_state: any) {
 		const targetUser = local_user;

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -55,11 +55,10 @@ export class ApGameService {
 		if (apgame.game_state.type === 'settings') {
 			const key = apgame.game_state.key;
 			const value = apgame.game_state.value;
-			const old_value = apgame.game_state.old_value;
-			if (key && value && old_value) {
-				await this.reversiService.updateSettings(id, remote_user, key, value, old_value);
+			if (key && value) {
+				await this.reversiService.updateSettings(id, remote_user, key, value);
 			} else {
-				this.logger.warn('skip ApReversi settings unknown key or value or old_value');
+				this.logger.warn('skip ApReversi settings unknown key or value');
 			}
 		} else if (apgame.game_state.type === 'ready_states') {
 			const ready = apgame.game_state.ready;

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -10,6 +10,7 @@ import type { MiRemoteUser, MiUser } from '@/models/User.js';
 import type { Config } from '@/config.js';
 import { DI } from '@/di-symbols.js';
 import { NotificationService } from '@/core/NotificationService.js';
+import { ReversiService } from '@/core/ReversiService.js';
 import { isGame } from '../type.js';
 import { ApLoggerService } from '../ApLoggerService.js';
 import { ApResolverService } from '../ApResolverService.js';
@@ -28,13 +29,14 @@ export class ApGameService {
 		private apResolverService: ApResolverService,
 		private userEntityService: UserEntityService,
 		private notificationService: NotificationService,
+		private reversiService: ReversiService,
 		private apLoggerService: ApLoggerService,
 	) {
 		this.logger = this.apLoggerService.logger;
 	}
-	reversiInboxInvite(local_user: MiUser, remote_user: MiUser, game_state: any) {
-		console.log(remote_user);
-		console.log(local_user);
+	reversiInboxInvite(local_user: MiUser, remote_user: MiRemoteUser, game_state: any) {
+		this.reversiService.inviteFromRemoteUser(remote_user, local_user);
+		//招待が飛んできたら通知を飛ばす
 		this.notificationService.createNotification(local_user.id, 'app', {
 			customBody: 'reversiInboxInvite',
 			customHeader: null,

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -101,15 +101,9 @@ export class ApGameService {
 			return cache;
 		}
 		//無かったらDBから探す
-		const games = await this.reversiGamesRepository.find({
-			where: [
-				{ federationId: game_session_id },
-			],
-			relations: ['id'],
-			order: { id: 'DESC' },
-		});
-		if (games.length > 0) {
-			return games[0].id;
+		const game = await this.reversiGamesRepository.findOneBy({ federationId: game_session_id });
+		if (game !== null) {
+			return game.id;
 		}
 		//DBにも無いなら知らん
 		return null;

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -46,10 +46,10 @@ export class ApGameService {
 		this.logger = this.apLoggerService.logger;
 	}
 	async reversiInboxUpdate(local_user: MiUser, remote_user: MiRemoteUser, apgame: IApReversi) {
-		console.log('リバーシのUpdateが飛んできた' + JSON.stringify(apgame.game_state));
+		this.logger.debug('リバーシのUpdateが飛んできた' + JSON.stringify(apgame.game_state));
 		const id = await this.reversiIdFromUUID(apgame.game_state.game_session_id);
 		if (id === null) {
-			console.error('Update reversi Id Solve error');
+			this.logger.error('Update reversi Id Solve error');
 			return;
 		}
 		if (apgame.game_state.type === 'settings') {
@@ -58,17 +58,25 @@ export class ApGameService {
 			const old_value = apgame.game_state.old_value;
 			if (key && value && old_value) {
 				await this.reversiService.updateSettings(id, remote_user, key, value, old_value);
+			} else {
+				this.logger.warn('skip ApReversi settings unknown key or value or old_value');
 			}
 		} else if (apgame.game_state.type === 'ready_states') {
 			const ready = apgame.game_state.ready;
 			if (ready !== undefined) {
 				await this.reversiService.gameReady(id, remote_user, ready);
+			} else {
+				this.logger.warn('skip ApReversi undefined ready');
 			}
 		} else if (apgame.game_state.type === 'putstone') {
 			const pos = apgame.game_state.pos;
 			if (pos !== undefined) {
 				await this.reversiService.putStoneToGame(id, remote_user, pos);
+			} else {
+				this.logger.warn('skip ApReversi undefined putstone');
 			}
+		} else {
+			this.logger.error('skip ApReversi unknown update type');
 		}
 	}
 	async reversiInboxLeave(local_user: MiUser, remote_user: MiRemoteUser, apgame: IApReversi) {

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -45,7 +45,7 @@ export class ApGameService {
 	) {
 		this.logger = this.apLoggerService.logger;
 	}
-	async reversiInboxUpdate(local_user: MiUser, remote_user: MiRemoteUser, apgame: IApGame) {
+	async reversiInboxUpdate(local_user: MiUser, remote_user: MiRemoteUser, apgame: IApReversi) {
 		console.log('リバーシのUpdateが飛んできた' + JSON.stringify(apgame.game_state));
 		const id = await this.reversiIdFromUUID(apgame.game_state.game_session_id);
 		if (id === null) {
@@ -55,17 +55,18 @@ export class ApGameService {
 		if (apgame.game_state.type === 'settings') {
 			const key = apgame.game_state.key;
 			const value = apgame.game_state.value;
-			if (key && value) {
-				await this.reversiService.updateSettings(id, remote_user, key, value);
+			const old_value = apgame.game_state.old_value;
+			if (key && value && old_value) {
+				await this.reversiService.updateSettings(id, remote_user, key, value, old_value);
 			}
 		} else if (apgame.game_state.type === 'ready_states') {
 			const ready = apgame.game_state.ready;
-			if (ready !== undefined && ready !== null) {
+			if (ready !== undefined) {
 				await this.reversiService.gameReady(id, remote_user, ready);
 			}
 		} else if (apgame.game_state.type === 'putstone') {
 			const pos = apgame.game_state.pos;
-			if (pos !== undefined && pos !== null) {
+			if (pos !== undefined) {
 				await this.reversiService.putStoneToGame(id, remote_user, pos);
 			}
 		}

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -9,6 +9,7 @@ import { bindThis } from '@/decorators.js';
 import type { MiRemoteUser, MiUser } from '@/models/User.js';
 import type { Config } from '@/config.js';
 import { DI } from '@/di-symbols.js';
+import { NotificationService } from '@/core/NotificationService.js';
 import { isGame } from '../type.js';
 import { ApLoggerService } from '../ApLoggerService.js';
 import { ApResolverService } from '../ApResolverService.js';
@@ -18,10 +19,6 @@ import type { IApGame, ICreate, IInvite, IObject } from '../type.js';
 
 @Injectable()
 export class ApGameService {
-	reversiInboxInvite(local_user: MiUser, remote_user: MiUser, game_state: any) {
-		console.log(remote_user);
-		console.log(local_user);
-	}
 	private logger: Logger;
 
 	constructor(
@@ -30,19 +27,30 @@ export class ApGameService {
 
 		private apResolverService: ApResolverService,
 		private userEntityService: UserEntityService,
+		private notificationService: NotificationService,
 		private apLoggerService: ApLoggerService,
 	) {
 		this.logger = this.apLoggerService.logger;
 	}
+	reversiInboxInvite(local_user: MiUser, remote_user: MiUser, game_state: any) {
+		console.log(remote_user);
+		console.log(local_user);
+		this.notificationService.createNotification(local_user.id, 'app', {
+			customBody: 'reversiInboxInvite',
+			customHeader: null,
+			customIcon: null,
+			appAccessTokenId: null,
+		});
+	}
 	@bindThis
-	public async renderReversiInvite(invite_id:string, invite_from:MiUser, invite_to:MiRemoteUser, invite_date:Date): Promise<IInvite> {
+	public async renderReversiInvite(game_session_id:string, invite_from:MiUser, invite_to:MiRemoteUser, invite_date:Date): Promise<IInvite> {
 		const game:IApGame = {
 			type: 'Game',
 			game_type_uuid: '1c086295-25e3-4b82-b31e-3e3959906312',
 			game_state: null,
 		};
 		const activity: IInvite = {
-			id: `${this.config.url}/games/${game.game_type_uuid}/${invite_id}/activity`,
+			id: `${this.config.url}/games/${game.game_type_uuid}/${game_session_id}/activity`,
 			actor: this.userEntityService.genLocalUserUri(invite_from.id),
 			type: 'Invite',
 			published: invite_date.toISOString(),

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -76,7 +76,13 @@ export class ApGameService {
 			console.error('Update reversi Id Solve error');
 			return;
 		}
-		this.reversiService.surrender(id, remote_user);
+		const game = await this.reversiService.get(id);
+		if (game === null) return;
+		if (game.isStarted) {
+			this.reversiService.surrender(id, remote_user);
+		} else {
+			this.reversiService.cancelGame(id, remote_user);
+		}
 	}
 	async reversiInboxJoin(local_user: MiUser, remote_user: MiRemoteUser, game: IApGame) {
 		const targetUser = local_user;

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project yojo-art team
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Injectable } from '@nestjs/common';
+import type Logger from '@/logger.js';
+import { bindThis } from '@/decorators.js';
+import { isGame } from '../type.js';
+import { ApLoggerService } from '../ApLoggerService.js';
+import { ApResolverService } from '../ApResolverService.js';
+import type { Resolver } from '../ApResolverService.js';
+import type { IObject } from '../type.js';
+
+@Injectable()
+export class ApGameService {
+	private logger: Logger;
+
+	constructor(
+		private apResolverService: ApResolverService,
+		private apLoggerService: ApLoggerService,
+	) {
+		this.logger = this.apLoggerService.logger;
+	}
+}

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -103,6 +103,13 @@ export class ApGameService {
 		//無かったらDBから探す
 		const game = await this.reversiGamesRepository.findOneBy({ federationId: game_session_id });
 		if (game !== null) {
+			const redisPipeline = this.redisClient.pipeline();
+			redisPipeline.set(`reversi:federationId:${game_session_id}`, game.id);
+			redisPipeline.expire(`reversi:federationId:${game_session_id}`, 300);//適当、いい感じにしたい
+			await redisPipeline.exec();
+			if (cache) {
+				return cache;
+			}
 			return game.id;
 		}
 		//DBにも無いなら知らん

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -23,7 +23,6 @@ import type { IApGame, ICreate, IInvite, IJoin, IObject, IUndo, IUpdate } from '
 
 @Injectable()
 export class ApGameService {
-	public static readonly reversiUUID = '1c086295-25e3-4b82-b31e-3e3959906312';
 	private logger: Logger;
 
 	constructor(

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -78,7 +78,7 @@ export class ApGameService {
 	async reversiInboxLeave(local_user: MiUser, remote_user: MiRemoteUser, apgame: IApReversi) {
 		const id = await this.reversiIdFromUUID(apgame.game_state.game_session_id);
 		if (id === null) {
-			console.error('Update reversi Id Solve error');
+			this.logger.error('Update reversi Id Solve error');
 			return;
 		}
 		const game = await this.reversiService.get(id);

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -6,7 +6,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import Redis from 'ioredis';
 import type Logger from '@/logger.js';
-import { bindThis } from '@/decorators.js';
 import type { MiLocalUser, MiRemoteUser, MiUser } from '@/models/User.js';
 import type { Config } from '@/config.js';
 import { DI } from '@/di-symbols.js';
@@ -14,12 +13,10 @@ import { NotificationService } from '@/core/NotificationService.js';
 import { ReversiService } from '@/core/ReversiService.js';
 import { GlobalEventService } from '@/core/GlobalEventService.js';
 import type { ReversiGamesRepository } from '@/models/_.js';
-import { isGame } from '../type.js';
 import { ApLoggerService } from '../ApLoggerService.js';
 import { ApResolverService } from '../ApResolverService.js';
 import { UserEntityService } from '../../entities/UserEntityService.js';
-import type { Resolver } from '../ApResolverService.js';
-import type { IApGame, IApReversi, ICreate, IInvite, IJoin, IObject, IUndo, IUpdate } from '../type.js';
+import type { IApReversi } from '../type.js';
 
 @Injectable()
 export class ApGameService {

--- a/packages/backend/src/core/activitypub/type.ts
+++ b/packages/backend/src/core/activitypub/type.ts
@@ -318,6 +318,12 @@ export interface IMove extends IActivity {
 	target: IObject | string;
 }
 
+export interface IGame extends IActivity {
+	type: 'Game';
+	game_type_uuid: string;
+	game_state: any;
+}
+
 export const isCreate = (object: IObject): object is ICreate => getApType(object) === 'Create';
 export const isDelete = (object: IObject): object is IDelete => getApType(object) === 'Delete';
 export const isUpdate = (object: IObject): object is IUpdate => getApType(object) === 'Update';
@@ -334,3 +340,4 @@ export const isBlock = (object: IObject): object is IBlock => getApType(object) 
 export const isFlag = (object: IObject): object is IFlag => getApType(object) === 'Flag';
 export const isMove = (object: IObject): object is IMove => getApType(object) === 'Move';
 export const isNote = (object: IObject): object is IPost => getApType(object) === 'Note';
+export const isGame = (object: IObject): object is IGame => getApType(object) === 'Game';

--- a/packages/backend/src/core/activitypub/type.ts
+++ b/packages/backend/src/core/activitypub/type.ts
@@ -328,6 +328,9 @@ export interface IMove extends IActivity {
 export interface IInvite extends IActivity {
 	type: 'Invite';
 }
+export interface IJoin extends IActivity {
+	type: 'Join';
+}
 
 export const isCreate = (object: IObject): object is ICreate => getApType(object) === 'Create';
 export const isDelete = (object: IObject): object is IDelete => getApType(object) === 'Delete';
@@ -346,3 +349,4 @@ export const isFlag = (object: IObject): object is IFlag => getApType(object) ==
 export const isMove = (object: IObject): object is IMove => getApType(object) === 'Move';
 export const isNote = (object: IObject): object is IPost => getApType(object) === 'Note';
 export const isInvite = (object: IObject): object is IInvite => getApType(object) === 'Invite';
+export const isJoin = (object: IObject): object is IJoin => getApType(object) === 'Join';

--- a/packages/backend/src/core/activitypub/type.ts
+++ b/packages/backend/src/core/activitypub/type.ts
@@ -261,8 +261,15 @@ export interface IApGame extends IObject {
 	game_type_uuid: string;
 	game_state: any;
 }
+export interface IApReversi extends IApGame {
+	type: 'Game';
+	game_type_uuid: '1c086295-25e3-4b82-b31e-3e3959906312';
+	game_state: any;
+}
 export const isGame = (object: IObject): object is IApGame =>
 	getApType(object) === 'Game';
+export const isReversi = (object: IObject): object is IApReversi =>
+	isGame(object) && object.game_type_uuid === '1c086295-25e3-4b82-b31e-3e3959906312';
 
 export interface ICreate extends IActivity {
 	type: 'Create';

--- a/packages/backend/src/core/activitypub/type.ts
+++ b/packages/backend/src/core/activitypub/type.ts
@@ -338,6 +338,9 @@ export interface IInvite extends IActivity {
 export interface IJoin extends IActivity {
 	type: 'Join';
 }
+export interface ILeave extends IActivity {
+	type: 'Leave';
+}
 
 export const isCreate = (object: IObject): object is ICreate => getApType(object) === 'Create';
 export const isDelete = (object: IObject): object is IDelete => getApType(object) === 'Delete';
@@ -357,3 +360,4 @@ export const isMove = (object: IObject): object is IMove => getApType(object) ==
 export const isNote = (object: IObject): object is IPost => getApType(object) === 'Note';
 export const isInvite = (object: IObject): object is IInvite => getApType(object) === 'Invite';
 export const isJoin = (object: IObject): object is IJoin => getApType(object) === 'Join';
+export const isLeave = (object: IObject): object is ILeave => getApType(object) === 'Leave';

--- a/packages/backend/src/core/activitypub/type.ts
+++ b/packages/backend/src/core/activitypub/type.ts
@@ -262,9 +262,17 @@ export interface IApGame extends IObject {
 	game_state: any;
 }
 export interface IApReversi extends IApGame {
-	type: 'Game';
 	game_type_uuid: '1c086295-25e3-4b82-b31e-3e3959906312';
-	game_state: any;
+	extent_flags: string[];
+	game_state: {
+		game_session_id:string,
+		type?:string,
+		key?:string, //設定変更
+		value?:any, //設定変更
+		old_value?:any, //設定変更
+		ready?:boolean, //準備完了
+		pos?:number, //石配置
+	};
 }
 export const isGame = (object: IObject): object is IApGame =>
 	getApType(object) === 'Game';

--- a/packages/backend/src/core/activitypub/type.ts
+++ b/packages/backend/src/core/activitypub/type.ts
@@ -269,7 +269,6 @@ export interface IApReversi extends IApGame {
 		type?:string,
 		key?:string, //設定変更
 		value?:any, //設定変更
-		old_value?:any, //設定変更
 		ready?:boolean, //準備完了
 		pos?:number, //石配置
 	};

--- a/packages/backend/src/core/activitypub/type.ts
+++ b/packages/backend/src/core/activitypub/type.ts
@@ -256,6 +256,14 @@ export interface IApImage extends IApDocument {
 	type: 'Image';
 }
 
+export interface IApGame extends IObject {
+	type: 'Game';
+	game_type_uuid: string;
+	game_state: any;
+}
+export const isGame = (object: IObject): object is IApGame =>
+	getApType(object) === 'Game';
+
 export interface ICreate extends IActivity {
 	type: 'Create';
 }
@@ -317,11 +325,8 @@ export interface IMove extends IActivity {
 	type: 'Move';
 	target: IObject | string;
 }
-
-export interface IGame extends IActivity {
-	type: 'Game';
-	game_type_uuid: string;
-	game_state: any;
+export interface IInvite extends IActivity {
+	type: 'Invite';
 }
 
 export const isCreate = (object: IObject): object is ICreate => getApType(object) === 'Create';
@@ -340,4 +345,4 @@ export const isBlock = (object: IObject): object is IBlock => getApType(object) 
 export const isFlag = (object: IObject): object is IFlag => getApType(object) === 'Flag';
 export const isMove = (object: IObject): object is IMove => getApType(object) === 'Move';
 export const isNote = (object: IObject): object is IPost => getApType(object) === 'Note';
-export const isGame = (object: IObject): object is IGame => getApType(object) === 'Game';
+export const isInvite = (object: IObject): object is IInvite => getApType(object) === 'Invite';

--- a/packages/backend/src/models/ReversiGame.ts
+++ b/packages/backend/src/models/ReversiGame.ts
@@ -145,4 +145,8 @@ export class MiReversiGame {
 		length: 32, nullable: true,
 	})
 	public crc32: string | null;
+	@Column('varchar', {
+		length: 36, nullable: true,
+	})
+	public federationId: string | null;
 }

--- a/packages/backend/src/server/api/endpoints/reversi/cancel-match.ts
+++ b/packages/backend/src/server/api/endpoints/reversi/cancel-match.ts
@@ -6,6 +6,8 @@
 import { Injectable } from '@nestjs/common';
 import { Endpoint } from '@/server/api/endpoint-base.js';
 import { ReversiService } from '@/core/ReversiService.js';
+import { ApiError } from '../../error.js';
+import { GetterService } from '../../GetterService.js';
 
 export const meta = {
 	tags: ['reversi', 'account'],
@@ -14,6 +16,11 @@ export const meta = {
 	kind: 'write:account',
 
 	errors: {
+		noSuchUser: {
+			message: 'No such user.',
+			code: 'NO_SUCH_USER',
+			id: '0b4f0559-b484-4e31-9581-3f73cee89b28',
+		},
 	},
 } as const;
 
@@ -28,11 +35,19 @@ export const paramDef = {
 @Injectable()
 export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-disable-line import/no-default-export
 	constructor(
+		private getterService: GetterService,
 		private reversiService: ReversiService,
 	) {
 		super(meta, paramDef, async (ps, me) => {
 			if (ps.userId) {
-				await this.reversiService.matchSpecificUserCancel(me, ps.userId);
+				const target = ps.userId ? await this.getterService.getUser(ps.userId).catch(err => {
+					if (err.id === '15348ddd-432d-49c2-8a5a-8069753becff') throw new ApiError(meta.errors.noSuchUser);
+					throw err;
+				}) : null;
+				if (target == null) {
+					throw new ApiError(meta.errors.noSuchUser);
+				}
+				await this.reversiService.matchSpecificUserCancel(me, target);
 				return;
 			} else {
 				await this.reversiService.matchAnyUserCancel(me);

--- a/packages/backend/src/server/api/endpoints/reversi/match.ts
+++ b/packages/backend/src/server/api/endpoints/reversi/match.ts
@@ -43,6 +43,7 @@ export const paramDef = {
 		userId: { type: 'string', format: 'misskey:id', nullable: true },
 		noIrregularRules: { type: 'boolean', default: false },
 		multiple: { type: 'boolean', default: false },
+		accept_only: { type: 'boolean', default: false },
 	},
 	required: [],
 } as const;
@@ -63,7 +64,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 			}) : null;
 
 			const game = target
-				? await this.reversiService.matchSpecificUser(me, target, ps.multiple)
+				? await this.reversiService.matchSpecificUser(me, target, ps.multiple, ps.accept_only)
 				: await this.reversiService.matchAnyUser(me, { noIrregularRules: ps.noIrregularRules }, ps.multiple);
 
 			if (game == null) return;

--- a/packages/cherrypick-js/src/autogen/types.ts
+++ b/packages/cherrypick-js/src/autogen/types.ts
@@ -29093,6 +29093,8 @@ export type operations = {
           noIrregularRules?: boolean;
           /** @default false */
           multiple?: boolean;
+          /** @default false */
+          accept_only?: boolean;
         };
       };
     };

--- a/packages/frontend/src/pages/reversi/game.board.vue
+++ b/packages/frontend/src/pages/reversi/game.board.vue
@@ -22,8 +22,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 			<div v-if="(logPos !== game.logs.length) && turnUser">
 				<Mfm :key="'past-turn-of:' + turnUser.id" :text="i18n.tsx._reversi.pastTurnOf({ name: turnUser.name ?? turnUser.username })" :plain="true" :customEmojis="turnUser.emojis"/>
 			</div>
-			<div v-if="iAmPlayer && !game.isEnded && !isMyTurn">{{ i18n.ts._reversi.opponentTurn }}<MkEllipsis/><span style="margin-left: 1em; opacity: 0.7;">({{ i18n.tsx.remainingN({ n: opTurnTimerRmain }) }})</span></div>
-			<div v-if="iAmPlayer && !game.isEnded && isMyTurn"><span style="display: inline-block; font-weight: bold; animation: global-tada 1s linear infinite both;">{{ i18n.ts._reversi.myTurn }}</span><span style="margin-left: 1em; opacity: 0.7;">({{ i18n.tsx.remainingN({ n: myTurnTimerRmain }) }})</span></div>
+			<div v-if="iAmPlayer && !game.isEnded && !isMyTurn">{{ i18n.ts._reversi.opponentTurn }}<MkEllipsis/><span v-if="!isFederation" style="margin-left: 1em; opacity: 0.7;">({{ i18n.tsx.remainingN({ n: opTurnTimerRmain }) }})</span></div>
+			<div v-if="iAmPlayer && !game.isEnded && isMyTurn"><span style="display: inline-block; font-weight: bold; animation: global-tada 1s linear infinite both;">{{ i18n.ts._reversi.myTurn }}</span><span v-if="!isFederation" style="margin-left: 1em; opacity: 0.7;">({{ i18n.tsx.remainingN({ n: myTurnTimerRmain }) }})</span></div>
 			<div v-if="game.isEnded && logPos == game.logs.length">
 				<template v-if="game.winner">
 					<Mfm :key="'won'" :text="i18n.tsx._reversi.won({ name: game.winner.name ?? game.winner.username })" :plain="true" :customEmojis="game.winner.emojis"/>
@@ -225,6 +225,12 @@ const isMyTurn = computed(() => {
 	const u = turnUser.value;
 	if (u == null) return false;
 	return u.id === $i.id;
+});
+
+const isFederation = computed(() => {
+	if (game.value.user1.host !== null) return true;
+	if (game.value.user2.host !== null) return true;
+	return false;
 });
 
 const cellsStyle = computed(() => {

--- a/packages/frontend/src/pages/reversi/game.setting.vue
+++ b/packages/frontend/src/pages/reversi/game.setting.vue
@@ -54,7 +54,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 						</MkRadios>
 					</MkFolder>
 
-					<MkFolder :defaultOpen="true">
+					<MkFolder v-if="!isFederation" :defaultOpen="true">
 						<template #label>{{ i18n.ts._reversi.timeLimitForEachTurn }}</template>
 						<template #suffix>{{ game.timeLimitForEachTurn }}{{ i18n.ts._time.second }}</template>
 
@@ -152,6 +152,11 @@ const isReady = computed(() => {
 const isOpReady = computed(() => {
 	if (game.value.user1Id !== $i.id && game.value.user1Ready) return true;
 	if (game.value.user2Id !== $i.id && game.value.user2Ready) return true;
+	return false;
+});
+const isFederation = computed(() => {
+	if (game.value.user1.host !== null) return true;
+	if (game.value.user2.host !== null) return true;
 	return false;
 });
 

--- a/packages/frontend/src/pages/reversi/game.setting.vue
+++ b/packages/frontend/src/pages/reversi/game.setting.vue
@@ -35,7 +35,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<MkFolder :defaultOpen="true">
 						<template #label>{{ i18n.ts._reversi.blackOrWhite }}</template>
 
-						<MkRadios v-model="game.bw">
+						<MkRadios v-model="game.bw" @click="updateSettings('bw')">
 							<option value="random">{{ i18n.ts.random }}</option>
 							<option :value="'1'">
 								<I18n :src="i18n.ts._reversi.blackIs" tag="span">
@@ -161,10 +161,6 @@ const isFederation = computed(() => {
 });
 
 const opponentHasSettingsChanged = ref(false);
-
-watch(() => game.value.bw, () => {
-	updateSettings('bw');
-});
 
 watch(() => game.value.timeLimitForEachTurn, () => {
 	updateSettings('timeLimitForEachTurn');

--- a/packages/frontend/src/pages/reversi/game.setting.vue
+++ b/packages/frontend/src/pages/reversi/game.setting.vue
@@ -58,7 +58,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 						<template #label>{{ i18n.ts._reversi.timeLimitForEachTurn }}</template>
 						<template #suffix>{{ game.timeLimitForEachTurn }}{{ i18n.ts._time.second }}</template>
 
-						<MkRadios v-model="game.timeLimitForEachTurn">
+						<MkRadios v-model="game.timeLimitForEachTurn" @click="updateSettings('timeLimitForEachTurn')">
 							<option :value="5">5{{ i18n.ts._time.second }}</option>
 							<option :value="10">10{{ i18n.ts._time.second }}</option>
 							<option :value="30">30{{ i18n.ts._time.second }}</option>
@@ -161,10 +161,6 @@ const isFederation = computed(() => {
 });
 
 const opponentHasSettingsChanged = ref(false);
-
-watch(() => game.value.timeLimitForEachTurn, () => {
-	updateSettings('timeLimitForEachTurn');
-});
 
 function chooseMap(ev: MouseEvent) {
 	const menu: MenuItem[] = [];

--- a/packages/frontend/src/pages/reversi/index.vue
+++ b/packages/frontend/src/pages/reversi/index.vue
@@ -237,9 +237,15 @@ function cancelMatching() {
 async function accept(user) {
 	const game = await misskeyApi('reversi/match', {
 		userId: user.id,
+		accept_only: true,
 	});
 	if (game) {
 		startGame(game);
+	} else {
+		//受けようとした招待が見つからなかった場合最新の情報に更新
+		misskeyApi('reversi/invitations').then(_invitations => {
+			invitations.value = _invitations;
+		});
 	}
 }
 

--- a/packages/frontend/src/pages/reversi/index.vue
+++ b/packages/frontend/src/pages/reversi/index.vue
@@ -150,6 +150,13 @@ if ($i) {
 		invitations.value.unshift(invitation.user);
 	});
 
+	connection.on('uninvited', invitation => {
+		let index = invitations.value.map(x => x.id).indexOf(invitation.user.id);
+		if (index >= 0) {
+			invitations.value.splice(index, 1);
+		}
+	});
+
 	onUnmounted(() => {
 		connection.dispose();
 	});

--- a/packages/frontend/src/pages/reversi/index.vue
+++ b/packages/frontend/src/pages/reversi/index.vue
@@ -196,7 +196,7 @@ async function matchHeatbeat() {
 async function matchUser() {
 	pleaseLogin();
 
-	const user = await os.selectUser({ includeSelf: false, localOnly: true });
+	const user = await os.selectUser({ includeSelf: false, localOnly: false });
 	if (user == null) return;
 
 	matchingUser.value = user;

--- a/packages/frontend/src/pages/reversi/index.vue
+++ b/packages/frontend/src/pages/reversi/index.vue
@@ -150,13 +150,6 @@ if ($i) {
 		invitations.value.unshift(invitation.user);
 	});
 
-	connection.on('uninvited', invitation => {
-		let index = invitations.value.map(x => x.id).indexOf(invitation.user.id);
-		if (index >= 0) {
-			invitations.value.splice(index, 1);
-		}
-	});
-
 	onUnmounted(() => {
 		connection.dispose();
 	});


### PR DESCRIPTION
close: #256
配送するActivityの種類が追加される
配送するObjectの種類が追加される
UndoされるActivityの種類が追加される
ランダムマッチングは連合できない
招待を受ける時にその招待が無効であれば招待一覧を最新に更新する
配送遅延を考慮し、時間制限は適用しない

## Checklist
- [ ] Read the [contribution guide](https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [x] (If needed) Update CHANGELOG_CHERRYPICK.md
- [ ] (If possible) Add tests
