### PR TITLE
(frontend)通知を個別に削除できるように

### DIFF
--- a/CHANGELOG_yojo.md
+++ b/CHANGELOG_yojo.md
@@ -23,7 +23,7 @@
 - Enhance: リバーシをリモートユーザーと対戦できるように [#271](https://github.com/yojo-art/cherrypick/pull/271)
 
 ### Client
--
+- Enhance: 個別に通知を削除できるように
 
 ### Server
 -

--- a/packages/frontend/src/components/MkNotification.vue
+++ b/packages/frontend/src/components/MkNotification.vue
@@ -65,6 +65,11 @@ SPDX-License-Identifier: AGPL-3.0-only
 			<span v-else-if="notification.type === 'renote:grouped'">{{ i18n.tsx._notification.renotedBySomeUsers({ n: notification.users.length }) }}</span>
 			<span v-else-if="notification.type === 'app'">{{ notification.header }}</span>
 			<MkTime v-if="withTime" :time="notification.createdAt" :class="$style.headerTime" :mode="defaultStore.state.enableAbsoluteTime ? 'absolute' : 'relative'"/>
+			<div>
+				<button class="_button" :class="$style.headerDelete" @click.stop="notificationDelete()">
+					<i class="ti ti-bell-x"></i>
+				</button>
+			</div>
 		</header>
 		<div>
 			<MkA v-if="notification.type === 'reaction' || notification.type === 'reaction:grouped'" :class="$style.text" :to="notePage(notification.note)" :title="getNoteSummary(notification.note)">
@@ -176,6 +181,10 @@ const props = withDefaults(defineProps<{
 const followRequestDone = ref(false);
 const groupInviteDone = ref(false);
 
+const notificationDelete = () => {
+	misskeyApi('notifications/delete', { notificationId: props.notification.id });
+};
+
 const acceptFollowRequest = () => {
 	if (!('user' in props.notification)) return;
 	followRequestDone.value = true;
@@ -196,11 +205,13 @@ function getActualReactedUsersCount(notification: Misskey.entities.Notification)
 const acceptGroupInvitation = () => {
 	groupInviteDone.value = true;
 	misskeyApi('users/groups/invitations/accept', { invitationId: props.notification.invitation.id });
+	misskeyApi('notifications/delete', { notificationId: props.notification.id });
 };
 
 const rejectGroupInvitation = () => {
 	groupInviteDone.value = true;
 	misskeyApi('users/groups/invitations/reject', { invitationId: props.notification.invitation.id });
+	misskeyApi('notifications/delete', { notificationId: props.notification.id });
 };
 </script>
 
@@ -348,6 +359,10 @@ const rejectGroupInvitation = () => {
 .headerTime {
 	margin-left: auto;
 	font-size: 0.9em;
+}
+
+.headerDelete {
+	margin-left: auto;
 }
 
 .text {


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
通知を個別に削除できるように
グループ招待返答時にフロントからも削除を呼ぶように(関連 #192 )無理やりすぎるなんとかしたい

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
close #217 
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [x] (If needed) Update CHANGELOG_CHERRYPICK.md
- [ ] (If possible) Add tests
