### PR TITLE
リモートユーザー作成後に相互リンク情報を登録

### DIFF
--- a/packages/backend/src/core/activitypub/models/ApPersonService.ts
+++ b/packages/backend/src/core/activitypub/models/ApPersonService.ts
@@ -448,7 +448,6 @@ export class ApPersonService implements OnModuleInit {
 					birthday: bday?.[0] ?? null,
 					location: person['vcard:Address'] ?? null,
 					userHost: host,
-					mutualLinkSections: await this.mutualLinkSections(person, user),
 				}));
 
 				if (person.publicKey) {
@@ -506,6 +505,11 @@ export class ApPersonService implements OnModuleInit {
 			this.logger.error('error occurred while fetching user avatar/banner', { stack: err });
 		}
 		//#endregion
+
+		//相互リンク機能の画像をドライブに登録する
+		await this.userProfilesRepository.update({ userId: user.id }, {
+			mutualLinkSections: await this.mutualLinkSections(person, user),
+		});
 
 		await this.updateFeatured(user.id, resolver).catch(err => this.logger.error(err));
 


### PR DESCRIPTION
リモートユーザー作成前にドライブ登録しようとして失敗してたのを修正する

## Checklist
- [ ] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
