### PR TITLE
nodeinfoにリバーシ連合の機能レベルを含める

### DIFF
--- a/packages/backend/src/core/FetchInstanceMetadataService.ts
+++ b/packages/backend/src/core/FetchInstanceMetadataService.ts
@@ -34,6 +34,7 @@ type NodeInfo = {
 			email?: unknown;
 		};
 		themeColor?: unknown;
+		reversiVersion?: unknown;
 	};
 };
 
@@ -138,7 +139,7 @@ export class FetchInstanceMetadataService {
 	}
 
 	@bindThis
-	private async fetchNodeinfo(instance: MiInstance): Promise<NodeInfo> {
+	public async fetchNodeinfo(instance: MiInstance): Promise<NodeInfo> {
 		this.logger.info(`Fetching nodeinfo of ${instance.host} ...`);
 
 		try {

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -39,8 +39,6 @@ const INVITATION_TIMEOUT_MS = 1000 * 20; // 20sec
 export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 	private notificationService: NotificationService;
 	private logger: Logger;
-	//semverに従って割り当てる
-	static federationVersion = '1.0.0-yojo';
 
 	constructor(
 		private moduleRef: ModuleRef,

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -24,6 +24,9 @@ import { NotificationService } from '@/core/NotificationService.js';
 import { Serialized } from '@/types.js';
 import { trackPromise } from '@/misc/promise-tracker.js';
 import type Logger from '@/logger.js';
+import { FetchInstanceMetadataService } from '@/core/FetchInstanceMetadataService.js';
+import { FederatedInstanceService } from '@/core/FederatedInstanceService.js';
+import { NodeinfoServerService } from '@/server/NodeinfoServerService.js';
 import { ReversiGameEntityService } from './entities/ReversiGameEntityService.js';
 import { ApRendererService } from './activitypub/ApRendererService.js';
 import { ApDeliverManagerService } from './activitypub/ApDeliverManagerService.js';
@@ -36,6 +39,8 @@ const INVITATION_TIMEOUT_MS = 1000 * 20; // 20sec
 export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 	private notificationService: NotificationService;
 	private logger: Logger;
+	//semverに従って割り当てる
+	static federationVersion = '1.0.0-yojo';
 
 	constructor(
 		private moduleRef: ModuleRef,
@@ -54,6 +59,8 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 		private apDeliverManagerService: ApDeliverManagerService,
 		private loggerService: LoggerService,
 		private idService: IdService,
+		private federatedInstanceService: FederatedInstanceService,
+		private fetchInstanceMetadataService: FetchInstanceMetadataService,
 	) {
 		this.logger = this.loggerService.getLogger('reversi');
 	}
@@ -98,6 +105,41 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 			crc32: game.crc32,
 			noIrregularRules: game.noIrregularRules,
 		} satisfies Partial<MiReversiGame>;
+	}
+
+	@bindThis
+	public async remoteVersion(host:string): Promise<string | null> {
+		const cache = await this.redisClient.get(`reversi:federation:version:${host}`);
+		if (cache !== null) {
+			return cache.length === 0 ? null : cache;
+		}
+		const instance = await this.federatedInstanceService.fetch(host);
+		const nodeinfo = await this.fetchInstanceMetadataService.fetchNodeinfo(instance);
+		const reversiVersion = nodeinfo.metadata?.reversiVersion;
+		if (typeof(reversiVersion) === 'string') {
+			//0.0.0-foo => 0.0.0
+			const version = reversiVersion.split('-')[0];
+			await this.redisClient.setex(`reversi:federation:version:${host}`, version, 5 * 60);
+			return version;
+		}
+		await this.redisClient.setex(`reversi:federation:version:${host}`, '', 5 * 60);
+		return null;
+	}
+	@bindThis
+	public async federationAvailable(host:string): Promise<boolean | null> {
+		const version = await this.remoteVersion(host);
+		if (version === null) {
+			//初期の実装はバージョンを返さない
+			return null;
+		}
+		const versionElements = version.split('.');
+		if (versionElements.length === 3) {
+			if (versionElements[0] !== NodeinfoServerService.reversiVersion.split('-')[0].split('.')[0]) {
+				//メジャーバージョン不一致
+				return false;
+			}
+		}
+		return true;
 	}
 
 	@bindThis

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -21,6 +21,7 @@ import type { IApReversi } from '../type.js';
 @Injectable()
 export class ApGameService {
 	private logger: Logger;
+	static reversiVersion: string="1.0-yojo";
 
 	constructor(
 		@Inject(DI.config)

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -21,7 +21,8 @@ import type { IApReversi } from '../type.js';
 @Injectable()
 export class ApGameService {
 	private logger: Logger;
-	static reversiVersion: string="1.0-yojo";
+	//semverに従って割り当てる
+	static reversiVersion: string="1.0.0-yojo";
 
 	constructor(
 		@Inject(DI.config)

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -24,7 +24,7 @@ import type { IApReversi } from '../type.js';
 export class ApGameService {
 	private logger: Logger;
 	//semverに従って割り当てる
-	static reversiVersion: string="1.0.0-yojo";
+	static reversiVersion = '1.0.0-yojo';
 
 	constructor(
 		@Inject(DI.config)

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -13,6 +13,8 @@ import { NotificationService } from '@/core/NotificationService.js';
 import { ReversiService } from '@/core/ReversiService.js';
 import { GlobalEventService } from '@/core/GlobalEventService.js';
 import type { ReversiGamesRepository } from '@/models/_.js';
+import { FetchInstanceMetadataService } from '@/core/FetchInstanceMetadataService.js';
+import { FederatedInstanceService } from '@/core/FederatedInstanceService.js';
 import { ApLoggerService } from '../ApLoggerService.js';
 import { ApResolverService } from '../ApResolverService.js';
 import { UserEntityService } from '../../entities/UserEntityService.js';
@@ -41,6 +43,8 @@ export class ApGameService {
 		private apLoggerService: ApLoggerService,
 		//ReversiServiceを先に初期化するのでReversiServiceからApGameServiceを利用してはいけない
 		private reversiService: ReversiService,
+		private federatedInstanceService: FederatedInstanceService,
+		private fetchInstanceMetadataService: FetchInstanceMetadataService,
 	) {
 		this.logger = this.apLoggerService.logger;
 	}
@@ -91,10 +95,39 @@ export class ApGameService {
 			this.reversiService.cancelGame(id, remote_user);
 		}
 	}
+	async reversiVersion(host:string): Promise<string | null> {
+		const cache = await this.redisClient.get(`reversi:federation:version:${host}`);
+		if (cache !== null) {
+			return cache.length === 0 ? null : cache;
+		}
+		const instance = await this.federatedInstanceService.fetch(host);
+		const nodeinfo = await this.fetchInstanceMetadataService.fetchNodeinfo(instance);
+		const reversiVersion = nodeinfo.metadata?.reversiVersion;
+		if (typeof(reversiVersion) === 'string') {
+			//0.0.0-foo => 0.0.0
+			const version = reversiVersion.split('-')[0];
+			await this.redisClient.setex(`reversi:federation:version:${host}`, version, 5 * 60);
+			return version;
+		}
+		await this.redisClient.setex(`reversi:federation:version:${host}`, '', 5 * 60);
+		return null;
+	}
 	async reversiInboxJoin(local_user: MiUser, remote_user: MiRemoteUser, game: IApReversi) {
 		const targetUser = local_user;
 		const fromUser = remote_user;
 		if (!game.game_state.game_session_id) throw Error('bad session' + JSON.stringify(game));
+		let version = await this.reversiVersion(remote_user.host);
+		if (version === null) {
+			//初期の実装はバージョンを返さない
+			version = '1.0.0';
+		}
+		const versionElements = version.split('.');
+		if (versionElements.length === 3) {
+			if (versionElements[0] !== ApGameService.reversiVersion.split('-')[0].split('.')[0]) {
+				//メジャーバージョン不一致
+				return;
+			}
+		}
 		const redisPipeline = this.redisClient.pipeline();
 		redisPipeline.zadd(`reversi:matchSpecific:${targetUser.id}`, Date.now(), JSON.stringify( {
 			from_user_id: fromUser.id,

--- a/packages/backend/src/server/NodeinfoServerService.ts
+++ b/packages/backend/src/server/NodeinfoServerService.ts
@@ -14,7 +14,6 @@ import { bindThis } from '@/decorators.js';
 import NotesChart from '@/core/chart/charts/notes.js';
 import UsersChart from '@/core/chart/charts/users.js';
 import { DEFAULT_POLICIES } from '@/core/RoleService.js';
-import { ApGameService } from '@/core/activitypub/models/ApGameService.js';
 import type { FastifyInstance, FastifyPluginOptions } from 'fastify';
 
 const nodeinfo2_1path = '/nodeinfo/2.1';
@@ -23,6 +22,8 @@ const nodeinfo_homepage = 'https://misskey-hub.net';
 
 @Injectable()
 export class NodeinfoServerService {
+	//semverに従って割り当てる
+	static reversiVersion = '1.0.0-yojo';
 	constructor(
 		@Inject(DI.config)
 		private config: Config,
@@ -132,7 +133,7 @@ export class NodeinfoServerService {
 					enableServiceWorker: meta.enableServiceWorker,
 					proxyAccountName: proxyAccount ? proxyAccount.username : null,
 					themeColor: meta.themeColor ?? '#ffbcdc',
-					reversiVersion: ApGameService.reversiVersion,
+					reversiVersion: NodeinfoServerService.reversiVersion,
 				},
 			};
 			if (version >= 21) {

--- a/packages/backend/src/server/NodeinfoServerService.ts
+++ b/packages/backend/src/server/NodeinfoServerService.ts
@@ -14,6 +14,7 @@ import { bindThis } from '@/decorators.js';
 import NotesChart from '@/core/chart/charts/notes.js';
 import UsersChart from '@/core/chart/charts/users.js';
 import { DEFAULT_POLICIES } from '@/core/RoleService.js';
+import { ApGameService } from '@/core/activitypub/models/ApGameService.js';
 import type { FastifyInstance, FastifyPluginOptions } from 'fastify';
 
 const nodeinfo2_1path = '/nodeinfo/2.1';
@@ -131,6 +132,7 @@ export class NodeinfoServerService {
 					enableServiceWorker: meta.enableServiceWorker,
 					proxyAccountName: proxyAccount ? proxyAccount.username : null,
 					themeColor: meta.themeColor ?? '#ffbcdc',
+					reversiVersion: ApGameService.reversiVersion,
 				},
 			};
 			if (version >= 21) {


### PR DESCRIPTION
#378 の対応状況の公開部分。対応状況の確認部分は別PRで出す

semverにした都合で部分的実装はできない
後で機能ネゴシエーション追加するかも

バージョン末尾の-yojoは実装名

## Checklist
- [ ] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
