### PR TITLE
サーバー情報にリバーシのバージョンを表示する

### DIFF
--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -34,12 +34,14 @@
   - ユーザー検索画面で照会しますか？のダイアログが2つ出る問題 
 - Fix: 更新情報を確認のCherryPickの項目へのリンクを修正 
 - Feat: お気に入りのタグリストを作成できるように
+- Enhance: リバーシ連合の対応状況をサーバー一覧に表示するように
 
 ### Server
 - Fix: ユーザーnull(System)の場合forceがfalseでも新規追加されるのを修正
 - Fix: Outboxから投稿を所得する際にタイムラインに投稿が流れないように
 - Fix: 翻訳にdeepl以外を利用していると翻訳できない問題を修正 [#355](https://github.com/yojo-art/cherrypick/pull/355)
 - Fix: 絵文字インポート時にすでにファイルがあるならそれを使うように
+- Enhance: リバーシ連合の対応状況をnodeinfoに追加
 
 ### Misc
 

--- a/locales/index.d.ts
+++ b/locales/index.d.ts
@@ -11575,6 +11575,14 @@ export interface Locale extends ILocale {
          * 石をアイコンにする
          */
         "useAvatarAsStone": string;
+        /**
+         * リモートサーバーのバージョンが不明です
+         */
+        "remoteVersionUnknown": string;
+        /**
+         * リモートサーバーのバージョンが非互換です
+         */
+        "remoteVersionBad": string;
     };
     "_offlineScreen": {
         /**

--- a/locales/index.d.ts
+++ b/locales/index.d.ts
@@ -11580,6 +11580,10 @@ export interface Locale extends ILocale {
          */
         "remoteVersionUnknown": string;
         /**
+         * 対応していない可能性があります
+         */
+        "remoteVersionUnknownCaption": string;
+        /**
          * リモートサーバーのバージョンが非互換です
          */
         "remoteVersionBad": string;

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -3079,6 +3079,7 @@ _reversi:
   showBoardLabels: "盤面に行・列番号を表示"
   useAvatarAsStone: "石をアイコンにする"
   remoteVersionUnknown: "リモートサーバーのバージョンが不明です"
+  remoteVersionUnknownCaption: "対応していない可能性があります"
   remoteVersionBad: "リモートサーバーのバージョンが非互換です"
 
 _offlineScreen:

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -3078,6 +3078,8 @@ _reversi:
   disallowIrregularRules: "変則なし"
   showBoardLabels: "盤面に行・列番号を表示"
   useAvatarAsStone: "石をアイコンにする"
+  remoteVersionUnknown: "リモートサーバーのバージョンが不明です"
+  remoteVersionBad: "リモートサーバーのバージョンが非互換です"
 
 _offlineScreen:
   title: "オフライン - サーバーに接続できません"

--- a/packages/backend/migration/1724921022768-AddNodeinfoReversi.js
+++ b/packages/backend/migration/1724921022768-AddNodeinfoReversi.js
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project, yojo-art team
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export class AddNodeinfoReversi1724921022768 {
+    name = 'AddNodeinfoReversi1724921022768'
+
+    async up(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "instance" ADD "reversiVersion" character varying(32)`);
+    }
+
+    async down(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "instance" DROP COLUMN "reversiVersion"`);
+    }
+}

--- a/packages/backend/src/core/FetchInstanceMetadataService.ts
+++ b/packages/backend/src/core/FetchInstanceMetadataService.ts
@@ -120,6 +120,7 @@ export class FetchInstanceMetadataService {
 				updates.openRegistrations = info.openRegistrations;
 				updates.maintainerName = info.metadata ? info.metadata.maintainer ? (info.metadata.maintainer.name ?? null) : null : null;
 				updates.maintainerEmail = info.metadata ? info.metadata.maintainer ? (info.metadata.maintainer.email ?? null) : null : null;
+				updates.reversiVersion = info.metadata ? info.metadata.reversiVersion ?? null : null;
 			}
 
 			if (name) updates.name = name;

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -117,10 +117,10 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 		if (typeof(reversiVersion) === 'string') {
 			//0.0.0-foo => 0.0.0
 			const version = reversiVersion.split('-')[0];
-			await this.redisClient.setex(`reversi:federation:version:${host}`, version, 5 * 60);
+			await this.redisClient.setex(`reversi:federation:version:${host}`, 5 * 60, version);
 			return version;
 		}
-		await this.redisClient.setex(`reversi:federation:version:${host}`, '', 5 * 60);
+		await this.redisClient.setex(`reversi:federation:version:${host}`, 5 * 60, '');
 		return null;
 	}
 	@bindThis

--- a/packages/backend/src/core/ReversiService.ts
+++ b/packages/backend/src/core/ReversiService.ts
@@ -132,7 +132,7 @@ export class ReversiService implements OnApplicationShutdown, OnModuleInit {
 		}
 		const versionElements = version.split('.');
 		if (versionElements.length === 3) {
-			if (versionElements[0] !== NodeinfoServerService.reversiVersion.split('-')[0].split('.')[0]) {
+			if (versionElements[0] !== NodeinfoServerService.reversiVersion.split('.')[0]) {
 				//メジャーバージョン不一致
 				return false;
 			}

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -94,7 +94,7 @@ export class ApGameService {
 		const targetUser = local_user;
 		const fromUser = remote_user;
 		if (!game.game_state.game_session_id) throw Error('bad session' + JSON.stringify(game));
-		if (await this.reversiService.federationAvailable(remote_user.host) === false) {
+		if ((await this.reversiService.federationAvailable(remote_user.host)) === false) {
 			//確実に利用できない時
 			return;
 		}

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -94,9 +94,7 @@ export class ApGameService {
 		const targetUser = local_user;
 		const fromUser = remote_user;
 		if (!game.game_state.game_session_id) throw Error('bad session' + JSON.stringify(game));
-		const federationAvailable = await this.reversiService.federationAvailable(remote_user.host);
-		console.log('federationAvailable' + federationAvailable);
-		if (federationAvailable === false) {
+		if ((await this.reversiService.federationAvailable(remote_user.host)) === false) {
 			//確実に利用できない時
 			return;
 		}

--- a/packages/backend/src/core/activitypub/models/ApGameService.ts
+++ b/packages/backend/src/core/activitypub/models/ApGameService.ts
@@ -94,7 +94,9 @@ export class ApGameService {
 		const targetUser = local_user;
 		const fromUser = remote_user;
 		if (!game.game_state.game_session_id) throw Error('bad session' + JSON.stringify(game));
-		if ((await this.reversiService.federationAvailable(remote_user.host)) === false) {
+		const federationAvailable = await this.reversiService.federationAvailable(remote_user.host);
+		console.log('federationAvailable' + federationAvailable);
+		if (federationAvailable === false) {
 			//確実に利用できない時
 			return;
 		}

--- a/packages/backend/src/core/entities/InstanceEntityService.ts
+++ b/packages/backend/src/core/entities/InstanceEntityService.ts
@@ -57,6 +57,7 @@ export class InstanceEntityService {
 			infoUpdatedAt: instance.infoUpdatedAt ? instance.infoUpdatedAt.toISOString() : null,
 			latestRequestReceivedAt: instance.latestRequestReceivedAt ? instance.latestRequestReceivedAt.toISOString() : null,
 			moderationNote: iAmModerator ? instance.moderationNote : null,
+			reversiVersion: instance.reversiVersion,
 		};
 	}
 

--- a/packages/backend/src/core/entities/MetaEntityService.ts
+++ b/packages/backend/src/core/entities/MetaEntityService.ts
@@ -17,6 +17,7 @@ import { InstanceActorService } from '@/core/InstanceActorService.js';
 import type { Config } from '@/config.js';
 import { DI } from '@/di-symbols.js';
 import { DEFAULT_POLICIES } from '@/core/RoleService.js';
+import { NodeinfoServerService } from '@/server/NodeinfoServerService.js';
 
 @Injectable()
 export class MetaEntityService {
@@ -132,6 +133,7 @@ export class MetaEntityService {
 			enableUrlPreview: instance.urlPreviewEnabled,
 			noteSearchableScope: (this.config.meilisearch == null || this.config.meilisearch.scope !== 'local') ? 'global' : 'local',
 			urlPreviewEndpoint: instance.directSummalyProxy ? (instance.urlPreviewSummaryProxyUrl || `${this.config.url}/url` ) : `${this.config.url}/url`,
+			reversiVersion: NodeinfoServerService.reversiVersion,
 		};
 
 		return packed;

--- a/packages/backend/src/models/Instance.ts
+++ b/packages/backend/src/models/Instance.ts
@@ -158,4 +158,9 @@ export class MiInstance {
 		length: 16384, default: '',
 	})
 	public moderationNote: string;
+
+	@Column('varchar', {
+		length: 64, nullable: true,
+	})
+	public reversiVersion: string | null;
 }

--- a/packages/backend/src/models/json-schema/federation-instance.ts
+++ b/packages/backend/src/models/json-schema/federation-instance.ts
@@ -120,5 +120,9 @@ export const packedFederationInstanceSchema = {
 			type: 'string',
 			optional: true, nullable: true,
 		},
+		reversiVersion: {
+			type: 'string',
+			optional: true, nullable: true,
+		},
 	},
 } as const;

--- a/packages/backend/src/models/json-schema/meta.ts
+++ b/packages/backend/src/models/json-schema/meta.ts
@@ -265,6 +265,10 @@ export const packedMetaLiteSchema = {
 			optional: false, nullable: false,
 			default: 'local',
 		},
+		reversiVersion: {
+			type: 'string',
+			optional: false, nullable: false,
+		},
 	},
 } as const;
 

--- a/packages/cherrypick-js/src/autogen/types.ts
+++ b/packages/cherrypick-js/src/autogen/types.ts
@@ -5283,6 +5283,7 @@ export type components = {
        * @enum {string}
        */
       noteSearchableScope: 'local' | 'global';
+      reversiVersion: string;
     };
     MetaDetailedOnly: {
       features?: {

--- a/packages/cherrypick-js/src/autogen/types.ts
+++ b/packages/cherrypick-js/src/autogen/types.ts
@@ -4939,6 +4939,7 @@ export type components = {
       /** Format: date-time */
       latestRequestReceivedAt: string | null;
       moderationNote?: string | null;
+      reversiVersion?: string | null;
     };
     GalleryPost: {
       /**

--- a/packages/frontend/src/components/MkInstanceCardMini.vue
+++ b/packages/frontend/src/components/MkInstanceCardMini.vue
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 	<div class="body">
 		<span class="host">{{ instance.name ?? instance.host }}</span>
 		<span class="sub _monospace"><b>{{ instance.host }}</b> / {{ instance.softwareName || '?' }} {{ instance.softwareVersion }}</span>
-		<span class="sub _monospace"><b>{{ i18n.ts._reversi.reversi }}</b> / {{ instance.reversiVersion || `(${i18n.ts.unknown})` }} {{ instance.softwareVersion }}</span>
+		<span class="sub _monospace"><b>{{ i18n.ts._reversi.reversi }}</b> / {{ instance.reversiVersion || `(${i18n.ts.unknown})` }}</span>
 	</div>
 	<MkMiniChart v-if="chartValues" class="chart" :src="chartValues"/>
 </div>

--- a/packages/frontend/src/components/MkInstanceCardMini.vue
+++ b/packages/frontend/src/components/MkInstanceCardMini.vue
@@ -9,6 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 	<div class="body">
 		<span class="host">{{ instance.name ?? instance.host }}</span>
 		<span class="sub _monospace"><b>{{ instance.host }}</b> / {{ instance.softwareName || '?' }} {{ instance.softwareVersion }}</span>
+		<span class="sub _monospace"><b>{{ i18n.ts._reversi.reversi }}</b> / {{ instance.reversiVersion || `(${i18n.ts.unknown})` }} {{ instance.softwareVersion }}</span>
 	</div>
 	<MkMiniChart v-if="chartValues" class="chart" :src="chartValues"/>
 </div>
@@ -20,6 +21,7 @@ import * as Misskey from 'cherrypick-js';
 import MkMiniChart from '@/components/MkMiniChart.vue';
 import { misskeyApiGet } from '@/scripts/misskey-api.js';
 import { getProxiedImageUrlNullable } from '@/scripts/media-proxy.js';
+import { i18n } from '@/i18n.js';
 
 const props = defineProps<{
 	instance: Misskey.entities.FederationInstance;

--- a/packages/frontend/src/pages/instance-info.vue
+++ b/packages/frontend/src/pages/instance-info.vue
@@ -23,6 +23,10 @@ SPDX-License-Identifier: AGPL-3.0-only
 						<template #value><span class="_monospace">{{ instance.softwareName || `(${i18n.ts.unknown})` }} / {{ instance.softwareVersion || `(${i18n.ts.unknown})` }}</span></template>
 					</MkKeyValue>
 					<MkKeyValue oneline>
+						<template #key>{{ i18n.ts._reversi.reversi }}</template>
+						<template #value><span class="_monospace">{{ instance.reversiVersion || `(${i18n.ts.unknown})` }} </span></template>
+					</MkKeyValue>
+					<MkKeyValue oneline>
 						<template #key>{{ i18n.ts.administrator }}</template>
 						<template #value>{{ instance.maintainerName || `(${i18n.ts.unknown})` }} ({{ instance.maintainerEmail || `(${i18n.ts.unknown})` }})</template>
 					</MkKeyValue>

--- a/packages/frontend/src/pages/reversi/index.vue
+++ b/packages/frontend/src/pages/reversi/index.vue
@@ -120,6 +120,7 @@ import * as os from '@/os.js';
 import { useInterval } from '@/scripts/use-interval.js';
 import { pleaseLogin } from '@/scripts/please-login.js';
 import * as sound from '@/scripts/sound.js';
+import { instance } from '@/instance.js';
 
 const myGamesPagination = {
 	endpoint: 'reversi/games' as const,
@@ -198,6 +199,33 @@ async function matchUser() {
 
 	const user = await os.selectUser({ includeSelf: false, localOnly: false });
 	if (user == null) return;
+	if (user.host) {
+		let remote_instance = await misskeyApi('federation/show-instance', {
+			host: user.host,
+		});
+		//初期のバージョン番号を持たない実装は1.0.0扱いにする
+		const reversiVersion = remote_instance?.reversiVersion ?? '1.0.0';
+
+		const versionElements = reversiVersion.split('.');
+		if (versionElements.length === 3) {
+			if (versionElements[0] !== instance.reversiVersion.split('.')[0]) {
+				//メジャーバージョン不一致
+				await os.alert({
+					type: 'error',
+					text: i18n.ts._reversi.remoteVersionBad,
+				});
+				return;
+			}
+		}
+		//バージョン番号不明の場合は警告だけ出す
+		if (!remote_instance?.reversiVersion) {
+			const { canceled } = await os.confirm({
+				type: 'warning',
+				text: i18n.ts._reversi.remoteVersionUnknown,
+			});
+			if (canceled) return;
+		}
+	}
 
 	matchingUser.value = user;
 

--- a/packages/frontend/src/pages/reversi/index.vue
+++ b/packages/frontend/src/pages/reversi/index.vue
@@ -222,6 +222,7 @@ async function matchUser() {
 			const { canceled } = await os.confirm({
 				type: 'warning',
 				text: i18n.ts._reversi.remoteVersionUnknown,
+				caption: i18n.ts._reversi.remoteVersionUnknownCaption,
 			});
 			if (canceled) return;
 		}


### PR DESCRIPTION
## What
リモートサーバー情報にリバーシのバージョンを追加
リモートユーザーをリバーシに招待する時、相手のバージョンを確認する

## Why
相手のサーバーの対応状況を確認できるように

## Additional info (optional)
resolve: #378 
#379 で発生した正しく対戦設定まで進めない不具合を修正してある

## Checklist
- [ ] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [x] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
