### PR TITLE
相互リンクに対応していない場合でもテキストが表示されるように

### DIFF
--- a/packages/backend/src/core/activitypub/ApRendererService.ts
+++ b/packages/backend/src/core/activitypub/ApRendererService.ts
@@ -483,13 +483,29 @@ export class ApRendererService {
 			this.userProfilesRepository.findOneByOrFail({ userId: user.id }),
 		]);
 
-		const attachment = profile.fields.map(field => ({
+		const attachment_mutual_links = [];
+
+		if (profile.mutualLinkSections.length > 0) {
+			for (const section of profile.mutualLinkSections) {
+				for (const entry of section.mutualLinks) {
+					if (!section.name && !entry.url.length && !entry.description) continue;
+					attachment_mutual_links.push({
+						type: 'PropertyValue',
+						name: section.name ?? '',
+						value: (entry.url.startsWith('http://') || entry.url.startsWith('https://'))
+							? `<a href="${new URL(entry.url).href}" rel="me nofollow noopener" target="_blank">${entry.description ?? new URL(entry.url).href}</a>`
+							: entry.description ?? '',
+					});
+				}
+			}
+		}
+		const attachment = attachment_mutual_links.concat(profile.fields.map(field => ({
 			type: 'PropertyValue',
 			name: field.name,
 			value: (field.value.startsWith('http://') || field.value.startsWith('https://'))
 				? `<a href="${new URL(field.value).href}" rel="me nofollow noopener" target="_blank">${new URL(field.value).href}</a>`
 				: field.value,
-		}));
+		})));
 
 		const emojis = await this.getEmojis(user.emojis);
 		const apemojis = emojis.filter(emoji => !emoji.localOnly).map(emoji => this.renderEmoji(emoji));

--- a/packages/backend/src/core/activitypub/models/ApPersonService.ts
+++ b/packages/backend/src/core/activitypub/models/ApPersonService.ts
@@ -736,12 +736,18 @@ export class ApPersonService implements OnModuleInit {
 		let filter_fields = fields;
 		for (const section of mutualLinkSections) {
 			for (const entry of section.mutualLinks) {
-				filter_fields = fields.filter(field => {
+				let flag_match = false;
+				filter_fields = filter_fields.filter(field => {
+					if (flag_match) return true;
 					if (field.name === (section.name ?? '')) {
 						const value = (entry.url.startsWith('http://') || entry.url.startsWith('https://'))
 							? this.mfmService.fromHtml(`<a href="${new URL(entry.url).href}" rel="me nofollow noopener" target="_blank">${entry.description ?? new URL(entry.url).href}</a>`)
 							: entry.description ?? '';
-						return field.value !== value;
+						if (field.value === value) {
+							flag_match = true;
+							return false;//初回一致のみ除外する
+						}
+						return true;
 					}
 					return true;
 				});

--- a/packages/backend/src/core/activitypub/models/ApPersonService.ts
+++ b/packages/backend/src/core/activitypub/models/ApPersonService.ts
@@ -325,8 +325,8 @@ export class ApPersonService implements OnModuleInit {
 						this.logger.error('error occurred while fetching following/followers collection', { stack: err });
 					}
 					return 'private';
-				})
-			)
+				}),
+			),
 		);
 
 		const bday = person['vcard:bday']?.match(/^\d{4}-\d{2}-\d{2}/);
@@ -591,8 +591,8 @@ export class ApPersonService implements OnModuleInit {
 						return undefined;
 					}
 					return 'private';
-				})
-			)
+				}),
+			),
 		);
 
 		const bday = person['vcard:bday']?.match(/^\d{4}-\d{2}-\d{2}/);
@@ -731,16 +731,32 @@ export class ApPersonService implements OnModuleInit {
 		} else if (person.summary) {
 			_description = this.apMfmService.htmlToMfm(truncate(person.summary, summaryLength), person.tag);
 		}
+		const mutualLinkSections = await this.mutualLinkSections(person, exist, role_policy);
+
+		let filter_fields = fields;
+		for (const section of mutualLinkSections) {
+			for (const entry of section.mutualLinks) {
+				filter_fields = fields.filter(field => {
+					if (field.name === (section.name ?? '')) {
+						const value = (entry.url.startsWith('http://') || entry.url.startsWith('https://'))
+							? this.mfmService.fromHtml(`<a href="${new URL(entry.url).href}" rel="me nofollow noopener" target="_blank">${entry.description ?? new URL(entry.url).href}</a>`)
+							: entry.description ?? '';
+						return field.value === value;
+					}
+					return false;
+				});
+			}
+		}
 
 		await this.userProfilesRepository.update({ userId: exist.id }, {
 			url,
-			fields,
+			fields: filter_fields,
 			description: _description,
 			followingVisibility,
 			followersVisibility,
 			birthday: bday?.[0] ?? null,
 			location: person['vcard:Address'] ?? null,
-			mutualLinkSections: await this.mutualLinkSections(person, exist, role_policy),
+			mutualLinkSections,
 		});
 
 		this.globalEventService.publishInternalEvent('remoteUserUpdated', { id: exist.id });

--- a/packages/backend/src/core/activitypub/models/ApPersonService.ts
+++ b/packages/backend/src/core/activitypub/models/ApPersonService.ts
@@ -741,9 +741,9 @@ export class ApPersonService implements OnModuleInit {
 						const value = (entry.url.startsWith('http://') || entry.url.startsWith('https://'))
 							? this.mfmService.fromHtml(`<a href="${new URL(entry.url).href}" rel="me nofollow noopener" target="_blank">${entry.description ?? new URL(entry.url).href}</a>`)
 							: entry.description ?? '';
-						return field.value === value;
+						return field.value !== value;
 					}
-					return false;
+					return true;
 				});
 			}
 		}


### PR DESCRIPTION
## What
「追加情報」の欄に相互リンクのテキスト要素を含めた。ioフォーク相当
yojo-art仕様の拡張に対応している場合は画像を含む完全な表示に切り替わる

## Why
既存実装との互換性を改善する

## Additional info (optional)
develop版のyojo-artと連合した時変になるけどリリースしてないからいいよね？

## Checklist
- [ ] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
