### PR TITLE
ノート詳細の本文表示優先度を変更

### DIFF
--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -26,6 +26,7 @@
 - Fix: 非ログインでリバーシの戦績が見れない不具合の修正 [#404](https://github.com/yojo-art/cherrypick/pull/404)
 - Fix: 翻訳に失敗したとき読み込み中のままになるのを修正
 - Enhance: ユーザー概要の...からサーバー情報にリンクを追加 [#406](https://github.com/yojo-art/cherrypick/pull/406)
+- Fix: ノート詳細の本文表示優先度を変更
 
 ### Server
 -

--- a/packages/frontend/src/components/MkNoteDetailed.vue
+++ b/packages/frontend/src/components/MkNoteDetailed.vue
@@ -924,6 +924,7 @@ onMounted(() => {
 .noteContent {
 	container-type: inline-size;
 	overflow-wrap: break-word;
+	z-index: 2;
 }
 
 .cw {

--- a/packages/frontend/src/components/MkNoteDetailed.vue
+++ b/packages/frontend/src/components/MkNoteDetailed.vue
@@ -925,6 +925,7 @@ onMounted(() => {
 	container-type: inline-size;
 	overflow-wrap: break-word;
 	z-index: 2;
+	position: relative;
 }
 
 .cw {


### PR DESCRIPTION
## What
ノート詳細の本文表示優先度を変更

## Why
アバターデコレーションが本文を覆い隠してしまう

## Additional info (optional)
resolve: #405 

## Checklist
- [ ] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [x] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
