### PR TITLE
Release: 1.0.0

### DIFF
--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -25,8 +25,9 @@
 ### Client
 - Fix: 非ログインでリバーシの戦績が見れない不具合の修正 [#404](https://github.com/yojo-art/cherrypick/pull/404)
 - Fix: 翻訳に失敗したとき読み込み中のままになるのを修正
-- Enhance: ユーザー概要の...からサーバー情報にリンクを追加 [#406](https://github.com/yojo-art/cherrypick/pull/406)
 - Fix: ノート詳細の本文表示優先度を変更
+- Feat: 同じノートを連続してリノートしようとしたときに警告する設定を追加(設定→全般)
+- Enhance: ユーザー概要の...からサーバー情報にリンクを追加 [#406](https://github.com/yojo-art/cherrypick/pull/406)
 
 ### Server
 -

--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -26,6 +26,7 @@
 - Fix: 非ログインでリバーシの戦績が見れない不具合の修正 [#404](https://github.com/yojo-art/cherrypick/pull/404)
 - Fix: 翻訳に失敗したとき読み込み中のままになるのを修正
 - Enhance: ユーザー概要の...からサーバー情報にリンクを追加 [#406](https://github.com/yojo-art/cherrypick/pull/406)
+- Fix: ノート詳細の本文表示優先度を変更
 
 ### Server
 -

--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -1,4 +1,3 @@
-<!--
 ## x.x.x (unreleased)
 
 ### Release Date
@@ -14,19 +13,20 @@
 
 ### Misc
 
--->
-## x.x.x (unreleased)
+## 1.0.0
+Cherrypick 4.11.1
 
 ### Release Date
+2024-09-05
 
 ### General
 -
 
 ### Client
 - Fix: 非ログインでリバーシの戦績が見れない不具合の修正 [#404](https://github.com/yojo-art/cherrypick/pull/404)
-- Fix: 翻訳に失敗したとき読み込み中のままになるのを修正
-- Fix: ノート詳細の本文表示優先度を変更
-- Feat: 同じノートを連続してリノートしようとしたときに警告する設定を追加(設定→全般)
+- Fix: 翻訳に失敗したとき読み込み中のままになるのを修正 [#407](https://github.com/yojo-art/cherrypick/pull/407)
+- Fix: ノート詳細の本文表示優先度を変更 [#408](https://github.com/yojo-art/cherrypick/pull/408)
+- Feat: 同じノートを連続してリノートしようとしたときに警告する設定を追加(設定→全般) [#409](https://github.com/yojo-art/cherrypick/pull/409)
 - Enhance: ユーザー概要の...からサーバー情報にリンクを追加 [#406](https://github.com/yojo-art/cherrypick/pull/406)
 
 ### Server

--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -24,6 +24,7 @@
 
 ### Client
 - Fix: 非ログインでリバーシの戦績が見れない不具合の修正 [#404](https://github.com/yojo-art/cherrypick/pull/404)
+- Enhance: ユーザー概要の...からサーバー情報にリンクを追加 [#406](https://github.com/yojo-art/cherrypick/pull/406)
 
 ### Server
 -

--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -23,7 +23,7 @@
 -
 
 ### Client
--
+- Fix: 非ログインでリバーシの戦績が見れない不具合の修正 [#404](https://github.com/yojo-art/cherrypick/pull/404)
 
 ### Server
 -

--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -24,6 +24,7 @@
 
 ### Client
 - Fix: 非ログインでリバーシの戦績が見れない不具合の修正 [#404](https://github.com/yojo-art/cherrypick/pull/404)
+- Fix: 翻訳に失敗したとき読み込み中のままになるのを修正
 - Enhance: ユーザー概要の...からサーバー情報にリンクを追加 [#406](https://github.com/yojo-art/cherrypick/pull/406)
 
 ### Server

--- a/locales/index.d.ts
+++ b/locales/index.d.ts
@@ -57,6 +57,10 @@ export interface Locale extends ILocale {
      */
     "cherrypickMigratedCacheClear": string;
     /**
+     * 同じノートを連続してリノートしようとしたときに警告する
+     */
+    "showMultipleRenoteWarning": string;
+    /**
      * リノートの公開範囲オプションを表示
      */
     "showRenoteVisibilitySelector": string;
@@ -11931,6 +11935,20 @@ export interface Locale extends ILocale {
          * 通知を削除しますか？
          */
         "notificationDeleteTitle": string;
+    };
+    "_renoteConfirm": {
+        /**
+         * このノートはリノートしたばかりです
+         */
+        "title": string;
+        /**
+         * リノートしますか？
+         */
+        "caption": string;
+        /**
+         * リノートする
+         */
+        "confirm": string;
     };
 }
 declare const locales: {

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -10,6 +10,7 @@ welcome: "ようこそ！"
 cherrypickMigrated: "CherryPickへの移行が完了しました！"
 cherrypickMigratedCacheClearTitle: "キャッシュクリアのご案内"
 cherrypickMigratedCacheClear: "このサーバーは<b>Misskey</b>または<b>CherryPick v4.3.0以前</b>のバージョンから移行されました。\nバージョン管理方式が異なり、残っているキャッシュが問題を引き起こす可能性があるため、移行後、最初の接続時にキャッシュを削除する作業を行う必要があります。\n\nこの作業は最初一度だけ行われます。"
+showMultipleRenoteWarning: "同じノートを連続してリノートしようとしたときに警告する"
 showRenoteVisibilitySelector: "リノートの公開範囲オプションを表示"
 cannotBeUsedFunc: "この機能は現在使用できません。"
 scale: "大きさ"
@@ -3188,3 +3189,8 @@ _dice:
 _deleteConfirm:
   delete: "削除する"
   notificationDeleteTitle: "通知を削除しますか？"
+
+_renoteConfirm:
+  title: "このノートはリノートしたばかりです"
+  caption: "リノートしますか？"
+  confirm: 'リノートする'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cherrypick",
-	"version": "4.11.1-yojo0.6.0",
+	"version": "4.11.1-yojo1.0.0",
 	"basedMisskeyVersion": "2024.8.0",
 	"codename": "nasubi",
 	"repository": {

--- a/packages/backend/src/server/api/endpoints/notes/translate.ts
+++ b/packages/backend/src/server/api/endpoints/notes/translate.ts
@@ -37,6 +37,7 @@ export const meta = {
 			message: 'Translate of notes unavailable.',
 			code: 'UNAVAILABLE',
 			id: '50a70314-2d8a-431b-b433-efa5cc56444c',
+			httpStatusCode: 403,
 		},
 		noSuchNote: {
 			message: 'No such note.',

--- a/packages/backend/src/server/api/endpoints/users/translate.ts
+++ b/packages/backend/src/server/api/endpoints/users/translate.ts
@@ -36,6 +36,7 @@ export const meta = {
 			message: 'Translate of description unavailable.',
 			code: 'UNAVAILABLE',
 			id: '50a70314-2d8a-431b-b433-efa5cc56444c',
+			httpStatusCode: 403,
 		},
 		noSuchDescription: {
 			message: 'No such description.',

--- a/packages/backend/test/e2e/note.ts
+++ b/packages/backend/test/e2e/note.ts
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import type { Repository } from "typeorm";
+import type { Repository } from 'typeorm';
 
 process.env.NODE_ENV = 'test';
 
 import * as assert from 'assert';
+import type * as misskey from 'cherrypick-js';
 import { MiNote } from '@/models/Note.js';
 import { MAX_NOTE_TEXT_LENGTH } from '@/const.js';
 import { api, castAsError, initTestDb, post, role, signup, uploadFile, uploadUrl } from '../utils.js';
-import type * as misskey from 'cherrypick-js';
 
 describe('Note', () => {
 	let Notes: Repository<MiNote>;
@@ -996,7 +996,7 @@ describe('Note', () => {
 					targetLang: 'ja',
 				}, alice);
 
-				assert.strictEqual(res.status, 400);
+				assert.strictEqual(res.status, 403);
 				assert.strictEqual(castAsError(res.body).error.code, 'UNAVAILABLE');
 			});
 

--- a/packages/cherrypick-js/package.json
+++ b/packages/cherrypick-js/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "cherrypick-js",
-	"version": "4.11.1-yojo0.6.0",
+	"version": "4.11.1-yojo1.0.0",
 	"basedMisskeyVersion": "2024.8.0",
 	"description": "CherryPick SDK for JavaScript",
 	"license": "MIT",

--- a/packages/frontend/src/components/MkNote.vue
+++ b/packages/frontend/src/components/MkNote.vue
@@ -735,8 +735,15 @@ async function translate(): Promise<void> {
 	const res = await misskeyApi('notes/translate', {
 		noteId: appearNote.value.id,
 		targetLang: miLocalStorage.getItem('lang') ?? navigator.language,
+	}).catch((err) => {
+		translating.value = false;
+		os.alert(
+			{
+				type: 'error',
+				title: err.message,
+				text: err.id,
+			});
 	});
-	translating.value = false;
 	translation.value = res;
 
 	vibrate(defaultStore.state.vibrateSystem ? [5, 5, 10] : []);

--- a/packages/frontend/src/components/MkNoteDetailed.vue
+++ b/packages/frontend/src/components/MkNoteDetailed.vue
@@ -278,6 +278,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 </template>
 
 <script lang="ts" setup>
+import { error } from 'console';
 import { computed, inject, onMounted, provide, ref, shallowRef } from 'vue';
 import * as mfm from 'cherrypick-mfm-js';
 import * as Misskey from 'cherrypick-js';
@@ -670,8 +671,15 @@ async function translate(): Promise<void> {
 	const res = await misskeyApi('notes/translate', {
 		noteId: appearNote.value.id,
 		targetLang: miLocalStorage.getItem('lang') ?? navigator.language,
+	}).catch((err) => {
+		translating.value = false;
+		os.alert(
+			{
+				type: 'error',
+				title: err.message,
+				text: err.id,
+			});
 	});
-	translating.value = false;
 	translation.value = res;
 
 	vibrate(defaultStore.state.vibrateSystem ? [5, 5, 10] : []);

--- a/packages/frontend/src/components/MkNoteDetailed.vue
+++ b/packages/frontend/src/components/MkNoteDetailed.vue
@@ -932,6 +932,8 @@ onMounted(() => {
 .noteContent {
 	container-type: inline-size;
 	overflow-wrap: break-word;
+	z-index: 2;
+	position: relative;
 }
 
 .cw {

--- a/packages/frontend/src/components/MkSubNoteContent.vue
+++ b/packages/frontend/src/components/MkSubNoteContent.vue
@@ -444,8 +444,15 @@ async function translate(): Promise<void> {
 	const res = await misskeyApi('notes/translate', {
 		noteId: props.note.id,
 		targetLang: miLocalStorage.getItem('lang') ?? navigator.language,
+	}).catch((err) => {
+		translating.value = false;
+		os.alert(
+			{
+				type: 'error',
+				title: err.message,
+				text: err.id,
+			});
 	});
-	translating.value = false;
 	translation.value = res;
 
 	vibrate(defaultStore.state.vibrateSystem ? [5, 5, 10] : []);

--- a/packages/frontend/src/pages/reversi/game.board.vue
+++ b/packages/frontend/src/pages/reversi/game.board.vue
@@ -154,7 +154,6 @@ import MkFolder from '@/components/MkFolder.vue';
 import MkSwitch from '@/components/MkSwitch.vue';
 import { deepClone } from '@/scripts/clone.js';
 import { useInterval } from '@/scripts/use-interval.js';
-import { signinRequired } from '@/account.js';
 import { url } from '@/config.js';
 import { i18n } from '@/i18n.js';
 import { misskeyApi } from '@/scripts/misskey-api.js';
@@ -164,8 +163,7 @@ import * as os from '@/os.js';
 import { confetti } from '@/scripts/confetti.js';
 import { defaultStore } from '@/store.js';
 import { getStaticImageUrl } from '@/scripts/media-proxy.js';
-
-const $i = signinRequired();
+import { $i } from '@/account.js';
 
 const props = defineProps<{
 	game: Misskey.entities.ReversiGameDetailed;
@@ -187,13 +185,13 @@ const engine = shallowRef<Reversi.Game>(Reversi.Serializer.restoreGame({
 }));
 
 const iAmPlayer = computed(() => {
-	return game.value.user1Id === $i.id || game.value.user2Id === $i.id;
+	return game.value.user1Id === $i?.id || game.value.user2Id === $i?.id;
 });
 
 const myColor = computed(() => {
 	if (!iAmPlayer.value) return null;
-	if (game.value.user1Id === $i.id && game.value.black === 1) return true;
-	if (game.value.user2Id === $i.id && game.value.black === 2) return true;
+	if (game.value.user1Id === $i?.id && game.value.black === 1) return true;
+	if (game.value.user2Id === $i?.id && game.value.black === 2) return true;
 	return false;
 });
 
@@ -224,7 +222,7 @@ const isMyTurn = computed(() => {
 	if (!iAmPlayer.value) return false;
 	const u = turnUser.value;
 	if (u == null) return false;
-	return u.id === $i.id;
+	return u.id === $i?.id;
 });
 
 const isFederation = computed(() => {
@@ -376,7 +374,7 @@ async function onStreamLog(log) {
 function onStreamEnded(x) {
 	game.value = deepClone(x.game);
 
-	if (game.value.winnerId === $i.id) {
+	if (game.value.winnerId === $i?.id) {
 		confetti({
 			duration: 1000 * 3,
 		});

--- a/packages/frontend/src/pages/reversi/game.setting.vue
+++ b/packages/frontend/src/pages/reversi/game.setting.vue
@@ -114,7 +114,6 @@ import { computed, watch, ref, onMounted, shallowRef, onUnmounted } from 'vue';
 import * as Misskey from 'cherrypick-js';
 import * as Reversi from 'misskey-reversi';
 import { i18n } from '@/i18n.js';
-import { signinRequired } from '@/account.js';
 import { deepClone } from '@/scripts/clone.js';
 import MkButton from '@/components/MkButton.vue';
 import MkRadios from '@/components/MkRadios.vue';
@@ -123,8 +122,7 @@ import MkFolder from '@/components/MkFolder.vue';
 import * as os from '@/os.js';
 import { MenuItem } from '@/types/menu.js';
 import { useRouter } from '@/router/supplier.js';
-
-const $i = signinRequired();
+import { $i } from '@/account.js';
 
 const router = useRouter();
 
@@ -222,7 +220,7 @@ function updateSettings(key: keyof Misskey.entities.ReversiGameDetailed) {
 }
 
 function onUpdateSettings({ userId, key, value }: { userId: string; key: keyof Misskey.entities.ReversiGameDetailed; value: any; }) {
-	if (userId === $i.id) return;
+	if (userId === $i?.id) return;
 	if (game.value[key] === value) return;
 	game.value[key] = value;
 	if (isReady.value) {

--- a/packages/frontend/src/pages/reversi/game.vue
+++ b/packages/frontend/src/pages/reversi/game.vue
@@ -17,14 +17,12 @@ import GameBoard from './game.board.vue';
 import { misskeyApi } from '@/scripts/misskey-api.js';
 import { definePageMetadata } from '@/scripts/page-metadata.js';
 import { useStream } from '@/stream.js';
-import { signinRequired } from '@/account.js';
 import { useRouter } from '@/router/supplier.js';
 import * as os from '@/os.js';
 import { url } from '@/config.js';
 import { i18n } from '@/i18n.js';
 import { useInterval } from '@/scripts/use-interval.js';
-
-const $i = signinRequired();
+import { $i } from '@/account.js';
 
 const router = useRouter();
 
@@ -74,7 +72,7 @@ async function fetchGame() {
 		connection.value.on('canceled', x => {
 			connection.value?.dispose();
 
-			if (x.userId !== $i.id) {
+			if (x.userId !== $i?.id) {
 				os.alert({
 					type: 'warning',
 					text: i18n.ts._reversi.gameCanceled,

--- a/packages/frontend/src/pages/settings/general.vue
+++ b/packages/frontend/src/pages/settings/general.vue
@@ -85,6 +85,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 				<MkSwitch v-model="infoButtonForNoteActionsEnabled">{{ i18n.ts.infoButtonForNoteActions }}<template #caption>{{ i18n.ts.infoButtonForNoteActionsDescription }}</template> <span class="_beta">CherryPick</span></MkSwitch>
 				<MkSwitch v-model="showReplyInNotification">{{ i18n.ts.showReplyInNotification }} <span class="_beta">CherryPick</span></MkSwitch>
 				<MkSwitch v-model="renoteQuoteButtonSeparation">{{ i18n.ts.renoteQuoteButtonSeparation }} <span class="_beta">CherryPick</span></MkSwitch>
+				<MkSwitch v-model="checkMultipleRenote">{{ i18n.ts.showMultipleRenoteWarning }} <span class="_beta">yojo-art</span></MkSwitch>
 				<MkSwitch v-model="renoteVisibilitySelection">{{ i18n.ts.showRenoteVisibilitySelector }} <span class="_beta">CherryPick</span></MkSwitch>
 				<MkSelect v-if="!renoteVisibilitySelection" v-model="forceRenoteVisibilitySelection">
 					<template #label>{{ i18n.ts.forceRenoteVisibilitySelector }}</template>
@@ -468,6 +469,7 @@ const showFixedPostFormInReplies = computed(defaultStore.makeGetterSetter('showF
 const showingAnimatedImages = computed(defaultStore.makeGetterSetter('showingAnimatedImages'));
 const allMediaNoteCollapse = computed(defaultStore.makeGetterSetter('allMediaNoteCollapse'));
 const nsfwOpenBehavior = computed(defaultStore.makeGetterSetter('nsfwOpenBehavior'));
+const checkMultipleRenote = computed(defaultStore.makeGetterSetter('checkMultipleRenote'));
 const renoteVisibilitySelection = computed(defaultStore.makeGetterSetter('renoteVisibilitySelection'));
 const forceRenoteVisibilitySelection = computed(defaultStore.makeGetterSetter('forceRenoteVisibilitySelection'));
 

--- a/packages/frontend/src/pages/settings/preferences-backups.vue
+++ b/packages/frontend/src/pages/settings/preferences-backups.vue
@@ -131,6 +131,7 @@ const defaultStoreSaveKeys: (keyof typeof defaultStore['state'])[] = [
 	'useEnterToSend',
 	'postFormVisibilityHotkey',
 	'showRenoteConfirmPopup',
+	'checkMultipleRenote',
 	'displayHeaderNavBarWhenScroll',
 	'infoButtonForNoteActionsEnabled',
 	'reactableRemoteReactionEnabled',

--- a/packages/frontend/src/pages/user/home.vue
+++ b/packages/frontend/src/pages/user/home.vue
@@ -338,8 +338,15 @@ async function translate(): Promise<void> {
 	const res = await misskeyApi('users/translate', {
 		userId: props.user.id,
 		targetLang: miLocalStorage.getItem('lang') ?? navigator.language,
+	}).catch((err) => {
+		translating.value = false;
+		os.alert(
+			{
+				type: 'error',
+				title: err.message,
+				text: err.id,
+			});
 	});
-	translating.value = false;
 	translation.value = res;
 
 	vibrate(defaultStore.state.vibrateSystem ? [5, 5, 10] : []);

--- a/packages/frontend/src/scripts/check-last-renote.ts
+++ b/packages/frontend/src/scripts/check-last-renote.ts
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project, yojo-art team
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { i18n } from '@/i18n.js';
+import * as os from '@/os.js';
+import { defaultStore } from '@/store.js';
+
+export async function confirmRenote(renoteId:string) : Promise<boolean> {
+	if (defaultStore.state.checkMultipleRenote === false ) return false;
+	const lastRenoteId = localStorage.getItem('lastRenoteId');
+	if (lastRenoteId) {
+		if (lastRenoteId === renoteId) {
+			const { canceled } = await os.confirm({
+				type: 'warning',
+				title: i18n.ts._renoteConfirm.title,
+				caption: i18n.ts._renoteConfirm.caption,
+				okText: i18n.ts._renoteConfirm.confirm,
+				cancelText: i18n.ts.thisPostMayBeAnnoyingCancel,
+			});
+			return canceled;
+		}
+	}
+	localStorage.setItem('lastRenoteId', renoteId);
+	return false;
+}

--- a/packages/frontend/src/scripts/get-note-menu.ts
+++ b/packages/frontend/src/scripts/get-note-menu.ts
@@ -6,6 +6,7 @@
 import { defineAsyncComponent, Ref, ShallowRef } from 'vue';
 import * as Misskey from 'cherrypick-js';
 import { claimAchievement } from './achievements.js';
+import { confirmRenote } from './check-last-renote.js';
 import { $i } from '@/account.js';
 import { i18n } from '@/i18n.js';
 import { instance } from '@/instance.js';
@@ -669,7 +670,7 @@ export function getRenoteMenu(props: {
 		normalRenoteItems.push({
 			text: i18n.ts.renote,
 			icon: 'ti ti-repeat',
-			action: () => {
+			action: async () => {
 				const el = props.renoteButton.value;
 				if (el) {
 					const rect = el.getBoundingClientRect();
@@ -688,6 +689,9 @@ export function getRenoteMenu(props: {
 				if (appearNote.channel?.isSensitive) {
 					visibility = smallerVisibility(visibility, 'home');
 				}
+
+				const result = await confirmRenote(appearNote.id);
+				if (result) return;
 
 				if (!props.mock) {
 					misskeyApi('notes/create', {
@@ -726,7 +730,10 @@ export function getRenoteMenu(props: {
 				visibilityRenoteItems.push({
 					text: `${i18n.ts.renote} (${i18n.ts._visibility.public})`,
 					icon: 'ti ti-world',
-					action: () => {
+					action: async () => {
+						const result =	await confirmRenote(appearNote.id);
+						if (result) return;
+
 						misskeyApi('notes/create', {
 							localOnly,
 							visibility: 'public',
@@ -743,7 +750,9 @@ export function getRenoteMenu(props: {
 				visibilityRenoteItems.push({
 					text: `${i18n.ts.renote} (${i18n.ts._visibility.home})`,
 					icon: 'ti ti-home',
-					action: () => {
+					action: async () => {
+						const result =	await confirmRenote(appearNote.id);
+						if (result) return;
 						misskeyApi('notes/create', {
 							localOnly,
 							visibility: 'home',
@@ -759,7 +768,9 @@ export function getRenoteMenu(props: {
 			visibilityRenoteItems.push({
 				text: `${i18n.ts.renote} (${i18n.ts._visibility.followers})`,
 				icon: 'ti ti-lock',
-				action: () => {
+				action: async () => {
+					const result =	await confirmRenote(appearNote.id);
+					if (result) return;
 					misskeyApi('notes/create', {
 						localOnly,
 						visibility: 'followers',
@@ -836,6 +847,9 @@ export async function getRenoteOnly(props: {
 		}
 
 		if (!props.mock && defaultStore.state.renoteVisibilitySelection) {
+			const result = await confirmRenote(appearNote.id);
+			if (result) return;
+
 			misskeyApi('notes/create', {
 				localOnly,
 				visibility,
@@ -850,6 +864,8 @@ export async function getRenoteOnly(props: {
 			!defaultStore.state.renoteVisibilitySelection &&
 			appearNote.visibility !== 'specified'
 		) {
+			const result = await confirmRenote(appearNote.id);
+			if (result) return;
 			if (defaultStore.state.forceRenoteVisibilitySelection !== 'none') {
 				if (appearNote.visibility === 'public' && defaultStore.state.forceRenoteVisibilitySelection === 'public') { // renote to public
 					misskeyApi('notes/create', {

--- a/packages/frontend/src/scripts/get-user-menu.ts
+++ b/packages/frontend/src/scripts/get-user-menu.ts
@@ -217,6 +217,13 @@ export function getUserMenu(user: Misskey.entities.UserDetailed, router: IRouter
 			if (user.url == null) return;
 			window.open(user.url, '_blank', 'noopener');
 		},
+	}] : []), ...(user.host != null ? [{
+		icon: 'ti ti-server',
+		text: i18n.ts.instanceInfo,
+		action: () => {
+			if (user.host == null) return;
+			router.push(`/instance-info/${user.host}`);
+		},
 	}] : []), {
 		icon: 'ti ti-share',
 		text: i18n.ts.copyProfileUrl,

--- a/packages/frontend/src/store.ts
+++ b/packages/frontend/src/store.ts
@@ -590,6 +590,10 @@ export const defaultStore = markRaw(new Storage('base', {
 		where: 'device',
 		default: 'none' as 'none' | 'public' | 'home' | 'followers',
 	},
+	checkMultipleRenote: {
+		where: 'device',
+		default: false,
+	},
 	showFixedPostFormInReplies: {
 		where: 'device',
 		default: true,


### PR DESCRIPTION
## 1.0.0
Cherrypick 4.11.1

### Release Date
2024-09-05

### General
-

### Client
- Fix: 非ログインでリバーシの戦績が見れない不具合の修正 [#404](https://github.com/yojo-art/cherrypick/pull/404)
- Fix: 翻訳に失敗したとき読み込み中のままになるのを修正 [#407](https://github.com/yojo-art/cherrypick/pull/407)
- Fix: ノート詳細の本文表示優先度を変更 [#408](https://github.com/yojo-art/cherrypick/pull/408)
- Feat: 同じノートを連続してリノートしようとしたときに警告する設定を追加(設定→全般) [#409](https://github.com/yojo-art/cherrypick/pull/409)
- Enhance: ユーザー概要の...からサーバー情報にリンクを追加 [#406](https://github.com/yojo-art/cherrypick/pull/406)

### Server
-

### Misc
-