### PR TITLE
リモートクリップのお気に入り登録

### DIFF
--- a/packages/backend/migration/1726276463152-ClipFavoriteRemote.js
+++ b/packages/backend/migration/1726276463152-ClipFavoriteRemote.js
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project, yojo-art team
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export class clipFavoriteRemote1726276463152 {
+	name = 'clipFavoriteRemote1726276463152'
+
+	async up(queryRunner) {
+			await queryRunner.query(`CREATE TABLE "clip_favorite_remote" ("id" character varying(32) NOT NULL, "userId" character varying(32) NOT NULL, "clipId" character varying(32) NOT NULL, "host" character varying(128) NOT NULL, CONSTRAINT "PK_5cfc42c4522f5253fd759947ec" PRIMARY KEY ("id"))`);
+			await queryRunner.query(`CREATE INDEX "IDX_99c7abefa295355f5725ce959f" ON "clip_favorite_remote" ("userId") `);
+			await queryRunner.query(`CREATE UNIQUE INDEX "IDX_7ca9b4f7544e2b2fdf959bc9f4" ON "clip_favorite_remote" ("userId", "clipId","host") `);
+			await queryRunner.query(`ALTER TABLE "clip_favorite_remote" ADD CONSTRAINT "FK_99c7abefa295355f5725ce959f1" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+	}
+
+	async down(queryRunner) {
+			await queryRunner.query(`ALTER TABLE "clip_favorite_remote" DROP CONSTRAINT "FK_99c7abefa295355f5725ce959f1"`);
+			await queryRunner.query(`DROP INDEX "public"."IDX_7ca9b4f7544e2b2fdf959bc9f4"`);
+			await queryRunner.query(`DROP INDEX "public"."IDX_99c7abefa295355f5725ce959f"`);
+			await queryRunner.query(`DROP TABLE "clip_favorite_remote"`);
+	}
+}

--- a/packages/backend/src/core/ClipService.ts
+++ b/packages/backend/src/core/ClipService.ts
@@ -5,6 +5,13 @@
 
 import { Inject, Injectable } from '@nestjs/common';
 import { QueryFailedError } from 'typeorm';
+import got, * as Got from 'got';
+import * as Redis from 'ioredis';
+import type { Config } from '@/config.js';
+import { HttpRequestService } from '@/core/HttpRequestService.js';
+import { UserEntityService } from '@/core/entities/UserEntityService.js';
+import { awaitAll } from '@/misc/prelude/await-all.js';
+import { RemoteUserResolveService } from '@/core/RemoteUserResolveService.js';
 import { DI } from '@/di-symbols.js';
 import type { ClipsRepository, MiNote, MiClip, ClipNotesRepository, NotesRepository } from '@/models/_.js';
 import { bindThis } from '@/decorators.js';
@@ -12,6 +19,7 @@ import { isDuplicateKeyValueError } from '@/misc/is-duplicate-key-value-error.js
 import { RoleService } from '@/core/RoleService.js';
 import { IdService } from '@/core/IdService.js';
 import type { MiLocalUser } from '@/models/User.js';
+import { Packed } from '@/misc/json-schema.js';
 
 @Injectable()
 export class ClipService {
@@ -20,8 +28,13 @@ export class ClipService {
 	public static AlreadyAddedError = class extends Error {};
 	public static TooManyClipNotesError = class extends Error {};
 	public static TooManyClipsError = class extends Error {};
+	public static FailedToResolveRemoteUserError = class extends Error {};
 
 	constructor(
+		@Inject(DI.config)
+		private config: Config,
+		@Inject(DI.redisForRemoteApis)
+		private redisForRemoteApis: Redis.Redis,
 		@Inject(DI.clipsRepository)
 		private clipsRepository: ClipsRepository,
 
@@ -31,6 +44,9 @@ export class ClipService {
 		@Inject(DI.notesRepository)
 		private notesRepository: NotesRepository,
 
+		private httpRequestService: HttpRequestService,
+		private userEntityService: UserEntityService,
+		private remoteUserResolveService: RemoteUserResolveService,
 		private roleService: RoleService,
 		private idService: IdService,
 	) {
@@ -154,5 +170,73 @@ export class ClipService {
 		});
 
 		this.notesRepository.decrement({ id: noteId }, 'clippedCount', 1);
+	}
+	@bindThis
+	public async showRemote(
+		clipId:string,
+		host:string,
+	) : Promise<Packed<'Clip'>> {
+		const cache_key = 'clip:show:' + clipId + '@' + host;
+		const cache_value = await this.redisForRemoteApis.get(cache_key);
+		let remote_json = null;
+		if (cache_value === null) {
+			const timeout = 30 * 1000;
+			const operationTimeout = 60 * 1000;
+			const url = 'https://' + host + '/api/clips/show';
+			const res = got.post(url, {
+				headers: {
+					'User-Agent': this.config.userAgent,
+					'Content-Type': 'application/json; charset=utf-8',
+				},
+				timeout: {
+					lookup: timeout,
+					connect: timeout,
+					secureConnect: timeout,
+					socket: timeout,	// read timeout
+					response: timeout,
+					send: timeout,
+					request: operationTimeout,	// whole operation timeout
+				},
+				agent: {
+					http: this.httpRequestService.httpAgent,
+					https: this.httpRequestService.httpsAgent,
+				},
+				http2: true,
+				retry: {
+					limit: 1,
+				},
+				enableUnixSockets: false,
+				body: JSON.stringify({
+					clipId,
+				}),
+			});
+			remote_json = await res.text();
+			const redisPipeline = this.redisForRemoteApis.pipeline();
+			redisPipeline.set(cache_key, remote_json);
+			redisPipeline.expire(cache_key, 10 * 60);
+			await redisPipeline.exec();
+		} else {
+			remote_json = cache_value;
+		}
+		const remote_clip = JSON.parse(remote_json);
+		if (remote_clip.user == null || remote_clip.user.username == null) {
+			throw new ClipService.FailedToResolveRemoteUserError();
+		}
+		const user = await this.remoteUserResolveService.resolveUser(remote_clip.user.username, host).catch(err => {
+			throw new ClipService.FailedToResolveRemoteUserError();
+		});
+		return await awaitAll({
+			id: clipId + '@' + host,
+			createdAt: remote_clip.createdAt ? remote_clip.createdAt : null,
+			lastClippedAt: remote_clip.lastClippedAt ? remote_clip.lastClippedAt : null,
+			userId: user.id,
+			user: this.userEntityService.pack(user),
+			name: remote_clip.name,
+			description: remote_clip.description,
+			isPublic: true,
+			favoritedCount: remote_clip.favoritedCount,
+			isFavorited: false,
+			notesCount: remote_clip.notesCount,
+		});
 	}
 }

--- a/packages/backend/src/di-symbols.ts
+++ b/packages/backend/src/di-symbols.ts
@@ -72,6 +72,7 @@ export const DI = {
 	clipsRepository: Symbol('clipsRepository'),
 	clipNotesRepository: Symbol('clipNotesRepository'),
 	clipFavoritesRepository: Symbol('clipFavoritesRepository'),
+	clipFavoritesRemoteRepository: Symbol('clipFavoritesRemoteRepository'),
 	antennasRepository: Symbol('antennasRepository'),
 	promoNotesRepository: Symbol('promoNotesRepository'),
 	promoReadsRepository: Symbol('promoReadsRepository'),

--- a/packages/backend/src/models/ClipFavoriteRemote.ts
+++ b/packages/backend/src/models/ClipFavoriteRemote.ts
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project, yojo-art team
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { PrimaryColumn, Entity, Index, JoinColumn, Column, ManyToOne } from 'typeorm';
+import { id } from './util/id.js';
+import { MiUser } from './User.js';
+
+@Entity('clip_favorite_remote')
+@Index(['userId', 'clipId', 'host'], { unique: true })
+export class MiClipFavoriteRemote {
+	@PrimaryColumn(id())
+	public id: string;
+
+	@Index()
+	@Column(id())
+	public userId: MiUser['id'];
+
+	@ManyToOne(type => MiUser, {
+		onDelete: 'CASCADE',
+	})
+	@JoinColumn()
+	public user: MiUser | null;
+
+	@Column('varchar', {
+		length: 32,
+	})
+	public clipId: string;
+
+	@Column('varchar', {
+		length: 128,
+	})
+	public host: string;
+}

--- a/packages/backend/src/models/RepositoryModule.ts
+++ b/packages/backend/src/models/RepositoryModule.ts
@@ -24,6 +24,7 @@ import {
 	MiChannelFollowing,
 	MiClip,
 	MiClipFavorite,
+	MiClipFavoriteRemote,
 	MiClipNote,
 	MiDriveFile,
 	MiDriveFolder,
@@ -412,6 +413,12 @@ const $clipFavoritesRepository: Provider = {
 	inject: [DI.db],
 };
 
+const $clipFavoritesRemoteRepository: Provider = {
+	provide: DI.clipFavoritesRemoteRepository,
+	useFactory: (db: DataSource) => db.getRepository(MiClipFavoriteRemote).extend(miRepository as MiRepository<MiClipFavoriteRemote>),
+	inject: [DI.db],
+};
+
 const $antennasRepository: Provider = {
 	provide: DI.antennasRepository,
 	useFactory: (db: DataSource) => db.getRepository(MiAntenna).extend(miRepository as MiRepository<MiAntenna>),
@@ -601,6 +608,7 @@ const $officialTagRepository: Provider = {
 		$clipsRepository,
 		$clipNotesRepository,
 		$clipFavoritesRepository,
+		$clipFavoritesRemoteRepository,
 		$antennasRepository,
 		$promoNotesRepository,
 		$promoReadsRepository,
@@ -679,6 +687,7 @@ const $officialTagRepository: Provider = {
 		$clipsRepository,
 		$clipNotesRepository,
 		$clipFavoritesRepository,
+		$clipFavoritesRemoteRepository,
 		$antennasRepository,
 		$promoNotesRepository,
 		$promoReadsRepository,

--- a/packages/backend/src/models/_.ts
+++ b/packages/backend/src/models/_.ts
@@ -27,6 +27,7 @@ import { MiChannelFavorite } from '@/models/ChannelFavorite.js';
 import { MiClip } from '@/models/Clip.js';
 import { MiClipNote } from '@/models/ClipNote.js';
 import { MiClipFavorite } from '@/models/ClipFavorite.js';
+import { MiClipFavoriteRemote } from '@/models/ClipFavoriteRemote.js';
 import { MiDriveFile } from '@/models/DriveFile.js';
 import { MiDriveFolder } from '@/models/DriveFolder.js';
 import { MiEmoji } from '@/models/Emoji.js';
@@ -149,6 +150,7 @@ export {
 	MiClip,
 	MiClipNote,
 	MiClipFavorite,
+	MiClipFavoriteRemote,
 	MiDriveFile,
 	MiDriveFolder,
 	MiEmoji,
@@ -227,6 +229,7 @@ export type ChannelFavoritesRepository = Repository<MiChannelFavorite> & MiRepos
 export type ClipsRepository = Repository<MiClip> & MiRepository<MiClip>;
 export type ClipNotesRepository = Repository<MiClipNote> & MiRepository<MiClipNote>;
 export type ClipFavoritesRepository = Repository<MiClipFavorite> & MiRepository<MiClipFavorite>;
+export type ClipFavoritesRemoteRepository = Repository<MiClipFavoriteRemote> & MiRepository<MiClipFavoriteRemote>;
 export type DriveFilesRepository = Repository<MiDriveFile> & MiRepository<MiDriveFile>;
 export type DriveFoldersRepository = Repository<MiDriveFolder> & MiRepository<MiDriveFolder>;
 export type EmojisRepository = Repository<MiEmoji> & MiRepository<MiEmoji>;

--- a/packages/backend/src/postgres.ts
+++ b/packages/backend/src/postgres.ts
@@ -26,6 +26,7 @@ import { MiChannelFavorite } from '@/models/ChannelFavorite.js';
 import { MiClip } from '@/models/Clip.js';
 import { MiClipNote } from '@/models/ClipNote.js';
 import { MiClipFavorite } from '@/models/ClipFavorite.js';
+import { MiClipFavoriteRemote } from '@/models/ClipFavoriteRemote.js';
 import { MiDriveFile } from '@/models/DriveFile.js';
 import { MiDriveFolder } from '@/models/DriveFolder.js';
 import { MiEmoji } from '@/models/Emoji.js';
@@ -190,6 +191,7 @@ export const entities = [
 	MiClip,
 	MiClipNote,
 	MiClipFavorite,
+	MiClipFavoriteRemote,
 	MiAntenna,
 	MiPromoNote,
 	MiPromoRead,

--- a/packages/backend/src/server/api/endpoints/clips/show.ts
+++ b/packages/backend/src/server/api/endpoints/clips/show.ts
@@ -10,11 +10,7 @@ import { Endpoint } from '@/server/api/endpoint-base.js';
 import type { ClipsRepository } from '@/models/_.js';
 import { ClipEntityService } from '@/core/entities/ClipEntityService.js';
 import { DI } from '@/di-symbols.js';
-import type { Config } from '@/config.js';
-import { HttpRequestService } from '@/core/HttpRequestService.js';
-import { UserEntityService } from '@/core/entities/UserEntityService.js';
-import { awaitAll } from '@/misc/prelude/await-all.js';
-import { RemoteUserResolveService } from '@/core/RemoteUserResolveService.js';
+import { ClipService } from '@/core/ClipService.js';
 import { ApiError } from '../../error.js';
 
 export const meta = {
@@ -60,24 +56,18 @@ export const paramDef = {
 @Injectable()
 export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-disable-line import/no-default-export
 	constructor(
-		@Inject(DI.config)
-		private config: Config,
 		@Inject(DI.clipsRepository)
 		private clipsRepository: ClipsRepository,
-		@Inject(DI.redisForRemoteApis)
-		private redisForRemoteApis: Redis.Redis,
 
-		private httpRequestService: HttpRequestService,
-		private userEntityService: UserEntityService,
-		private remoteUserResolveService: RemoteUserResolveService,
+		private clipService: ClipService,
 		private clipEntityService: ClipEntityService,
 	) {
 		super(meta, paramDef, async (ps, me) => {
 			const parsed_id = ps.clipId.split('@');
 			if (parsed_id.length === 2 ) {//is remote
-				const url = 'https://' + parsed_id[1] + '/api/clips/show';
-				console.log(url);
-				return remote(config, httpRequestService, userEntityService, remoteUserResolveService, redisForRemoteApis, url, parsed_id[0], parsed_id[1], ps.clipId);
+				return clipService.showRemote(parsed_id[0], parsed_id[1]).catch(err => {
+					throw new ApiError(meta.errors.failedToResolveRemoteUser);
+				});
 			}
 			if (parsed_id.length !== 1 ) {//is not local
 				throw new ApiError(meta.errors.invalidIdFormat);
@@ -100,76 +90,3 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 	}
 }
 
-async function remote(
-	config:Config,
-	httpRequestService: HttpRequestService,
-	userEntityService: UserEntityService,
-	remoteUserResolveService: RemoteUserResolveService,
-	redisForRemoteApis: Redis.Redis,
-	url:string,
-	clipId:string,
-	host:string,
-	local_id:string,
-) {
-	const cache_key = 'clip:show:' + local_id;
-	const cache_value = await redisForRemoteApis.get(cache_key);
-	let remote_json = null;
-	if (cache_value === null) {
-		const timeout = 30 * 1000;
-		const operationTimeout = 60 * 1000;
-		const res = got.post(url, {
-			headers: {
-				'User-Agent': config.userAgent,
-				'Content-Type': 'application/json; charset=utf-8',
-			},
-			timeout: {
-				lookup: timeout,
-				connect: timeout,
-				secureConnect: timeout,
-				socket: timeout,	// read timeout
-				response: timeout,
-				send: timeout,
-				request: operationTimeout,	// whole operation timeout
-			},
-			agent: {
-				http: httpRequestService.httpAgent,
-				https: httpRequestService.httpsAgent,
-			},
-			http2: true,
-			retry: {
-				limit: 1,
-			},
-			enableUnixSockets: false,
-			body: JSON.stringify({
-				clipId,
-			}),
-		});
-		remote_json = await res.text();
-		const redisPipeline = redisForRemoteApis.pipeline();
-		redisPipeline.set(cache_key, remote_json);
-		redisPipeline.expire(cache_key, 10 * 60);
-		await redisPipeline.exec();
-	} else {
-		remote_json = cache_value;
-	}
-	const remote_clip = JSON.parse(remote_json);
-	if (remote_clip.user == null || remote_clip.user.username == null) {
-		throw new ApiError(meta.errors.failedToResolveRemoteUser);
-	}
-	const user = await remoteUserResolveService.resolveUser(remote_clip.user.username, host).catch(err => {
-		throw new ApiError(meta.errors.failedToResolveRemoteUser);
-	});
-	return await awaitAll({
-		id: local_id,
-		createdAt: remote_clip.createdAt ? remote_clip.createdAt : null,
-		lastClippedAt: remote_clip.lastClippedAt ? remote_clip.lastClippedAt : null,
-		userId: user.id,
-		user: userEntityService.pack(user),
-		name: remote_clip.name,
-		description: remote_clip.description,
-		isPublic: true,
-		favoritedCount: remote_clip.favoritedCount,
-		isFavorited: false,
-		notesCount: remote_clip.notesCount,
-	});
-}

--- a/packages/cherrypick-js/etc/cherrypick-js.api.md
+++ b/packages/cherrypick-js/etc/cherrypick-js.api.md
@@ -947,6 +947,9 @@ type ClipsFavoriteRequest = operations['clips___favorite']['requestBody']['conte
 type ClipsListResponse = operations['clips___list']['responses']['200']['content']['application/json'];
 
 // @public (undocumented)
+type ClipsMyFavoritesRequest = operations['clips___my-favorites']['requestBody']['content']['application/json'];
+
+// @public (undocumented)
 type ClipsMyFavoritesResponse = operations['clips___my-favorites']['responses']['200']['content']['application/json'];
 
 // @public (undocumented)
@@ -1395,6 +1398,7 @@ declare namespace entities {
         ClipsUpdateResponse,
         ClipsFavoriteRequest,
         ClipsUnfavoriteRequest,
+        ClipsMyFavoritesRequest,
         ClipsMyFavoritesResponse,
         DriveResponse,
         DriveFilesRequest,

--- a/packages/cherrypick-js/src/autogen/endpoint.ts
+++ b/packages/cherrypick-js/src/autogen/endpoint.ts
@@ -202,6 +202,7 @@ import type {
 	ClipsUpdateResponse,
 	ClipsFavoriteRequest,
 	ClipsUnfavoriteRequest,
+	ClipsMyFavoritesRequest,
 	ClipsMyFavoritesResponse,
 	DriveResponse,
 	DriveFilesRequest,
@@ -746,7 +747,7 @@ export type Endpoints = {
 	'clips/update': { req: ClipsUpdateRequest; res: ClipsUpdateResponse };
 	'clips/favorite': { req: ClipsFavoriteRequest; res: EmptyResponse };
 	'clips/unfavorite': { req: ClipsUnfavoriteRequest; res: EmptyResponse };
-	'clips/my-favorites': { req: EmptyRequest; res: ClipsMyFavoritesResponse };
+	'clips/my-favorites': { req: ClipsMyFavoritesRequest; res: ClipsMyFavoritesResponse };
 	'drive': { req: EmptyRequest; res: DriveResponse };
 	'drive/files': { req: DriveFilesRequest; res: DriveFilesResponse };
 	'drive/files/attached-notes': { req: DriveFilesAttachedNotesRequest; res: DriveFilesAttachedNotesResponse };

--- a/packages/cherrypick-js/src/autogen/entities.ts
+++ b/packages/cherrypick-js/src/autogen/entities.ts
@@ -205,6 +205,7 @@ export type ClipsUpdateRequest = operations['clips___update']['requestBody']['co
 export type ClipsUpdateResponse = operations['clips___update']['responses']['200']['content']['application/json'];
 export type ClipsFavoriteRequest = operations['clips___favorite']['requestBody']['content']['application/json'];
 export type ClipsUnfavoriteRequest = operations['clips___unfavorite']['requestBody']['content']['application/json'];
+export type ClipsMyFavoritesRequest = operations['clips___my-favorites']['requestBody']['content']['application/json'];
 export type ClipsMyFavoritesResponse = operations['clips___my-favorites']['responses']['200']['content']['application/json'];
 export type DriveResponse = operations['drive']['responses']['200']['content']['application/json'];
 export type DriveFilesRequest = operations['drive___files']['requestBody']['content']['application/json'];

--- a/packages/cherrypick-js/src/autogen/types.ts
+++ b/packages/cherrypick-js/src/autogen/types.ts
@@ -13814,7 +13814,6 @@ export type operations = {
     requestBody: {
       content: {
         'application/json': {
-          /** Format: misskey:id */
           clipId: string;
         };
       };
@@ -13863,6 +13862,16 @@ export type operations = {
    * **Credential required**: *Yes* / **Permission**: *read:clip-favorite*
    */
   'clips___my-favorites': {
+    requestBody: {
+      content: {
+        'application/json': {
+          /** @default true */
+          withLocal?: boolean;
+          /** @default true */
+          withRemote?: boolean;
+        };
+      };
+    };
     responses: {
       /** @description OK (with results) */
       200: {


### PR DESCRIPTION
## What
リモートのクリップをお気に入りに登録できるようにした。
clips/my-favoritesのオプションでローカルのみ、リモートのみに絞る事もできる

## Why
resolve: #296 

## Additional info (optional)
デフォルト設定だとclips/my-favorites呼ばれるたびに2回DB読んでるから速度は悪そう

## Checklist
- [ ] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
