### PR TITLE
リモートから添付されてきたクリップURLにホスト情報があると二重になる不具合を修正

### DIFF
--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -11,6 +11,7 @@ Cherrypick 4.11.1
 - Fix: リアクションが閲覧できる状態でも見れない問題を修正 [#429](https://github.com/yojo-art/cherrypick/pull/429)
 - Enhance: チャートの連合グラフで割合を表示
 - Enhance: お気に入り登録クリップの一覧画面から登録解除できるように
+- Fix: リモートから添付されてきたクリップURLにホスト情報があると二重になる不具合を修正 [#460](https://github.com/yojo-art/cherrypick/pull/460)
 
 ### Server
 - 

--- a/packages/frontend/src/components/MkLink.vue
+++ b/packages/frontend/src/components/MkLink.vue
@@ -36,7 +36,8 @@ const props = withDefaults(defineProps<{
 let self = props.url.startsWith(local);
 let requestUrl = new URL(props.url);
 if (props.host === requestUrl.host && requestUrl.pathname.startsWith('/clips/')) {
-	requestUrl = new URL(local + requestUrl.pathname.split('@')[0] + '@' + props.host);
+	let split = requestUrl.pathname.split('@');
+	requestUrl = new URL(local + split[0] + '@' + (split.length >= 2 ? split[1] : props.host));
 	self = true;
 }
 const url_string = requestUrl.toString();

--- a/packages/frontend/src/components/MkLink.vue
+++ b/packages/frontend/src/components/MkLink.vue
@@ -36,7 +36,7 @@ const props = withDefaults(defineProps<{
 let self = props.url.startsWith(local);
 let requestUrl = new URL(props.url);
 if (props.host === requestUrl.host && requestUrl.pathname.startsWith('/clips/')) {
-	requestUrl = new URL(local + requestUrl.pathname + '@' + props.host);
+	requestUrl = new URL(local + requestUrl.pathname.split('@')[0] + '@' + props.host);
 	self = true;
 }
 const url_string = requestUrl.toString();

--- a/packages/frontend/src/components/MkUrlPreview.vue
+++ b/packages/frontend/src/components/MkUrlPreview.vue
@@ -118,7 +118,8 @@ let self = props.url.startsWith(local);
 let requestUrl = new URL(props.url);
 let url_string: string;
 if (props.host === requestUrl.host && requestUrl.pathname.startsWith('/clips/')) {
-	requestUrl = new URL(local + requestUrl.pathname.split('@')[0] + '@' + props.host);
+	let split = requestUrl.pathname.split('@');
+	requestUrl = new URL(local + split[0] + '@' + (split.length >= 2 ? split[1] : props.host));
 	self = true;
 	url_string = requestUrl.toString();
 	requestUrl = new URL(props.url);

--- a/packages/frontend/src/components/MkUrlPreview.vue
+++ b/packages/frontend/src/components/MkUrlPreview.vue
@@ -118,7 +118,7 @@ let self = props.url.startsWith(local);
 let requestUrl = new URL(props.url);
 let url_string: string;
 if (props.host === requestUrl.host && requestUrl.pathname.startsWith('/clips/')) {
-	requestUrl = new URL(local + requestUrl.pathname + '@' + props.host);
+	requestUrl = new URL(local + requestUrl.pathname.split('@')[0] + '@' + props.host);
 	self = true;
 	url_string = requestUrl.toString();
 	requestUrl = new URL(props.url);

--- a/packages/frontend/src/components/global/MkUrl.vue
+++ b/packages/frontend/src/components/global/MkUrl.vue
@@ -50,7 +50,7 @@ let url = new URL(props.url);
 if (!['http:', 'https:'].includes(url.protocol)) throw new Error('invalid url');
 
 if (props.host === url.host && url.pathname.startsWith('/clips/')) {
-	url = new URL(local + url.pathname + '@' + props.host);
+	url = new URL(local + url.pathname.split('@')[0] + '@' + props.host);
 	self = true;
 }
 const url_string = url.toString();

--- a/packages/frontend/src/components/global/MkUrl.vue
+++ b/packages/frontend/src/components/global/MkUrl.vue
@@ -50,7 +50,8 @@ let url = new URL(props.url);
 if (!['http:', 'https:'].includes(url.protocol)) throw new Error('invalid url');
 
 if (props.host === url.host && url.pathname.startsWith('/clips/')) {
-	url = new URL(local + url.pathname.split('@')[0] + '@' + props.host);
+	let split = url.pathname.split('@');
+	url = new URL(local + split[0] + '@' + (split.length >= 2 ? split[1] : props.host));
 	self = true;
 }
 const url_string = url.toString();


### PR DESCRIPTION
## What
リモートから添付されてきたクリップURLにホスト情報があればそれを優先する

## Why
fix: #459 

## Additional info (optional)

## Checklist
- [ ] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [x] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
