### PR TITLE
連合割合%の表示が1000件以上のインスタンスでNaNになる不具合の修正

### DIFF
--- a/packages/frontend/src/scripts/use-chart-tooltip.ts
+++ b/packages/frontend/src/scripts/use-chart-tooltip.ts
@@ -42,7 +42,7 @@ export function useChartTooltip(opts: { position: 'top' | 'middle', total?:numbe
 		tooltipSeries.value = context.tooltip.body.map((b, i) => {
 			let ratio = '';
 			if (opts.total !== undefined) {
-				ratio = '(' + String(Math.round(Number(b.lines[0]) / opts.total * 1000) / 10) + '%)';
+				ratio = '(' + String(Math.round(Number(b.lines[0].replaceAll(/[^0-9]/gi, '')) / opts.total * 1000) / 10) + '%)';
 			}
 			return ({
 				backgroundColor: context.tooltip.labelColors[i].backgroundColor,


### PR DESCRIPTION
## What
Number("1,000")===NaNの問題を修正する

## Why
#437 で実装した表示が計算対象の数が1,000を超えてるとNaNになってしまう問題

## Additional info (optional)

## Checklist
- [ ] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [ ] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
