### PR TITLE
リモートクリップ説明文がローカル仕様になってる問題の修正

### DIFF
--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -12,9 +12,10 @@ Cherrypick 4.11.1
 - Enhance: チャートの連合グラフで割合を表示
 - Enhance: お気に入り登録クリップの一覧画面から登録解除できるように
 - Fix: リモートから添付されてきたクリップURLにホスト情報があると二重になる不具合を修正 [#460](https://github.com/yojo-art/cherrypick/pull/460)
+- Fix: リモートクリップ説明文がローカル仕様になってる問題の修正 [#466](https://github.com/yojo-art/cherrypick/pull/466)
 
 ### Server
-- 
+- Enhance: リモートユーザーの`/api/clips/show`と`/api/users/clips`の応答にemojisを追加 [#466](https://github.com/yojo-art/cherrypick/pull/466)
 
 ### Misc
 

--- a/packages/backend/src/core/ClipService.ts
+++ b/packages/backend/src/core/ClipService.ts
@@ -20,6 +20,7 @@ import { RoleService } from '@/core/RoleService.js';
 import { IdService } from '@/core/IdService.js';
 import type { MiLocalUser, MiUser } from '@/models/User.js';
 import { Packed } from '@/misc/json-schema.js';
+import { emojis } from '@/misc/remote-api-utils.js';
 
 @Injectable()
 export class ClipService {
@@ -201,6 +202,7 @@ export class ClipService {
 	public async showRemote(
 		clipId:string,
 		host:string,
+		fetch_emoji = false,
 	) : Promise<Packed<'Clip'>> {
 		const cache_key = 'clip:show:' + clipId + '@' + host;
 		const cache_value = await this.redisForRemoteApis.get(cache_key);
@@ -263,6 +265,7 @@ export class ClipService {
 			favoritedCount: remote_clip.favoritedCount,
 			isFavorited: false,
 			notesCount: remote_clip.notesCount,
+			emojis: (remote_clip.description && fetch_emoji) ? emojis(this.config, this.httpRequestService, this.redisForRemoteApis, host, remote_clip.description) : {},
 		});
 	}
 }

--- a/packages/backend/src/misc/remote-api-utils.ts
+++ b/packages/backend/src/misc/remote-api-utils.ts
@@ -42,6 +42,7 @@ export async function fetch_remote_emojis(
 	host: string,
 ):Promise<Map<string, string>> {
 	const cache_key = 'emojis:' + host;
+	/*
 	const cache_value = await redisForRemoteApis.get(cache_key);
 	if (cache_value !== null) {
 		//ステータス格納
@@ -50,8 +51,9 @@ export async function fetch_remote_emojis(
 			//未定義のステータス
 			return new Map();
 		}
-		return JSON.parse(cache_value);
+		return new Map(Object.entries(JSON.parse(cache_value)));
 	}
+	*/
 	const url = 'https://' + host + '/api/emojis';
 	const timeout = 30 * 1000;
 	const operationTimeout = 60 * 1000;
@@ -87,7 +89,7 @@ export async function fetch_remote_emojis(
 		}
 	}
 	const redisPipeline = redisForRemoteApis.pipeline();
-	redisPipeline.set(cache_key, JSON.stringify(parsed));
+	redisPipeline.set(cache_key, JSON.stringify(Object.fromEntries(parsed)));
 	redisPipeline.expire(cache_key, 60 * 60);
 	await redisPipeline.exec();
 	return parsed;

--- a/packages/backend/src/misc/remote-api-utils.ts
+++ b/packages/backend/src/misc/remote-api-utils.ts
@@ -26,10 +26,10 @@ export async function emojis(
 ):Promise<Map<string, string>> {
 	const emojis = new Map<string, string>();
 	const remote_emojis = await fetch_remote_emojis(config, httpRequestService, redisForRemoteApis, host);
-	for (const entry of remote_emojis.entries()) {
-		const name = ':' + entry[0] + ':';
+	for (const [key, value] of remote_emojis) {
+		const name = ':' + key + ':';
 		if (text.indexOf(name) !== -1) {
-			emojis.set(entry[0], entry[1]);
+			emojis.set(key, value);
 		}
 	}
 	return emojis;

--- a/packages/backend/src/misc/remote-api-utils.ts
+++ b/packages/backend/src/misc/remote-api-utils.ts
@@ -42,7 +42,6 @@ export async function fetch_remote_emojis(
 	host: string,
 ):Promise<Map<string, string>> {
 	const cache_key = 'emojis:' + host;
-	/*
 	const cache_value = await redisForRemoteApis.get(cache_key);
 	if (cache_value !== null) {
 		//ステータス格納
@@ -51,9 +50,9 @@ export async function fetch_remote_emojis(
 			//未定義のステータス
 			return new Map();
 		}
+		console.log(cache_value);
 		return new Map(Object.entries(JSON.parse(cache_value)));
 	}
-	*/
 	const url = 'https://' + host + '/api/emojis';
 	const timeout = 30 * 1000;
 	const operationTimeout = 60 * 1000;

--- a/packages/backend/src/misc/remote-api-utils.ts
+++ b/packages/backend/src/misc/remote-api-utils.ts
@@ -26,6 +26,7 @@ export async function emojis(
 ):Promise<Map<string, string>> {
 	const emojis = new Map<string, string>();
 	const remote_emojis = await fetch_remote_emojis(config, httpRequestService, redisForRemoteApis, host);
+	console.log(remote_emojis);
 	for (const [key, value] of remote_emojis) {
 		const name = ':' + key + ':';
 		if (text.indexOf(name) !== -1) {
@@ -50,7 +51,6 @@ export async function fetch_remote_emojis(
 			//未定義のステータス
 			return new Map();
 		}
-		console.log(cache_value);
 		return new Map(Object.entries(JSON.parse(cache_value)));
 	}
 	const url = 'https://' + host + '/api/emojis';

--- a/packages/backend/src/misc/remote-api-utils.ts
+++ b/packages/backend/src/misc/remote-api-utils.ts
@@ -23,17 +23,16 @@ export async function emojis(
 	redisForRemoteApis: Redis.Redis,
 	host: string,
 	text:string,
-):Promise<Map<string, string>> {
+):Promise<{[k: string]: string}> {
 	const emojis = new Map<string, string>();
 	const remote_emojis = await fetch_remote_emojis(config, httpRequestService, redisForRemoteApis, host);
 	for (const [key, value] of remote_emojis) {
 		const name = ':' + key + ':';
 		if (text.indexOf(name) !== -1) {
-			console.log(key);
 			emojis.set(key, value);
 		}
 	}
-	return emojis;
+	return Object.fromEntries(emojis);
 }
 
 export async function fetch_remote_emojis(

--- a/packages/backend/src/misc/remote-api-utils.ts
+++ b/packages/backend/src/misc/remote-api-utils.ts
@@ -26,10 +26,10 @@ export async function emojis(
 ):Promise<Map<string, string>> {
 	const emojis = new Map<string, string>();
 	const remote_emojis = await fetch_remote_emojis(config, httpRequestService, redisForRemoteApis, host);
-	console.log(remote_emojis);
 	for (const [key, value] of remote_emojis) {
 		const name = ':' + key + ':';
 		if (text.indexOf(name) !== -1) {
+			console.log(key);
 			emojis.set(key, value);
 		}
 	}

--- a/packages/backend/src/models/json-schema/clip.ts
+++ b/packages/backend/src/models/json-schema/clip.ts
@@ -56,5 +56,14 @@ export const packedClipSchema = {
 			type: 'integer',
 			optional: true, nullable: false,
 		},
+		emojis: {
+			type: 'object',
+			optional: true, nullable: false,
+			additionalProperties: {
+				anyOf: [{
+					type: 'string',
+				}],
+			},
+		},
 	},
 } as const;

--- a/packages/backend/src/server/api/endpoints/clips/show.ts
+++ b/packages/backend/src/server/api/endpoints/clips/show.ts
@@ -68,6 +68,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 			const parsed_id = ps.clipId.split('@');
 			if (parsed_id.length === 2 ) {//is remote
 				const clip = await clipService.showRemote(parsed_id[0], parsed_id[1], true).catch(err => {
+					console.error(err);
 					throw new ApiError(meta.errors.failedToResolveRemoteUser);
 				});
 				if (me) {

--- a/packages/backend/src/server/api/endpoints/clips/show.ts
+++ b/packages/backend/src/server/api/endpoints/clips/show.ts
@@ -67,7 +67,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 		super(meta, paramDef, async (ps, me) => {
 			const parsed_id = ps.clipId.split('@');
 			if (parsed_id.length === 2 ) {//is remote
-				const clip = await clipService.showRemote(parsed_id[0], parsed_id[1]).catch(err => {
+				const clip = await clipService.showRemote(parsed_id[0], parsed_id[1], true).catch(err => {
 					throw new ApiError(meta.errors.failedToResolveRemoteUser);
 				});
 				if (me) {

--- a/packages/backend/src/server/api/endpoints/users/clips.ts
+++ b/packages/backend/src/server/api/endpoints/users/clips.ts
@@ -14,7 +14,7 @@ import { UserEntityService } from '@/core/entities/UserEntityService.js';
 import type { Config } from '@/config.js';
 import { HttpRequestService } from '@/core/HttpRequestService.js';
 import { awaitAll } from '@/misc/prelude/await-all.js';
-import { fetch_remote_api, fetch_remote_user_id } from '@/misc/remote-api-utils.js';
+import { emojis, fetch_remote_api, fetch_remote_user_id } from '@/misc/remote-api-utils.js';
 import type { FindOptionsWhere } from 'typeorm';
 
 export const meta = {
@@ -127,6 +127,7 @@ async function remote(
 			favoritedCount: remote_clip.favoritedCount,
 			isFavorited: false,
 			notesCount: remote_clip.notesCount,
+			emojis: remote_clip.description ? emojis(config, httpRequestService, redisForRemoteApis, user.host, remote_clip.description) : {},
 		});
 		clips.push(clip);
 	}

--- a/packages/cherrypick-js/src/autogen/types.ts
+++ b/packages/cherrypick-js/src/autogen/types.ts
@@ -4901,6 +4901,9 @@ export type components = {
       favoritedCount: number;
       isFavorited?: boolean;
       notesCount?: number;
+      emojis?: {
+        [key: string]: string;
+      };
     };
     FederationInstance: {
       /** Format: id */

--- a/packages/frontend/src/pages/clip.vue
+++ b/packages/frontend/src/pages/clip.vue
@@ -12,7 +12,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 			<div class="_panel">
 				<div class="_gaps_s" :class="$style.description">
 					<div v-if="clip.description">
-						<Mfm :text="clip.description" :isNote="false"/>
+						<Mfm :text="clip.description" :isNote="false" :author="clip.user" :emojiUrls="clip.emojis"/>
 					</div>
 					<div v-else>({{ i18n.ts.noDescription }})</div>
 					<div>


### PR DESCRIPTION
## What
リモートユーザーのクリップ説明文に含まれるメンションと絵文字をリモート仕様にした
絵文字の情報が無かったからノートと同じ仕様でAPIに追加してある

## Why
fix: #464 

## Additional info (optional)
リモートの絵文字情報をredisForRemoteApisに入れてるからメモリ消費が気になるかも

## Checklist
- [ ] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [x] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
