### PR TITLE
Fix: ノート編集時に3001文字以上の場合編集できない問題を修正

### DIFF
--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -43,7 +43,8 @@ Cherrypick 4.11.1
 - Fix: Opensearch利用時ファイルのセンシティブ状態が変更されたとき変更されるように
 - Change: `notes/advanced-search`で`query`が必須ではなくなりました
 - Fix: (Opensearch利用時)高度な検索でリプライ除外にするとエラーがでる
-
+- Fix: ノート編集時に3001文字以上の場合編集できない問題を修正
+ 
 ### Misc
 
 ## 1.0.1

--- a/packages/backend/migration/1729171469427-noteEditHistoryLength.js
+++ b/packages/backend/migration/1729171469427-noteEditHistoryLength.js
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project, yojo-art team
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+export class noteEditHistoryLength1729171469427 {
+	name = 'noteEditHistoryLength1729171469427';
+	async up(queryRunner) {
+		await queryRunner.query('ALTER TABLE "note" ALTER COLUMN "noteEditHistory" TYPE varchar(8192)[]');
+	}
+
+	async down(queryRunner) {
+		await queryRunner.query('ALTER TABLE "note" ALTER COLUMN "noteEditHistory" TYPE varchar(3000)[]');
+	}
+}

--- a/packages/backend/src/models/Note.ts
+++ b/packages/backend/src/models/Note.ts
@@ -27,7 +27,7 @@ export class MiNote {
 	public updatedAtHistory: Date[] | null;
 
 	@Column('varchar', {
-		length: 3000,
+		length: 8192,
 		array: true,
 		default: '{}',
 	})


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
ノートの編集履歴を保持する配列のDB上の長さを8192文字に変更
const.ts
最大ノート文字数: 5120
DBの最大ノート文字数:8192
なのでDBの最大ノート文字数に合わせる
## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Fix #435
## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [x] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
