### PR TITLE
通知APIがページ境界で重複する問題の修正

### DIFF
--- a/packages/backend/src/core/AdvancedSearchService.ts
+++ b/packages/backend/src/core/AdvancedSearchService.ts
@@ -1110,14 +1110,10 @@ export class AdvancedSearchService {
 			}
 			if (followingFilter === 'following' && !Followings.includes(Note._source.userId)) return null;
 			if (followingFilter === 'notFollowing' && Followings.includes(Note._source.userId)) return null;
-
-			if (Note._source.userId === meUserId) {//自分のノート
-				return Note;
-			}
 		}
 
 		const user = await this.cacheService.findUserById(Note._source.userId);
- 		if (user.isIndexable === false) { //検索許可されていないが、
+ 		if (user.isIndexable === false && meUserId !== undefined && user.id !== meUserId) { //検索許可されていないが、
 			if (!meUserId || !this.opensearch) {
 				return null;
 			}
@@ -1187,11 +1183,13 @@ export class AdvancedSearchService {
 		if (meUserId) {
 			if (Note._source.visibility === 'followers') { //鍵だけどフォローしてる
 				if (Followings.includes(Note._source.userId)) return Note;
+				if (Note._source.userId === meUserId) return Note;//または自分
 			}
 
 			if (Note._source.visibility === 'specified') {//自分が宛先に含まれている
 				if (Note._source.visibleUserIds) {
 					if (Note._source.visibleUserIds.includes(meUserId)) return Note;
+					if (Note._source.userId === meUserId) return Note;//または自分
 				}
 			}
 		}

--- a/packages/backend/src/server/api/endpoints/i/notifications-grouped.ts
+++ b/packages/backend/src/server/api/endpoints/i/notifications-grouped.ts
@@ -97,7 +97,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				return [];
 			}
 
-			let notifications = notificationsRes.map(x => JSON.parse(x[1][1])).filter(x => x.id !== ps.untilId && x !== ps.sinceId) as MiNotification[];
+			let notifications = notificationsRes.map(x => JSON.parse(x[1][1])).filter(x => x.id !== ps.untilId && x.id !== ps.sinceId) as MiNotification[];
 
 			if (includeTypes && includeTypes.length > 0) {
 				notifications = notifications.filter(notification => includeTypes.includes(notification.type));

--- a/packages/backend/src/server/api/endpoints/i/notifications.ts
+++ b/packages/backend/src/server/api/endpoints/i/notifications.ts
@@ -110,15 +110,12 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 					return [];
 				}
 
-				notifications = notificationsRes.map(x => JSON.parse(x[1][1])) as MiNotification[];
+				notifications = notificationsRes.map(x => JSON.parse(x[1][1])).filter(x => x.id !== ps.untilId && x.id !== ps.sinceId) as MiNotification[];
 
 				if (includeTypes && includeTypes.length > 0) {
 					notifications = notifications.filter(notification => includeTypes.includes(notification.type));
 				} else if (excludeTypes && excludeTypes.length > 0) {
 					notifications = notifications.filter(notification => !excludeTypes.includes(notification.type));
-				}
-				if (ps.untilId ?? ps.sinceId) {
-					notifications = notifications.filter(notification => ps.untilId !== notification.id && ps.sinceId !== notification.id);
 				}
 
 				if (notifications.length !== 0) {

--- a/packages/backend/src/server/api/endpoints/i/notifications.ts
+++ b/packages/backend/src/server/api/endpoints/i/notifications.ts
@@ -117,6 +117,9 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				} else if (excludeTypes && excludeTypes.length > 0) {
 					notifications = notifications.filter(notification => !excludeTypes.includes(notification.type));
 				}
+				if (ps.untilId ?? ps.sinceId) {
+					notifications = notifications.filter(notification => ps.untilId !== notification.id && ps.sinceId !== notification.id);
+				}
 
 				if (notifications.length !== 0) {
 					// 通知が１件以上ある場合は返す


### PR DESCRIPTION
## What
通知APIがページ境界で重複する問題の修正

## Why
fix: #493 

## Additional info (optional)

## Checklist
- [ ] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [x] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
