### PR TITLE
feat: 絵文字を登録する際にシステムユーザーとして再アップロード

### DIFF
--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -46,6 +46,8 @@ Cherrypick 4.11.1
 - Fix: (Opensearch利用時)高度な検索でリプライ除外にするとエラーがでる
 - Fix: ノート編集時に3001文字以上の場合編集できない問題を修正
 - Fix: 通知APIがページ境界で重複する問題の修正
+- Change: 絵文字を登録する際にシステムユーザーとして再アップロードするように  
+  (Cherry-picked from https://github.com/team-shahu/misskey/pull/11)
 
 ### Misc
 

--- a/packages/backend/src/core/CustomEmojiService.ts
+++ b/packages/backend/src/core/CustomEmojiService.ts
@@ -19,6 +19,7 @@ import { UtilityService } from '@/core/UtilityService.js';
 import { query } from '@/misc/prelude/url.js';
 import type { Serialized } from '@/types.js';
 import { ModerationLogService } from '@/core/ModerationLogService.js';
+import { DriveService } from '@/core/DriveService.js';
 
 const parseEmojiStrRegexp = /^([-\w]+)(?:@([\w.-]+))?$/;
 
@@ -39,6 +40,7 @@ export class CustomEmojiService implements OnApplicationShutdown {
 		private emojiEntityService: EmojiEntityService,
 		private moderationLogService: ModerationLogService,
 		private globalEventService: GlobalEventService,
+		private driveService: DriveService,
 	) {
 		this.emojisCache = new MemoryKVCache<MiEmoji | null>(1000 * 60 * 60 * 12); // 12h
 
@@ -68,6 +70,14 @@ export class CustomEmojiService implements OnApplicationShutdown {
 		localOnly: boolean;
 		roleIdsThatCanBeUsedThisEmojiAsReaction: MiRole['id'][];
 	}, moderator?: MiUser): Promise<MiEmoji> {
+		// システムユーザーとして再アップロード
+		if (!data.driveFile.user?.isRoot) {
+			data.driveFile = await this.driveService.uploadFromUrl({
+				url: data.driveFile.url,
+				user: null,
+				force: true,
+			});
+		}
 		const emoji = await this.emojisRepository.insertOne({
 			id: this.idService.gen(),
 			updatedAt: new Date(),


### PR DESCRIPTION
## What
絵文字を登録する際にシステムユーザーとして再アップロード

## Why
登録したユーザーがアカウントを削除しても絵文字が消えないように

## Additional info (optional)

## Checklist
- [ ] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [ ] ローカル環境で動作しました(Test working in a local environment)
- [x] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
