### PR TITLE
サーバー情報で公式タグを開いてもページタイトルを更新しない

### DIFF
--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -53,6 +53,7 @@ Cherrypick 4.11.1
 - Fix: ユーザー概要の「ファイル」の挙動を通常の添付ファイルに合わせる [#472](https://github.com/yojo-art/cherrypick/pull/472)
 - Fix: チャットの絵文字ピッカーが正しく入力できないことがあるのを修正
 - Enhance: 非ログイン時に動きのあるMFMを動かすか選べるように
+- Fix: サーバー情報画面で公式タグを選択するとヘッダが公式タグのままになる不具合を修正 [#527](https://github.com/yojo-art/cherrypick/pull/527)
 
 ### Server
 - Enhance: リモートユーザーの`/api/clips/show`と`/api/users/clips`の応答にemojisを追加 [#466](https://github.com/yojo-art/cherrypick/pull/466)

--- a/packages/frontend/src/pages/about.vue
+++ b/packages/frontend/src/pages/about.vue
@@ -20,7 +20,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 			<MkInstanceStats/>
 		</MkSpacer>
 		<MkSpacer v-else-if="tab === 'officialTags'" :contentMax="1000" :marginMin="20">
-			<XOfficialTag :showHeader="false"/>
+			<XOfficialTag :showHeader="false" :setTitle="false"/>
 		</MkSpacer>
 	</MkHorizontalSwipe>
 </MkStickyContainer>

--- a/packages/frontend/src/pages/official-tags.vue
+++ b/packages/frontend/src/pages/official-tags.vue
@@ -24,8 +24,10 @@ import { misskeyApi } from '@/scripts/misskey-api.js';
 
 const props = withDefaults(defineProps<{
 	showHeader?: boolean;
+	setTitle?: boolean;
 }>(), {
 	showHeader: true,
+	setTitle: true,
 });
 
 const official_tags = ref<Misskey.entities.OfficialTagsShowResponse>([]);
@@ -33,9 +35,11 @@ const official_tags = ref<Misskey.entities.OfficialTagsShowResponse>([]);
 	official_tags.value = await misskeyApi('official-tags/show', {});
 })();
 
-definePageMetadata(() => ({
-	title: i18n.ts._official_tag.title,
-	icon: 'ti ti-bookmarks',
-}));
+if (props.setTitle) {
+	definePageMetadata(() => ({
+		title: i18n.ts._official_tag.title,
+		icon: 'ti ti-bookmarks',
+	}));
+}
 </script>
 


### PR DESCRIPTION
## What
definePageMetadataするかオプションにした

## Why
fix: #445

## Additional info (optional)

## Checklist
- [ ] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [x] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
