### PR TITLE
searchableByのマイグレーションを修正

### DIFF
--- a/packages/backend/migration/1729457336777-AddSearchable.js
+++ b/packages/backend/migration/1729457336777-AddSearchable.js
@@ -6,15 +6,16 @@ export class AddSearchable1729457336777 {
 	name = 'AddSearchable1729457336777';
 
 	async up(queryRunner) {
-		await queryRunner.query('ALTER TABLE "user" ADD "searchableBy" "public"."user_searchableby_enum"');
+		await queryRunner.query('CREATE TYPE "public"."user_searchableby_enum" AS ENUM(\'public\', \'followersAndReacted\', \'reactedOnly\', \'private\')');
 		await queryRunner.query('CREATE TYPE "public"."note_searchableby_enum" AS ENUM(\'public\', \'followersAndReacted\', \'reactedOnly\', \'private\')');
+		await queryRunner.query('ALTER TABLE "user" ADD "searchableBy" "public"."user_searchableby_enum"');
 		await queryRunner.query('ALTER TABLE "note" ADD "searchableBy" "public"."note_searchableby_enum"');
-		await queryRunner.query('CREATE INDEX "IDX_3932b42da4cf440203d2013649" ON "user" ("searchableBy") ');
-			    }
+	}
 
 	async down(queryRunner) {
 		await queryRunner.query('ALTER TABLE "note" DROP COLUMN "searchableBy"');
-		await queryRunner.query('DROP TYPE "public"."note_searchableby_enum"');
 		await queryRunner.query('ALTER TABLE "user" DROP COLUMN "searchableBy"');
+		await queryRunner.query('DROP TYPE "public"."note_searchableby_enum"');
+		await queryRunner.query('DROP TYPE "public"."user_searchableby_enum"');
 	}
 };


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
```
query: START TRANSACTION

query: ALTER TABLE "user" ADD "searchableBy" "public"."user_searchableby_enum"

query failed: ALTER TABLE "user" ADD "searchableBy" "public"."user_searchableby_enum"

error: error: type "public.user_searchableby_enum" does not exist

Migration "AddSearchable1729457336777" failed, error: type "public.user_searchableby_enum" does not exist

query: ROLLBACK

Error during migration run:

QueryFailedError: type "public.user_searchableby_enum" does not exist

    at PostgresQueryRunner.query (/cherrypick/node_modules/.pnpm/typeorm@0.3.20_ioredis@5.4.1_pg@8.12.0/node_modules/typeorm/driver/postgres/PostgresQueryRunner.js:219:19)

    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

    at async AddSearchable1729457336777.up (file:///cherrypick/packages/backend/migration/1729457336777-AddSearchable.js:9:3)

    at async MigrationExecutor.executePendingMigrations (/cherrypick/node_modules/.pnpm/typeorm@0.3.20_ioredis@5.4.1_pg@8.12.0/node_modules/typeorm/migration/MigrationExecutor.js:225:17)

    at async DataSource.runMigrations (/cherrypick/node_modules/.pnpm/typeorm@0.3.20_ioredis@5.4.1_pg@8.12.0/node_modules/typeorm/data-source/DataSource.js:265:35)

    at async Object.handler (/cherrypick/node_modules/.pnpm/typeorm@0.3.20_ioredis@5.4.1_pg@8.12.0/node_modules/typeorm/commands/MigrationRunCommand.js:68:13) {

  query: 'ALTER TABLE "user" ADD "searchableBy" "public"."user_searchableby_enum"',

  parameters: undefined,

  driverError: error: type "public.user_searchableby_enum" does not exist

      at /cherrypick/node_modules/.pnpm/pg@8.12.0/node_modules/pg/lib/client.js:526:17

      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

      at async PostgresQueryRunner.query (/cherrypick/node_modules/.pnpm/typeorm@0.3.20_ioredis@5.4.1_pg@8.12.0/node_modules/typeorm/driver/postgres/PostgresQueryRunner.js:184:25)

      at async AddSearchable1729457336777.up (file:///cherrypick/packages/backend/migration/1729457336777-AddSearchable.js:9:3)

      at async MigrationExecutor.executePendingMigrations (/cherrypick/node_modules/.pnpm/typeorm@0.3.20_ioredis@5.4.1_pg@8.12.0/node_modules/typeorm/migration/MigrationExecutor.js:225:17)

      at async DataSource.runMigrations (/cherrypick/node_modules/.pnpm/typeorm@0.3.20_ioredis@5.4.1_pg@8.12.0/node_modules/typeorm/data-source/DataSource.js:265:35)

      at async Object.handler (/cherrypick/node_modules/.pnpm/typeorm@0.3.20_ioredis@5.4.1_pg@8.12.0/node_modules/typeorm/commands/MigrationRunCommand.js:68:13) {

    length: 116,

    severity: 'ERROR',

    code: '42704',

    detail: undefined,

    hint: undefined,

    position: '39',

    internalPosition: undefined,

    internalQuery: undefined,

    where: undefined,

    schema: undefined,

    table: undefined,

    column: undefined,

    dataType: undefined,

    constraint: undefined,

    file: 'parse_type.c',

    line: '270',

    routine: 'typenameType'

  },

  length: 116,

  severity: 'ERROR',

  code: '42704',

  detail: undefined,

  hint: undefined,

  position: '39',

  internalPosition: undefined,

  internalQuery: undefined,

  where: undefined,

  schema: undefined,

  table: undefined,

  column: undefined,

  dataType: undefined,

  constraint: undefined,

  file: 'parse_type.c',

  line: '270',

  routine: 'typenameType'

}

 ELIFECYCLE  Command failed with exit code 1.

 ELIFECYCLE  Command failed with exit code 1.

 ELIFECYCLE  Command failed with exit code 1.
```
## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [ ] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
