### PR TITLE
Fix: 高度な検索でノート本文に含まれないタグが検索対象外なのを修正

### DIFF
--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -57,6 +57,7 @@ Cherrypick 4.11.1
 - Fix: サーバー情報画面で公式タグを選択するとヘッダが公式タグのままになる不具合を修正 [#527](https://github.com/yojo-art/cherrypick/pull/527)
 
 ### Server
+- Fix: 高度な検索でノート本文に含まれないタグが検索対象外なのを修正
 - Enhance: リモートユーザーの`/api/clips/show`と`/api/users/clips`の応答にemojisを追加 [#466](https://github.com/yojo-art/cherrypick/pull/466)
 - Fix: Opensearch利用時ファイルのセンシティブ状態が変更されたとき変更されるように
 - Change: `notes/advanced-search`で`query`が必須ではなくなりました

--- a/packages/backend/src/core/AdvancedSearchService.ts
+++ b/packages/backend/src/core/AdvancedSearchService.ts
@@ -956,7 +956,7 @@ export class AdvancedSearchService {
 			}
 
 			if (q && q !== '') {
-				const fields = [opts.useStrictSearch ? 'text.keyword' : 'text'];
+				const fields = ['tags', opts.useStrictSearch ? 'text.keyword' : 'text'];
 				if (!opts.excludeCW) {	fields.push(opts.useStrictSearch ? 'cw.keyword' : 'cw' );}
 				osFilter.bool.must.push({ simple_query_string: { fields: fields, 'query': q, default_operator: 'and' } });
 			}


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
高度な検索でノート本文に含まれないタグが検索対象外なのを修正
## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [ ] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
