### PR TITLE
デフォルトの公開範囲から連合なしを削除

### DIFF
--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -80,6 +80,7 @@ docker環境でノートレコードが多数(数百万件)ある場合**一時�
   - `excludeQuote` 引用除外 true/false
   - `strictSearch` 表記ゆれ検索有効 true/false
 - Enhance: 非ログイン時に動きのあるMFMを動かすか選べるように [#508](https://github.com/yojo-art/cherrypick/pull/508)
+- Fix: デフォルトの公開範囲から連合なしを削除 [#532](https://github.com/yojo-art/cherrypick/pull/532)
 
 ### Server
 - Change: `notes/advanced-search`で`query`が必須ではなくなりました [#496](https://github.com/yojo-art/cherrypick/pull/496)

--- a/packages/frontend/src/pages/settings/privacy.vue
+++ b/packages/frontend/src/pages/settings/privacy.vue
@@ -77,7 +77,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 						<option value="followers">{{ i18n.ts._visibility.followers }}</option>
 						<option value="specified">{{ i18n.ts._visibility.specified }}</option>
 					</MkSelect>
-					<MkSwitch v-model="defaultNoteLocalOnly">{{ i18n.ts._visibility.disableFederation }}</MkSwitch>
 				</div>
 			</MkFolder>
 			<MkSwitch v-model="remenberNoteSearchbility" @update:modelValue="save()">{{ i18n.ts.rememberNoteSearchbility }}</MkSwitch>
@@ -134,7 +133,6 @@ const searchableBy = ref($i.searchableBy);
 const defaultNoteVisibility = computed(defaultStore.makeGetterSetter('defaultNoteVisibility'));
 const defaultNoteSearchbility = computed(defaultStore.makeGetterSetter('defaultNoteSearchableBy'));
 const remenberNoteSearchbility = computed(defaultStore.makeGetterSetter('rememberNoteSearchableBy'));
-const defaultNoteLocalOnly = computed(defaultStore.makeGetterSetter('defaultNoteLocalOnly'));
 const rememberNoteVisibility = computed(defaultStore.makeGetterSetter('rememberNoteVisibility'));
 const keepCw = computed(defaultStore.makeGetterSetter('keepCw'));
 


### PR DESCRIPTION
## What
デフォルトの公開範囲の設定から連合なしを削除

## Why
連合なし機能は削除済、機能してない設定項目は紛らわしい

## Additional info (optional)
localStorageには残してある

## Checklist
- [ ] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [x] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
