### PR TITLE
Fix: リアクション再インデックスでリモートのリアクションを含まないようにする

### DIFF
--- a/packages/backend/src/core/AdvancedSearchService.ts
+++ b/packages/backend/src/core/AdvancedSearchService.ts
@@ -571,7 +571,7 @@ export class AdvancedSearchService {
 				.where('reac.id > :latestid', { latestid })
 				.innerJoin('reac.user', 'user')
 				.leftJoin('reac.note', 'note')
-				.select(['reac', 'user.host', 'note.searchableBy'])
+				.select(['reac', 'note.searchableBy'])
 				.andWhere('user.host IS NULL')
 				.orderBy('reac.id', 'ASC')
 				.limit(limit)


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Fix #540
## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
リアクション再インデックスでリモートのリアクションを含まないようにする
## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [ ] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
