### PR TITLE
ノートを編集する時に検索許可範囲を記憶する

### DIFF
--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -1,4 +1,6 @@
 ## 1.2.0
+### General
+- Fix: ノートを編集する時に検索許可範囲を記憶する [#558](https://github.com/yojo-art/cherrypick/pull/558)
 
 ### Server
 - Enhance: `/users/${id}`に`Accept: application/ld+json`ではないリクエストが来たとき`/@${username}`にリダイレクトするように [#554](https://github.com/yojo-art/cherrypick/pull/554)

--- a/packages/backend/src/core/WebhookTestService.ts
+++ b/packages/backend/src/core/WebhookTestService.ts
@@ -161,6 +161,7 @@ function toPackedNote(note: MiNote, detail = true, override?: Packed<'Note'>): P
 		renoteId: note.renoteId,
 		isHidden: false,
 		visibility: note.visibility,
+		searchableBy: note.searchableBy,
 		mentions: note.mentions,
 		visibleUserIds: note.visibleUserIds,
 		fileIds: note.fileIds,

--- a/packages/backend/src/models/json-schema/note.ts
+++ b/packages/backend/src/models/json-schema/note.ts
@@ -95,7 +95,7 @@ export const packedNoteSchema = {
 		},
 		searchableBy: {
 			type: 'string',
-			optional: false, nullable: false,
+			optional: false, nullable: true,
 			enum: ['public', 'private', 'followersAndReacted', 'reactedOnly'],
 		},
 		mentions: {

--- a/packages/backend/src/models/json-schema/note.ts
+++ b/packages/backend/src/models/json-schema/note.ts
@@ -93,6 +93,11 @@ export const packedNoteSchema = {
 			optional: false, nullable: false,
 			enum: ['public', 'home', 'followers', 'specified'],
 		},
+		searchableBy: {
+			type: 'string',
+			optional: false, nullable: false,
+			enum: ['public', 'private', 'followersAndReacted', 'reactedOnly'],
+		},
 		mentions: {
 			type: 'array',
 			optional: true, nullable: false,

--- a/packages/cherrypick-js/src/autogen/types.ts
+++ b/packages/cherrypick-js/src/autogen/types.ts
@@ -4456,6 +4456,8 @@ export type components = {
       isHidden?: boolean;
       /** @enum {string} */
       visibility: 'public' | 'home' | 'followers' | 'specified';
+      /** @enum {string} */
+      searchableBy: 'public' | 'private' | 'followersAndReacted' | 'reactedOnly';
       mentions?: string[];
       visibleUserIds?: string[];
       fileIds?: string[];

--- a/packages/cherrypick-js/src/autogen/types.ts
+++ b/packages/cherrypick-js/src/autogen/types.ts
@@ -4456,7 +4456,7 @@ export type components = {
       isHidden?: boolean;
       /** @enum {string} */
       visibility: 'public' | 'home' | 'followers' | 'specified';
-      /** @enum {string} */
+      /** @enum {string|null} */
       searchableBy: 'public' | 'private' | 'followersAndReacted' | 'reactedOnly';
       mentions?: string[];
       visibleUserIds?: string[];

--- a/packages/frontend/src/components/MkPostForm.vue
+++ b/packages/frontend/src/components/MkPostForm.vue
@@ -742,6 +742,7 @@ function saveDraft() {
 			cw: cw.value,
 			disableRightClick: disableRightClick.value,
 			visibility: visibility.value,
+			searchableBy: searchableBy.value,
 			files: files.value,
 			poll: poll.value,
 			event: event.value,
@@ -1166,7 +1167,7 @@ onMounted(() => {
 				cw.value = draft.data.cw;
 				disableRightClick.value = draft.data.disableRightClick;
 				visibility.value = draft.data.visibility;
-				searchableBy.value = draft.data.searchbility;
+				searchableBy.value = draft.data.searchableBy;
 				files.value = (draft.data.files || []).filter(draftFile => draftFile);
 				if (draft.data.poll) {
 					poll.value = draft.data.poll;
@@ -1191,6 +1192,7 @@ onMounted(() => {
 			useCw.value = init.cw != null;
 			cw.value = init.cw ?? null;
 			visibility.value = init.visibility;
+			searchableBy.value = init.searchableBy;
 			files.value = init.files ?? [];
 			if (init.isSchedule) {
 				schedule.value = {

--- a/packages/frontend/src/components/MkPostForm.vue
+++ b/packages/frontend/src/components/MkPostForm.vue
@@ -405,6 +405,7 @@ function watchForDraft() {
 	watch(event, () => saveDraft());
 	watch(files, () => saveDraft(), { deep: true });
 	watch(visibility, () => saveDraft());
+	watch(searchableBy, () => saveDraft());
 	watch(quoteId, () => saveDraft());
 	watch(reactionAcceptance, () => saveDraft());
 	watch(scheduledNoteDelete, () => saveDraft());

--- a/packages/frontend/src/components/MkPostFormSimple.vue
+++ b/packages/frontend/src/components/MkPostFormSimple.vue
@@ -233,7 +233,7 @@ const showAddMfmFunction = ref(defaultStore.state.enableQuickAddMfmFunction);
 watch(showAddMfmFunction, () => defaultStore.set('enableQuickAddMfmFunction', showAddMfmFunction.value));
 const cw = ref<string | null>(props.initialCw ?? null);
 const visibility = ref(props.initialVisibility ?? (defaultStore.state.rememberNoteVisibility ? defaultStore.state.visibility : defaultStore.state.defaultNoteVisibility));
-const searchableBy = ref(defaultStore.state.rememberNoteSearchableBy ? defaultStore.state.searchableBy : defaultStore.state.defaultNotesearchableBy);
+const searchableBy = ref(defaultStore.state.rememberNoteSearchbility ? defaultStore.state.searchbility : defaultStore.state.defaultNoteSearchbility);
 const visibleUsers = ref<Misskey.entities.UserDetailed[]>([]);
 if (props.initialVisibleUsers) {
 	props.initialVisibleUsers.forEach(u => pushVisibleUser(u));
@@ -722,6 +722,7 @@ function saveDraft() {
 			cw: cw.value,
 			disableRightClick: disableRightClick.value,
 			visibility: visibility.value,
+			searchableBy: searchableBy.value,
 			files: files.value,
 			poll: poll.value,
 			event: event.value,
@@ -841,6 +842,7 @@ async function post(ev?: MouseEvent) {
 		event: event.value,
 		cw: useCw.value ? cw.value ?? '' : null,
 		visibility: visibility.value,
+		searchableBy: searchableBy.value,
 		visibleUserIds: visibility.value === 'specified' ? visibleUsers.value.map(u => u.id) : undefined,
 		reactionAcceptance: reactionAcceptance.value,
 		disableRightClick: disableRightClick.value,
@@ -1183,7 +1185,7 @@ onMounted(() => {
 				cw.value = draft.data.cw;
 				disableRightClick.value = draft.data.disableRightClick;
 				visibility.value = draft.data.visibility;
-				searchableBy.value = draft.data.searchbility;
+				searchableBy.value = draft.data.searchableBy;
 				files.value = (draft.data.files || []).filter(draftFile => draftFile);
 				if (draft.data.poll) {
 					poll.value = draft.data.poll;
@@ -1208,7 +1210,7 @@ onMounted(() => {
 			useCw.value = init.cw != null;
 			cw.value = init.cw ?? null;
 			visibility.value = init.visibility;
-			searchableBy.value = init.searchbility;
+			searchableBy.value = init.searchableBy;
 			files.value = init.files ?? [];
 			if (init.poll) {
 				poll.value = {

--- a/packages/frontend/src/components/MkPostFormSimple.vue
+++ b/packages/frontend/src/components/MkPostFormSimple.vue
@@ -396,6 +396,7 @@ function watchForDraft() {
 	watch(event, () => saveDraft());
 	watch(files, () => saveDraft(), { deep: true });
 	watch(visibility, () => saveDraft());
+	watch(searchableBy, () => saveDraft());
 	watch(quoteId, () => saveDraft());
 	watch(reactionAcceptance, () => saveDraft());
 	watch(scheduledNoteDelete, () => saveDraft());


### PR DESCRIPTION
## What
#553 

## Why
Fix: #553

## Additional info (optional)

## Checklist
- [ ] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
