### PR TITLE
ユーザー詳細「サーバー情報」の重複を修正

### DIFF
--- a/packages/frontend/src/scripts/get-user-menu.ts
+++ b/packages/frontend/src/scripts/get-user-menu.ts
@@ -316,14 +316,6 @@ export function getUserMenu(user: Misskey.entities.UserDetailed, router: IRouter
 				window.open(user.url, '_blank', 'noopener');
 			},
 		});
-		menuItems.push({
-			icon: 'ti ti-server',
-			text: i18n.ts.instanceInfo,
-			action: () => {
-				if (user.host == null) return;
-				router.push(`/instance-info/${user.host}`);
-			},
-		});
 	} else {
 		menuItems.push({
 			icon: 'ti ti-code',


### PR DESCRIPTION
## What
ユーザー詳細の「サーバー情報」が重複してたのを片方削除

## Why
独自追加してたけどcherrypick側でも追加されて重複した

## Additional info (optional)
cherrypick側の実装を残した

## Checklist
- [ ] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
