### PR TITLE
リモートクリップ/リモートplay機能のURLで外部サイト警告が出る問題を修正

### DIFF
--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -1,5 +1,5 @@
 ## 1.2.1
-Cherrypick 4.13.0
+Cherrypick 4.13.0  
 Misskey 2024.10.1
 
 ### Release Date
@@ -15,11 +15,12 @@ Misskey 2024.10.1
   - ユーザー設定全般のデータセーバー、メディアの読み込みを無効化が無視されてたのを修正
   - センシティブ画像を開く時に年齢確認ダイアログを表示する機能が無視されてたのを修正
   - 画像左上にALT/GIF/APNG/センシティブの表示を追加
+- Fix: リモートクリップ/リモートplay機能のURLで外部サイト警告が出る問題を修正 [#581](https://github.com/yojo-art/cherrypick/pull/581)
 
 ### Server
 
 ## 1.2.0
-Cherrypick 4.13.0
+Cherrypick 4.13.0  
 Misskey 2024.10.1
 
 ### Release Date

--- a/packages/frontend/src/components/MkLink.vue
+++ b/packages/frontend/src/components/MkLink.vue
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 	:is="self ? 'MkA' : 'a'" ref="el" style="word-break: break-all;" class="_link" :[attr]="self ? url_string.substring(local.length) : url_string" :rel="rel ?? 'nofollow noopener'" :target="target"
 	:behavior="props.navigationBehavior"
 	:title="url_string"
-	@click.stop="(ev: MouseEvent) => warningExternalWebsite(ev, props.url)"
+	@click.stop="(ev: MouseEvent) => warningExternalWebsite(ev, url_string)"
 >
 	<slot></slot>
 	<i v-if="target === '_blank' && !hideIcon" class="ti ti-external-link" :class="$style.icon"></i>

--- a/packages/frontend/src/components/MkUrlPreview.vue
+++ b/packages/frontend/src/components/MkUrlPreview.vue
@@ -44,7 +44,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 	</div>
 </template>
 <div v-else>
-	<component :is="self ? 'MkA' : 'a'" :class="[$style.link, { [$style.compact]: compact }]" :[attr]="self ? url_string.substring(local.length) : url_string" rel="nofollow noopener" :target="target" :title="url_string" @click.stop="(ev: MouseEvent) => warningExternalWebsite(ev, url)">
+	<component :is="self ? 'MkA' : 'a'" :class="[$style.link, { [$style.compact]: compact }]" :[attr]="self ? url_string.substring(local.length) : url_string" rel="nofollow noopener" :target="target" :title="url_string" @click.stop="(ev: MouseEvent) => warningExternalWebsite(ev, url_string)">
 		<div v-if="thumbnail && !sensitive" :class="[$style.thumbnail, { [$style.thumbnailBlur]: sensitive }]" :style="defaultStore.state.dataSaver.urlPreview ? '' : `background-image: url('${thumbnail}')`">
 		</div>
 		<article :class="$style.body">

--- a/packages/frontend/src/components/global/MkUrl.vue
+++ b/packages/frontend/src/components/global/MkUrl.vue
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <component
 	:is="self ? 'MkA' : 'a'" ref="el" :class="$style.root" class="_link" :[attr]="self ? url_string.substring(local.length) : url_string" :rel="rel ?? 'nofollow noopener'" :target="target"
 	:behavior="props.navigationBehavior"
-	@click.stop="(ev: MouseEvent) => warningExternalWebsite(ev, props.url)"
+	@click.stop="(ev: MouseEvent) => warningExternalWebsite(ev, url_string)"
 	@contextmenu.stop="() => {}"
 >
 	<template v-if="!self">


### PR DESCRIPTION
## What
リモートのplay/clipをローカルで見る機能はローカルのページが開くにも関わらず誤ったURLで外部リンク警告が出ていた問題を修正する

## Why
条件を満たしたリモートのplay/clipはローカルで利用できる。外部リンク警告は必要無い

## Additional info (optional)

## Checklist
- [ ] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
