### PR TITLE
タイムラインオプションで表示有無選択の選択肢を修正

### DIFF
--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -10,6 +10,7 @@ xxxx-xx-xx
 
 ### Client
 - Fix: ノート詳細画面でリアクション出来ない [#584](https://github.com/yojo-art/cherrypick/pull/584)
+- Fix: タイムラインオプションで表示有無選択の選択肢を修正 [#590](https://github.com/yojo-art/cherrypick/pull/590)
 - Fix: MFMチートシートが表示できない不具合を修正 [#592](https://github.com/yojo-art/cherrypick/pull/592)
 
 ### Server

--- a/packages/frontend/src/pages/timeline.vue
+++ b/packages/frontend/src/pages/timeline.vue
@@ -525,7 +525,7 @@ const headerActions = computed(() => {
 							ref: enableAntennaTimeline,
 						}, {
 							type: 'switch',
-							text: i18n.ts.channel,
+							text: i18n.ts.tags,
 							icon: 'ti ti-hash',
 							ref: enableTagTimeline,
 						});

--- a/packages/frontend/src/pages/timeline.vue
+++ b/packages/frontend/src/pages/timeline.vue
@@ -176,7 +176,7 @@ const enableSocialTimeline = ref(defaultStore.state.enableSocialTimeline);
 const enableGlobalTimeline = ref(defaultStore.state.enableGlobalTimeline);
 const enableListTimeline = ref(defaultStore.state.enableListTimeline);
 const enableAntennaTimeline = ref(defaultStore.state.enableAntennaTimeline);
-const enableChannelTimeline = ref(defaultStore.state.enableChannelTimeline);
+const enableTagTimeline = ref(defaultStore.state.enableTagTimeline);
 
 const collapseRenotes = ref(defaultStore.state.collapseRenotes);
 const collapseReplies = ref(defaultStore.state.collapseReplies);
@@ -234,8 +234,8 @@ watch(enableAntennaTimeline, (x) => {
 	reloadAsk({ reason: i18n.ts.reloadToApplySetting, unison: true });
 });
 
-watch(enableChannelTimeline, (x) => {
-	defaultStore.set('enableChannelTimeline', x);
+watch(enableTagTimeline, (x) => {
+	defaultStore.set('enableTagTimeline', x);
 	reloadAsk({ reason: i18n.ts.reloadToApplySetting, unison: true });
 });
 
@@ -526,8 +526,8 @@ const headerActions = computed(() => {
 						}, {
 							type: 'switch',
 							text: i18n.ts.channel,
-							icon: 'ti ti-device-tv',
-							ref: enableChannelTimeline,
+							icon: 'ti ti-hash',
+							ref: enableTagTimeline,
 						});
 
 						return displayOfTimelineChildMenu;


### PR DESCRIPTION
## What
タイムラインオプションで表示切り替えするタブ選択肢からチャンネルを削除し、タグを追加
![image](https://github.com/user-attachments/assets/5958f7a5-d8c3-4c25-8ad9-86bda7cad682)

## Why
ユーザー設定画面と統一、存在しない項目を修正

## Additional info (optional)

## Checklist
- [ ] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [x] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
