### PR TITLE
Release: 1.2.2

### DIFF
--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -12,6 +12,7 @@ xxxx-xx-xx
 - Fix: ノート詳細画面でリアクション出来ない [#584](https://github.com/yojo-art/cherrypick/pull/584)
 - Fix: タイムラインオプションで表示有無選択の選択肢を修正 [#590](https://github.com/yojo-art/cherrypick/pull/590)
 - Fix: MFMチートシートが表示できない不具合を修正 [#592](https://github.com/yojo-art/cherrypick/pull/592)
+- Fix: 引用や返信のノートすべてに翻訳ボタンが表示される [#598](https://github.com/yojo-art/cherrypick/pull/598)
 
 ### Server
 - Fix:`api/ap/fetch-outbox`でリノートしか取得されないのを修正 [#588](https://github.com/yojo-art/cherrypick/pull/588)

--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -1,3 +1,19 @@
+## 1.2.2
+Cherrypick 4.13.0  
+Misskey 2024.10.1
+
+### Release Date
+xxxx-xx-xx
+
+### General
+-
+
+### Client
+- Fix: ノート詳細画面でリアクション出来ない [#584](https://github.com/yojo-art/cherrypick/pull/584)
+
+### Server
+-
+
 ## 1.2.1
 Cherrypick 4.13.0  
 Misskey 2024.10.1

--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -10,6 +10,7 @@ xxxx-xx-xx
 
 ### Client
 - Fix: ノート詳細画面でリアクション出来ない [#584](https://github.com/yojo-art/cherrypick/pull/584)
+- Fix: タイムラインオプションで表示有無選択の選択肢を修正 [#590](https://github.com/yojo-art/cherrypick/pull/590)
 - Fix: MFMチートシートが表示できない不具合を修正 [#592](https://github.com/yojo-art/cherrypick/pull/592)
 
 ### Server

--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -3,7 +3,7 @@ Cherrypick 4.13.0
 Misskey 2024.10.1
 
 ### Release Date
-xxxx-xx-xx
+2024-12-27
 
 ### General
 -

--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -14,7 +14,7 @@ xxxx-xx-xx
 - Fix: MFMチートシートが表示できない不具合を修正 [#592](https://github.com/yojo-art/cherrypick/pull/592)
 
 ### Server
--
+- Fix:`api/ap/fetch-outbox`でリノートしか取得されないのを修正 [#588](https://github.com/yojo-art/cherrypick/pull/588)
 
 ## 1.2.1
 Cherrypick 4.13.0  

--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -10,6 +10,7 @@ xxxx-xx-xx
 
 ### Client
 - Fix: ノート詳細画面でリアクション出来ない [#584](https://github.com/yojo-art/cherrypick/pull/584)
+- Fix: MFMチートシートが表示できない不具合を修正 [#592](https://github.com/yojo-art/cherrypick/pull/592)
 
 ### Server
 -

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "yojo-art",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"basedMisskeyVersion": "2024.10.1",
 	"basedCherrypickVersion": "4.13.0",
 	"codename": "nasubi",

--- a/packages/backend/src/core/activitypub/models/ApOutboxFetchService.ts
+++ b/packages/backend/src/core/activitypub/models/ApOutboxFetchService.ts
@@ -66,7 +66,6 @@ export class ApOutboxFetchService implements OnModuleInit {
 		this.apLoggerService = this.moduleRef.get('ApLoggerService');
 		this.logger = this.apLoggerService.logger;
 	}
-
 	/**
 	 * outboxから投稿を取得します
 	 */
@@ -85,14 +84,19 @@ export class ApOutboxFetchService implements OnModuleInit {
 		const cache = await this.redisClient.get(`${outboxUrl}--next`);
 		let next: string | IOrderedCollectionPage;
 
-		if (!cache) {
+		if (cache) {
+			next = cache;
+		} else {
 			// Resolve to (Ordered)Collection Object
 			const outbox = await Resolver.resolveOrderedCollection(outboxUrl);
 			if (!outbox.first) throw new IdentifiableError('a723c2df-0250-4091-b5fc-e3a7b36c7b61', 'outbox first page not exist');
 			next = outbox.first;
-		} else next = cache;
+		}
 
-		let created = 0;
+		let current = {
+			created: 0,
+			breaked: false,
+		};
 
 		for (let page = 0; page < pagelimit; page++) {
 			const collection = (typeof(next) === 'string' ? await Resolver.resolveOrderedCollectionPage(next) : next);
@@ -101,10 +105,13 @@ export class ApOutboxFetchService implements OnModuleInit {
 			const activityes = (collection.orderedItems ?? collection.items);
 			if (!activityes) throw new IdentifiableError('2a05bb06-f38c-4854-af6f-7fd5e87c98ee', 'item is unavailable');
 
-			created = await this.fetchObjects(user, activityes, includeAnnounce, created);
-			if (createLimit <= created) break;//次ページ見て一件だけしか取れないのは微妙
-			if (!collection.next) break;
+			do {
+				current = await this.fetchObjects(user, activityes, includeAnnounce, current.created);
+				page++;
+			}
+			while (!current.breaked && page < pagelimit);
 
+			if (!collection.next) break;
 			next = collection.next;
 			await this.redisClient.set(`${outboxUrl}--next`, `${next}`, 'EX', 60 * 15);//15min
 		}
@@ -112,9 +119,12 @@ export class ApOutboxFetchService implements OnModuleInit {
 	}
 
 	@bindThis
-	private async fetchObjects(user: MiRemoteUser, activityes: any[], includeAnnounce:boolean, created: number): Promise<number> {
+	private async fetchObjects(user: MiRemoteUser, activityes: any[], includeAnnounce:boolean, created: number): Promise<{
+		created: number;
+		breaked: boolean;
+	}> {
 		for (const activity of activityes) {
-			if (createLimit < created) return created;
+			if (createLimit < created) return { created: created, breaked: true };
 			try {
 				if (activity.actor !== user.uri) throw new IdentifiableError('bde7c204-5441-4a87-9b7e-f81e8d05788a');
 				if (activity.type === 'Announce' && includeAnnounce) {
@@ -177,7 +187,7 @@ export class ApOutboxFetchService implements OnModuleInit {
 					}
 				} else if (isCreate(activity)) {
 					if (typeof(activity.object) !== 'string') {
-						if (!isNote(activity)) continue;
+						if (!isNote(activity.object)) continue;
 					}
 					const fetch = await this.apNoteService.fetchNote(activity.object);
 					if (fetch) continue;
@@ -190,11 +200,11 @@ export class ApOutboxFetchService implements OnModuleInit {
 				} else {
 					this.logger.error(`fetchError:${activity.id}`);
 					this.logger.error(`${err}`);
-					continue;
 				}
+				continue;
 			}
 			created ++;
 		}
-		return created;
+		return { created: created, breaked: false };
 	}
 }

--- a/packages/cherrypick-js/package.json
+++ b/packages/cherrypick-js/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "cherrypick-js",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"basedMisskeyVersion": "2024.10.1",
 	"basedCherrypickVersion": "4.13.0",
 	"description": "yojo-art SDK for JavaScript",

--- a/packages/frontend-embed/src/boot.ts
+++ b/packages/frontend-embed/src/boot.ts
@@ -23,7 +23,7 @@ import { serverMetadata } from '@/server-metadata.js';
 import { postMessageToParentWindow, setIframeId } from '@/post-message.js';
 import { serverContext } from '@/server-context.js';
 
-console.log('CherryPick Embed');
+console.log('yojo-art Embed');
 
 //#region Embedパラメータの取得・パース
 const params = new URLSearchParams(location.search);

--- a/packages/frontend/src/boot/common.ts
+++ b/packages/frontend/src/boot/common.ts
@@ -27,7 +27,7 @@ import { createMainRouter } from '@/router/definition.js';
 import { popup } from '@/os.js';
 
 export async function common(createVue: () => App<Element>) {
-	console.info(`CherryPick v${version}`);
+	console.info(`yojo-art v${version}`);
 
 	if (_DEV_) {
 		console.warn('Development mode!!!');

--- a/packages/frontend/src/components/MkNoteDetailed.vue
+++ b/packages/frontend/src/components/MkNoteDetailed.vue
@@ -201,7 +201,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 			<button v-if="appearNote.reactionAcceptance !== 'likeOnly' && appearNote.myReaction == null && defaultStore.state.showLikeButtonInNoteFooter" ref="heartReactButton" v-vibrate="defaultStore.state.vibrateSystem ? [30, 50, 50] : []" v-tooltip="i18n.ts.like" :class="$style.noteFooterButton" class="_button" @click="heartReact()">
 				<i class="ti ti-heart"></i>
 			</button>
-			<button v-if="defaultStore.state.showDoReactionButtonInNoteFooter" ref="reactButton" v-vibrate="defaultStore.state.vibrateSystem ? [30, 50, 50] : []" v-tooltip="appearNote.reactionAcceptance === 'likeOnly' && appearNote.myReaction != null ? i18n.ts.unlike : appearNote.myReaction != null ? i18n.ts.editReaction : appearNote.reactionAcceptance === 'likeOnly' ? i18n.ts.like : i18n.ts.doReaction" :class="$style.noteFooterButton" class="_button" @click.stop="toggleReact()">
+			<button v-if="defaultStore.state.showDoReactionButtonInNoteFooter" ref="reactButton" v-vibrate="defaultStore.state.vibrateSystem ? [30, 50, 50] : []" v-tooltip="appearNote.reactionAcceptance === 'likeOnly' && appearNote.myReaction != null ? i18n.ts.unlike : appearNote.myReaction != null ? i18n.ts.editReaction : appearNote.reactionAcceptance === 'likeOnly' ? i18n.ts.like : i18n.ts.doReaction" :class="$style.noteFooterButton" class="_button" @click.stop="react()">
 				<i v-if="appearNote.reactionAcceptance === 'likeOnly' && appearNote.myReaction != null" class="ti ti-heart-filled" style="color: var(--MI_THEME-love);"></i>
 				<i v-else-if="appearNote.myReaction != null" class="ti ti-mood-edit" style="color: var(--MI_THEME-accent);"></i>
 				<i v-else-if="appearNote.reactionAcceptance === 'likeOnly'" class="ti ti-heart"></i>

--- a/packages/frontend/src/pages/admin/index.vue
+++ b/packages/frontend/src/pages/admin/index.vue
@@ -70,7 +70,7 @@ const noInquiryUrl = computed(() => isEmpty(instance.inquiryUrl));
 const thereIsUnresolvedAbuseReport = ref(false);
 const currentPage = computed(() => router.currentRef.value.child);
 const updateAvailable = ref(false);
-const releasesCherryPick = ref(null);
+const releasesYojoArt = ref(null);
 
 misskeyApi('admin/abuse-user-reports', {
 	state: 'unresolved',
@@ -81,11 +81,11 @@ misskeyApi('admin/abuse-user-reports', {
 
 misskeyApi('admin/meta')
 	.then(meta => {
-		return fetch('https://api.github.com/repos/kokonect-link/cherrypick/releases')
+		return fetch('https://api.github.com/repos/yojo-art/cherrypick/releases')
 			.then(res => res.json())
 			.then(cherryPickData => {
-				releasesCherryPick.value = meta.enableReceivePrerelease ? cherryPickData : cherryPickData.filter(x => !x.prerelease);
-				if ((compareVersions(version, releasesCherryPick.value[0].tag_name) < 0) && (compareVersions(meta.skipCherryPickVersion, releasesCherryPick.value[0].tag_name) < 0)) {
+				releasesYojoArt.value = meta.enableReceivePrerelease ? cherryPickData : cherryPickData.filter(x => !x.prerelease);
+				if ((compareVersions(version, releasesYojoArt.value[0].tag_name) < 0) && (compareVersions(meta.skipCherryPickVersion, releasesYojoArt.value[0].tag_name) < 0)) {
 					updateAvailable.value = true;
 				}
 			});

--- a/packages/frontend/src/pages/mfc-cheat-sheet.vue
+++ b/packages/frontend/src/pages/mfc-cheat-sheet.vue
@@ -15,7 +15,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.mentionDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_mention"/>
-						<MkTextarea v-model="preview_mention" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_mention" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.hashtagDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_hashtag"/>
-						<MkTextarea v-model="preview_hashtag" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_hashtag" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -35,7 +35,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.urlDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_url"/>
-						<MkTextarea v-model="preview_url" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_url" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -45,7 +45,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.linkDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_link"/>
-						<MkTextarea v-model="preview_link" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_link" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -55,7 +55,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.emojiDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_emoji"/>
-						<MkTextarea v-model="preview_emoji" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_emoji" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -65,7 +65,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.boldDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_bold"/>
-						<MkTextarea v-model="preview_bold" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_bold" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -75,7 +75,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.smallDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_small"/>
-						<MkTextarea v-model="preview_small" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_small" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -85,7 +85,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.quoteDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_quote"/>
-						<MkTextarea v-model="preview_quote" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_quote" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -95,7 +95,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.centerDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_center"/>
-						<MkTextarea v-model="preview_center" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_center" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -105,7 +105,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.inlineCodeDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_inlineCode"/>
-						<MkTextarea v-model="preview_inlineCode" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_inlineCode" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -115,7 +115,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.blockCodeDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_blockCode"/>
-						<MkTextarea v-model="preview_blockCode" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_blockCode" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -125,7 +125,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.inlineMathDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_inlineMath"/>
-						<MkTextarea v-model="preview_inlineMath" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_inlineMath" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -135,7 +135,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.blockMathDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_blockMath"/>
-						<MkTextarea v-model="preview_blockMath" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_blockMath" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -145,7 +145,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.searchDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_search"/>
-						<MkTextarea v-model="preview_search" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_search" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -155,7 +155,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.flipDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_flip"/>
-						<MkTextarea v-model="preview_flip" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_flip" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -165,7 +165,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.fontDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_font"/>
-						<MkTextarea v-model="preview_font" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_font" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -175,7 +175,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.x2Description }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_x2"/>
-						<MkTextarea v-model="preview_x2" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_x2" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -185,7 +185,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.x3Description }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_x3"/>
-						<MkTextarea v-model="preview_x3" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_x3" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -195,7 +195,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.x4Description }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_x4"/>
-						<MkTextarea v-model="preview_x4" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_x4" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -205,7 +205,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.blurDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_blur"/>
-						<MkTextarea v-model="preview_blur" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_blur" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -215,7 +215,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.jellyDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_jelly"/>
-						<MkTextarea v-model="preview_jelly" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_jelly" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -225,7 +225,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.tadaDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_tada"/>
-						<MkTextarea v-model="preview_tada" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_tada" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -235,7 +235,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.jumpDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_jump"/>
-						<MkTextarea v-model="preview_jump" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_jump" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -245,7 +245,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.bounceDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_bounce"/>
-						<MkTextarea v-model="preview_bounce" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_bounce" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -255,7 +255,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.spinDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_spin"/>
-						<MkTextarea v-model="preview_spin" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_spin" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -265,7 +265,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.shakeDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_shake"/>
-						<MkTextarea v-model="preview_shake" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_shake" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -275,7 +275,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.twitchDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_twitch"/>
-						<MkTextarea v-model="preview_twitch" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_twitch" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -285,7 +285,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.rainbowDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_rainbow"/>
-						<MkTextarea v-model="preview_rainbow" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_rainbow" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -295,7 +295,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.sparkleDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_sparkle"/>
-						<MkTextarea v-model="preview_sparkle" :class="$style.text"><span>MFC {{ i18n.ts.sample }}</span></MkTextarea>
+						<MkTextarea v-model="preview_sparkle" :class="$style.text"><span>MFM {{ i18n.ts.sample }}</span></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -305,7 +305,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.fadeDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_fade"/>
-						<MkTextarea v-model="preview_fade" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_fade" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -315,7 +315,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.rotateDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_rotate"/>
-						<MkTextarea v-model="preview_rotate" :class="$style.text"><span>MFC {{ i18n.ts.sample }}</span></MkTextarea>
+						<MkTextarea v-model="preview_rotate" :class="$style.text"><span>MFM {{ i18n.ts.sample }}</span></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -325,7 +325,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.positionDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_position"/>
-						<MkTextarea v-model="preview_position" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_position" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -335,7 +335,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.scaleDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_scale"/>
-						<MkTextarea v-model="preview_scale" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_scale" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -345,7 +345,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.fgDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_fg"/>
-						<MkTextarea v-model="preview_fg" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_fg" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -355,7 +355,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.bgDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_bg"/>
-						<MkTextarea v-model="preview_bg" :class="$style.text"><template #label>MFC {{ i18n.ts.sample }}</template></MkTextarea>
+						<MkTextarea v-model="preview_bg" :class="$style.text"><template #label>MFM {{ i18n.ts.sample }}</template></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -365,7 +365,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.plainDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_plain"/>
-						<MkTextarea v-model="preview_plain" :class="$style.text"><span>MFC {{ i18n.ts.sample }}</span></MkTextarea>
+						<MkTextarea v-model="preview_plain" :class="$style.text"><span>MFM {{ i18n.ts.sample }}</span></MkTextarea>
 					</div>
 				</div>
 			</div>
@@ -375,15 +375,15 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<p>{{ i18n.ts._mfc.rubyDescription }}</p>
 					<div :class="$style.preview">
 						<Mfm :text="preview_ruby"/>
-						<MkTextarea v-model="preview_ruby" :class="$style.text"><span>MFC {{ i18n.ts.sample }}</span></MkTextarea>
+						<MkTextarea v-model="preview_ruby" :class="$style.text"><span>MFM {{ i18n.ts.sample }}</span></MkTextarea>
 					</div>
 				</div>
 			</div>
 		</div>
 		<div :class="$style.section">
-			<div :class="$style.title">{{ i18n.ts._mfm.border }}</div>
+			<div :class="$style.title">{{ i18n.ts._mfc.border }}</div>
 			<div :class="$style.content">
-				<p>{{ i18n.ts._mfm.borderDescription }}</p>
+				<p>{{ i18n.ts._mfc.borderDescription }}</p>
 				<div :class="$style.preview">
 					<Mfm :text="preview_border"/>
 					<MkTextarea v-model="preview_border" :class="$style.text"><span>MFM {{ i18n.ts.sample }}</span></MkTextarea>

--- a/packages/frontend/src/pages/timeline.vue
+++ b/packages/frontend/src/pages/timeline.vue
@@ -176,7 +176,7 @@ const enableSocialTimeline = ref(defaultStore.state.enableSocialTimeline);
 const enableGlobalTimeline = ref(defaultStore.state.enableGlobalTimeline);
 const enableListTimeline = ref(defaultStore.state.enableListTimeline);
 const enableAntennaTimeline = ref(defaultStore.state.enableAntennaTimeline);
-const enableChannelTimeline = ref(defaultStore.state.enableChannelTimeline);
+const enableTagTimeline = ref(defaultStore.state.enableTagTimeline);
 
 const collapseRenotes = ref(defaultStore.state.collapseRenotes);
 const collapseReplies = ref(defaultStore.state.collapseReplies);
@@ -234,8 +234,8 @@ watch(enableAntennaTimeline, (x) => {
 	reloadAsk({ reason: i18n.ts.reloadToApplySetting, unison: true });
 });
 
-watch(enableChannelTimeline, (x) => {
-	defaultStore.set('enableChannelTimeline', x);
+watch(enableTagTimeline, (x) => {
+	defaultStore.set('enableTagTimeline', x);
 	reloadAsk({ reason: i18n.ts.reloadToApplySetting, unison: true });
 });
 
@@ -525,9 +525,9 @@ const headerActions = computed(() => {
 							ref: enableAntennaTimeline,
 						}, {
 							type: 'switch',
-							text: i18n.ts.channel,
-							icon: 'ti ti-device-tv',
-							ref: enableChannelTimeline,
+							text: i18n.ts.tags,
+							icon: 'ti ti-hash',
+							ref: enableTagTimeline,
 						});
 
 						return displayOfTimelineChildMenu;

--- a/packages/frontend/src/ui/_common_/navbar-for-mobile.vue
+++ b/packages/frontend/src/ui/_common_/navbar-for-mobile.vue
@@ -74,7 +74,7 @@ const otherMenuItemIndicated = computed(() => {
 	return false;
 });
 const controlPanelIndicated = ref(false);
-const releasesCherryPick = ref(null);
+const releasesYojoArt = ref(null);
 
 if ($i.isAdmin ?? $i.isModerator) {
 	misskeyApi('admin/abuse-user-reports', {
@@ -86,11 +86,11 @@ if ($i.isAdmin ?? $i.isModerator) {
 
 	misskeyApi('admin/meta')
 		.then(meta => {
-			return fetch('https://api.github.com/repos/kokonect-link/cherrypick/releases')
+			return fetch('https://api.github.com/repos/yojo-art/cherrypick/releases')
 				.then(res => res.json())
 				.then(cherryPickData => {
-					releasesCherryPick.value = meta.enableReceivePrerelease ? cherryPickData : cherryPickData.filter(x => !x.prerelease);
-					if ((compareVersions(version, releasesCherryPick.value[0].tag_name) < 0) && (compareVersions(meta.skipCherryPickVersion, releasesCherryPick.value[0].tag_name) < 0)) {
+					releasesYojoArt.value = meta.enableReceivePrerelease ? cherryPickData : cherryPickData.filter(x => !x.prerelease);
+					if ((compareVersions(version, releasesYojoArt.value[0].tag_name) < 0) && (compareVersions(meta.skipCherryPickVersion, releasesYojoArt.value[0].tag_name) < 0)) {
 						controlPanelIndicated.value = true;
 					}
 				});

--- a/packages/frontend/src/ui/_common_/navbar.vue
+++ b/packages/frontend/src/ui/_common_/navbar.vue
@@ -86,7 +86,7 @@ const otherMenuItemIndicated = computed(() => {
 	return false;
 });
 const controlPanelIndicated = ref(false);
-const releasesCherryPick = ref(null);
+const releasesYojoArt = ref(null);
 
 if ($i.isAdmin ?? $i.isModerator) {
 	misskeyApi('admin/abuse-user-reports', {
@@ -98,11 +98,11 @@ if ($i.isAdmin ?? $i.isModerator) {
 
 	misskeyApi('admin/meta')
 		.then(meta => {
-			return fetch('https://api.github.com/repos/kokonect-link/cherrypick/releases')
+			return fetch('https://api.github.com/repos/yojo-art/cherrypick/releases')
 				.then(res => res.json())
 				.then(cherryPickData => {
-					releasesCherryPick.value = meta.enableReceivePrerelease ? cherryPickData : cherryPickData.filter(x => !x.prerelease);
-					if ((compareVersions(version, releasesCherryPick.value[0].tag_name) < 0) && (compareVersions(meta.skipCherryPickVersion, releasesCherryPick.value[0].tag_name) < 0)) {
+					releasesYojoArt.value = meta.enableReceivePrerelease ? cherryPickData : cherryPickData.filter(x => !x.prerelease);
+					if ((compareVersions(version, releasesYojoArt.value[0].tag_name) < 0) && (compareVersions(meta.skipCherryPickVersion, releasesYojoArt.value[0].tag_name) < 0)) {
 						controlPanelIndicated.value = true;
 					}
 				});

--- a/packages/frontend/src/ui/classic.header.vue
+++ b/packages/frontend/src/ui/classic.header.vue
@@ -74,7 +74,7 @@ const otherNavItemIndicated = computed<boolean>(() => {
 });
 
 const controlPanelIndicated = ref(false);
-const releasesCherryPick = ref(null);
+const releasesYojoArt = ref(null);
 
 if ($i.isAdmin ?? $i.isModerator) {
 	misskeyApi('admin/abuse-user-reports', {
@@ -86,11 +86,11 @@ if ($i.isAdmin ?? $i.isModerator) {
 
 	misskeyApi('admin/meta')
 		.then(meta => {
-			return fetch('https://api.github.com/repos/kokonect-link/cherrypick/releases')
+			return fetch('https://api.github.com/repos/yojo-art/cherrypick/releases')
 				.then(res => res.json())
 				.then(cherryPickData => {
-					releasesCherryPick.value = meta.enableReceivePrerelease ? cherryPickData : cherryPickData.filter(x => !x.prerelease);
-					if ((compareVersions(version, releasesCherryPick.value[0].tag_name) < 0) && (compareVersions(meta.skipCherryPickVersion, releasesCherryPick.value[0].tag_name) < 0)) {
+					releasesYojoArt.value = meta.enableReceivePrerelease ? cherryPickData : cherryPickData.filter(x => !x.prerelease);
+					if ((compareVersions(version, releasesYojoArt.value[0].tag_name) < 0) && (compareVersions(meta.skipCherryPickVersion, releasesYojoArt.value[0].tag_name) < 0)) {
 						controlPanelIndicated.value = true;
 					}
 				});

--- a/packages/frontend/src/ui/classic.sidebar.vue
+++ b/packages/frontend/src/ui/classic.sidebar.vue
@@ -83,7 +83,7 @@ const el = shallowRef<HTMLElement>();
 const iconOnly = ref(false);
 const settingsWindowed = ref(false);
 const controlPanelIndicated = ref(false);
-const releasesCherryPick = ref(null);
+const releasesYojoArt = ref(null);
 
 if ($i.isAdmin ?? $i.isModerator) {
 	misskeyApi('admin/abuse-user-reports', {
@@ -95,11 +95,11 @@ if ($i.isAdmin ?? $i.isModerator) {
 
 	misskeyApi('admin/meta')
 		.then(meta => {
-			return fetch('https://api.github.com/repos/kokonect-link/cherrypick/releases')
+			return fetch('https://api.github.com/repos/yojo-art/cherrypick/releases')
 				.then(res => res.json())
 				.then(cherryPickData => {
-					releasesCherryPick.value = meta.enableReceivePrerelease ? cherryPickData : cherryPickData.filter(x => !x.prerelease);
-					if ((compareVersions(version, releasesCherryPick.value[0].tag_name) < 0) && (compareVersions(meta.skipCherryPickVersion, releasesCherryPick.value[0].tag_name) < 0)) {
+					releasesYojoArt.value = meta.enableReceivePrerelease ? cherryPickData : cherryPickData.filter(x => !x.prerelease);
+					if ((compareVersions(version, releasesYojoArt.value[0].tag_name) < 0) && (compareVersions(meta.skipCherryPickVersion, releasesYojoArt.value[0].tag_name) < 0)) {
 						controlPanelIndicated.value = true;
 					}
 				});

--- a/packages/frontend/src/ui/friendly/navbar-for-mobile.vue
+++ b/packages/frontend/src/ui/friendly/navbar-for-mobile.vue
@@ -76,7 +76,7 @@ const otherMenuItemIndicated = computed(() => {
 	return false;
 });
 const controlPanelIndicated = ref(false);
-const releasesCherryPick = ref(null);
+const releasesYojoArt = ref(null);
 
 if ($i.isAdmin ?? $i.isModerator) {
 	misskeyApi('admin/abuse-user-reports', {
@@ -88,11 +88,11 @@ if ($i.isAdmin ?? $i.isModerator) {
 
 	misskeyApi('admin/meta')
 		.then(meta => {
-			return fetch('https://api.github.com/repos/kokonect-link/cherrypick/releases')
+			return fetch('https://api.github.com/repos/yojo-art/cherrypick/releases')
 				.then(res => res.json())
 				.then(cherryPickData => {
-					releasesCherryPick.value = meta.enableReceivePrerelease ? cherryPickData : cherryPickData.filter(x => !x.prerelease);
-					if ((compareVersions(version, releasesCherryPick.value[0].tag_name) < 0) && (compareVersions(meta.skipCherryPickVersion, releasesCherryPick.value[0].tag_name) < 0)) {
+					releasesYojoArt.value = meta.enableReceivePrerelease ? cherryPickData : cherryPickData.filter(x => !x.prerelease);
+					if ((compareVersions(version, releasesYojoArt.value[0].tag_name) < 0) && (compareVersions(meta.skipCherryPickVersion, releasesYojoArt.value[0].tag_name) < 0)) {
 						controlPanelIndicated.value = true;
 					}
 				});

--- a/packages/frontend/src/ui/friendly/navbar.vue
+++ b/packages/frontend/src/ui/friendly/navbar.vue
@@ -93,7 +93,7 @@ const otherMenuItemIndicated = computed(() => {
 	return false;
 });
 const controlPanelIndicated = ref(false);
-const releasesCherryPick = ref(null);
+const releasesYojoArt = ref(null);
 
 if ($i.isAdmin ?? $i.isModerator) {
 	misskeyApi('admin/abuse-user-reports', {
@@ -105,11 +105,11 @@ if ($i.isAdmin ?? $i.isModerator) {
 
 	misskeyApi('admin/meta')
 		.then(meta => {
-			return fetch('https://api.github.com/repos/kokonect-link/cherrypick/releases')
+			return fetch('https://api.github.com/repos/yojo-art/cherrypick/releases')
 				.then(res => res.json())
 				.then(cherryPickData => {
-					releasesCherryPick.value = meta.enableReceivePrerelease ? cherryPickData : cherryPickData.filter(x => !x.prerelease);
-					if ((compareVersions(version, releasesCherryPick.value[0].tag_name) < 0) && (compareVersions(meta.skipCherryPickVersion, releasesCherryPick.value[0].tag_name) < 0)) {
+					releasesYojoArt.value = meta.enableReceivePrerelease ? cherryPickData : cherryPickData.filter(x => !x.prerelease);
+					if ((compareVersions(version, releasesYojoArt.value[0].tag_name) < 0) && (compareVersions(meta.skipCherryPickVersion, releasesYojoArt.value[0].tag_name) < 0)) {
 						controlPanelIndicated.value = true;
 					}
 				});

--- a/packages/sw/src/scripts/create-notification.ts
+++ b/packages/sw/src/scripts/create-notification.ts
@@ -323,7 +323,7 @@ export async function createEmptyNotification(): Promise<void> {
 		await globalThis.registration.showNotification(
 			(new URL(origin)).host,
 			{
-				body: `CherryPick v${_VERSION_}`,
+				body: `yojo-art v${_VERSION_}`,
 				silent: true,
 				badge: iconUrl('null'),
 				tag: 'read_notification',


### PR DESCRIPTION
## 1.2.2
Cherrypick 4.13.0  
Misskey 2024.10.1

### Release Date
2024-12-27

### General
-

### Client
- Fix: ノート詳細画面でリアクション出来ない [#584](https://github.com/yojo-art/cherrypick/pull/584)
- Fix: タイムラインオプションで表示有無選択の選択肢を修正 [#590](https://github.com/yojo-art/cherrypick/pull/590)
- Fix: MFMチートシートが表示できない不具合を修正 [#592](https://github.com/yojo-art/cherrypick/pull/592)
- Fix: 引用や返信のノートすべてに翻訳ボタンが表示される [#598](https://github.com/yojo-art/cherrypick/pull/598)

### Server
- Fix:`api/ap/fetch-outbox`でリノートしか取得されないのを修正 [#588](https://github.com/yojo-art/cherrypick/pull/588)
