### PR TITLE
ローカルのリアクションに相乗りする時の確認ダイアログを修正

### DIFF
--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -11,6 +11,7 @@ Misskey 2025.2.0
 - Fix: 返信用投稿フォームを通常投稿フォームと統一 [#676](https://github.com/yojo-art/cherrypick/pull/676)
 - Fix: 右クリックメニューにスクロールバーがある時、派生メニューで考慮されない不具合の修正 [#680](https://github.com/yojo-art/cherrypick/pull/680)
   - 問題が起きていた変更部分を1.3.1時点に戻しました
+- Fix: ローカルのリアクションに相乗りする時の確認ダイアログを修正 [#682](https://github.com/yojo-art/cherrypick/pull/682)
 
 ### Server
 

--- a/packages/frontend/src/scripts/check-reaction-create.ts
+++ b/packages/frontend/src/scripts/check-reaction-create.ts
@@ -12,7 +12,7 @@ export async function notesReactionsCreate(data:{ noteId: string, reaction: stri
 	if (defaultStore.state.checkReactionDialog === true ) {
 		const { canceled } = await os.confirm({
 			type: 'warning',
-			title: i18n.tsx._reactionConfirm.title({ emoji: data.reaction }),
+			title: i18n.tsx._reactionConfirm.title({ emoji: data.reaction.replace('@.', '') }),
 			caption: i18n.ts._reactionConfirm.caption,
 			okText: i18n.ts._reactionConfirm.confirm,
 			cancelText: i18n.ts.cancel,


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
`reaction.replace('@.', '')`

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Fix: #679 

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [ ] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
