### PR TITLE
Release: 1.4.1

### DIFF
--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -12,6 +12,7 @@ Misskey 2025.2.0
 - Fix: 右クリックメニューにスクロールバーがある時、派生メニューで考慮されない不具合の修正 [#680](https://github.com/yojo-art/cherrypick/pull/680)
   - 問題が起きていた変更部分を1.3.1時点に戻しました
 - Fix: ローカルのリアクションに相乗りする時の確認ダイアログを修正 [#682](https://github.com/yojo-art/cherrypick/pull/682)
+- Fix: ノート内絵文字を付ける機能でローカルに無い絵文字は機能を非表示に [#683](https://github.com/yojo-art/cherrypick/pull/683)
 
 ### Server
 

--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -7,7 +7,8 @@ Misskey 2025.2.0
 ### General
 
 ### Client
-- Fix:ノート詳細から前後TL見る機能の修正 [#677](https://github.com/yojo-art/cherrypick/pull/677)
+- Fix: ノート詳細から前後TL見る機能の修正 [#677](https://github.com/yojo-art/cherrypick/pull/677)
+- Fix: 返信用投稿フォームを通常投稿フォームと統一 [#676](https://github.com/yojo-art/cherrypick/pull/676)
 
 ### Server
 

--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -1,3 +1,16 @@
+## 1.4.1
+Cherrypick 4.15.0  
+Misskey 2025.2.0
+
+### Release Date
+
+### General
+
+### Client
+- Fix:ノート詳細から前後TL見る機能の修正 [#677](https://github.com/yojo-art/cherrypick/pull/677)
+
+### Server
+
 ## 1.4.0
 Cherrypick 4.15.0  
 Misskey 2025.2.0

--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -9,6 +9,8 @@ Misskey 2025.2.0
 ### Client
 - Fix: ノート詳細から前後TL見る機能の修正 [#677](https://github.com/yojo-art/cherrypick/pull/677)
 - Fix: 返信用投稿フォームを通常投稿フォームと統一 [#676](https://github.com/yojo-art/cherrypick/pull/676)
+- Fix: 右クリックメニューにスクロールバーがある時、派生メニューで考慮されない不具合の修正 [#680](https://github.com/yojo-art/cherrypick/pull/680)
+  - 問題が起きていた変更部分を1.3.1時点に戻しました
 
 ### Server
 

--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -3,6 +3,7 @@ Cherrypick 4.15.0
 Misskey 2025.2.0
 
 ### Release Date
+2025-03-29
 
 ### General
 

--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -13,6 +13,7 @@ Misskey 2025.2.0
   - 問題が起きていた変更部分を1.3.1時点に戻しました
 - Fix: ローカルのリアクションに相乗りする時の確認ダイアログを修正 [#682](https://github.com/yojo-art/cherrypick/pull/682)
 - Fix: ノート内絵文字を付ける機能でローカルに無い絵文字は機能を非表示に [#683](https://github.com/yojo-art/cherrypick/pull/683)
+- Fix: ノート詳細リアクションタブ内のリアクションボタンの画像部分にクリック判定が無い問題を修正 [#684](https://github.com/yojo-art/cherrypick/pull/684)
 
 ### Server
 

--- a/CHANGELOG_YOJO.md
+++ b/CHANGELOG_YOJO.md
@@ -11,6 +11,7 @@ Misskey 2025.2.0
 - Fix: 返信用投稿フォームを通常投稿フォームと統一 [#676](https://github.com/yojo-art/cherrypick/pull/676)
 - Fix: 右クリックメニューにスクロールバーがある時、派生メニューで考慮されない不具合の修正 [#680](https://github.com/yojo-art/cherrypick/pull/680)
   - 問題が起きていた変更部分を1.3.1時点に戻しました
+- Fix: ローカルのリアクションに相乗りする時の確認ダイアログを修正 [#682](https://github.com/yojo-art/cherrypick/pull/682)
 
 ### Server
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "yojo-art",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"basedCherrypickVersion": "4.15.1",
 	"basedMisskeyVersion": "2025.2.1",
 	"codename": "nasubi",

--- a/packages/cherrypick-js/package.json
+++ b/packages/cherrypick-js/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "cherrypick-js",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"basedCherrypickVersion": "4.15.1",
 	"basedMisskeyVersion": "2025.2.1",
 	"description": "yojo-art SDK for JavaScript",

--- a/packages/frontend/src/components/MkMenu.vue
+++ b/packages/frontend/src/components/MkMenu.vue
@@ -15,7 +15,10 @@ SPDX-License-Identifier: AGPL-3.0-only
 	@focusin.passive.stop="() => {}"
 >
 	<div
+		ref="itemsEl"
+		v-hotkey="keymap"
 		v-vibrate="defaultStore.state.vibrateSystem ? 5 : []"
+		tabindex="0"
 		class="_shadow"
 		:class="[
 			$style.menu,
@@ -31,156 +34,147 @@ SPDX-License-Identifier: AGPL-3.0-only
 		@keydown.stop="() => {}"
 		@contextmenu.self.prevent="() => {}"
 	>
-		<slot name="header"></slot>
-		<div
-			ref="itemsEl"
-			v-hotkey="keymap"
-			tabindex="0"
-			:class="$style.menuItems"
-		>
-			<template v-for="item in (items2 ?? [])">
-				<div v-if="item.type === 'divider'" role="separator" tabindex="-1" :class="$style.divider"></div>
-				<span v-else-if="item.type === 'label'" role="menuitem" tabindex="-1" :class="[$style.label, $style.item]">
-					<span style="opacity: 0.7;">{{ item.text }}</span>
-				</span>
-				<span v-else-if="item.type === 'pending'" role="menuitem" tabindex="0" :class="[$style.pending, $style.item]">
-					<span><MkEllipsis/></span>
-				</span>
-				<MkA
-					v-else-if="item.type === 'link'"
-					role="menuitem"
-					tabindex="0"
-					:class="['_button', $style.item]"
-					:to="item.to"
-					@click.passive="close(true)"
-					@mouseenter.passive="onItemMouseEnter"
-					@mouseleave.passive="onItemMouseLeave"
-				>
-					<i v-if="item.icon" class="ti-fw" :class="[$style.icon, item.icon]"></i>
-					<MkAvatar v-if="item.avatar" :user="item.avatar" :class="$style.avatar"/>
-					<div :class="$style.item_content">
-						<span :class="$style.item_content_text">{{ item.text }}</span>
-						<span v-if="item.indicate" :class="$style.indicator" class="_blink"><i class="_indicatorCircle"></i></span>
-					</div>
-				</MkA>
-				<a
-					v-else-if="item.type === 'a'"
-					role="menuitem"
-					tabindex="0"
-					:class="['_button', $style.item]"
-					:href="item.href"
-					:target="item.target"
-					:rel="item.target === '_blank' ? 'noopener noreferrer' : undefined"
-					:download="item.download"
-					@click.passive="close(true)"
-					@mouseenter.passive="onItemMouseEnter"
-					@mouseleave.passive="onItemMouseLeave"
-				>
-					<i v-if="item.icon" class="ti-fw" :class="[$style.icon, item.icon]"></i>
-					<div :class="$style.item_content">
-						<span :class="$style.item_content_text">{{ item.text }}</span>
-						<span v-if="item.indicate" :class="$style.indicator" class="_blink"><i class="_indicatorCircle"></i></span>
-					</div>
-				</a>
-				<button
-					v-else-if="item.type === 'user'"
-					role="menuitem"
-					tabindex="0"
-					:class="['_button', $style.item, { [$style.active]: item.active }]"
-					@click.prevent="item.active ? close(false) : clicked(item.action, $event)"
-					@mouseenter.passive="onItemMouseEnter"
-					@mouseleave.passive="onItemMouseLeave"
-				>
-					<MkAvatar :user="item.user" :class="$style.avatar"/><MkUserName :user="item.user"/>
-					<div v-if="item.indicate" :class="$style.item_content">
-						<span :class="$style.indicator" class="_blink"><i class="_indicatorCircle"></i></span>
-					</div>
-				</button>
-				<button
-					v-else-if="item.type === 'switch'"
-					role="menuitemcheckbox"
-					tabindex="0"
-					:class="['_button', $style.item]"
-					:disabled="unref(item.disabled)"
-					@click.prevent="switchItem(item)"
-					@mouseenter.passive="onItemMouseEnter"
-					@mouseleave.passive="onItemMouseLeave"
-				>
-					<i v-if="item.icon" class="ti-fw" :class="[$style.icon, item.icon]"></i>
-					<MkSwitchButton v-else :class="$style.switchButton" :checked="item.ref" :disabled="item.disabled" @toggle="switchItem(item)"/>
-					<div :class="$style.item_content">
-						<span :class="[$style.item_content_text, { [$style.switchText]: !item.icon }]">{{ item.text }}</span>
-						<MkSwitchButton v-if="item.icon" :class="[$style.switchButton, $style.caret]" :checked="item.ref" :disabled="item.disabled" @toggle="switchItem(item)"/>
-					</div>
-				</button>
-				<button
-					v-else-if="item.type === 'radio'"
-					role="menuitem"
-					tabindex="0"
-					:class="['_button', $style.item, $style.parent, { [$style.active]: childShowingItem === item }]"
-					:disabled="unref(item.disabled)"
-					@mouseenter.prevent="preferClick ? null : showRadioOptions(item, $event)"
-					@keydown.enter.prevent="preferClick ? null : showRadioOptions(item, $event)"
-					@click.prevent="!preferClick ? null : showRadioOptions(item, $event)"
-				>
-					<i v-if="item.icon" class="ti-fw" :class="[$style.icon, item.icon]" style="pointer-events: none;"></i>
-					<div :class="$style.item_content">
-						<span :class="$style.item_content_text" style="pointer-events: none;">{{ item.text }}</span>
-						<span :class="$style.caret" style="pointer-events: none;"><i class="ti ti-chevron-right ti-fw"></i></span>
-					</div>
-				</button>
-				<button
-					v-else-if="item.type === 'radioOption'"
-					role="menuitemradio"
-					tabindex="0"
-					:class="['_button', $style.item, $style.radio, { [$style.active]: unref(item.active) }]"
-					@click.prevent="unref(item.active) ? null : clicked(item.action, $event, false)"
-					@mouseenter.passive="onItemMouseEnter"
-					@mouseleave.passive="onItemMouseLeave"
-				>
-					<div :class="$style.icon">
-						<span :class="[$style.radioIcon, { [$style.radioChecked]: unref(item.active) }]"></span>
-					</div>
-					<div :class="$style.item_content">
-						<span :class="$style.item_content_text">{{ item.text }}</span>
-					</div>
-				</button>
-				<button
-					v-else-if="item.type === 'parent'"
-					role="menuitem"
-					tabindex="0"
-					:class="['_button', $style.item, $style.parent, { [$style.active]: childShowingItem === item }]"
-					@mouseenter.prevent="preferClick ? null : showChildren(item, $event)"
-					@keydown.enter.prevent="preferClick ? null : showChildren(item, $event)"
-					@click.prevent="!preferClick ? null : showChildren(item, $event)"
-				>
-					<i v-if="item.icon" class="ti-fw" :class="[$style.icon, item.icon]" style="pointer-events: none;"></i>
-					<div :class="$style.item_content">
-						<span :class="$style.item_content_text" style="pointer-events: none;">{{ item.text }}</span>
-						<span :class="$style.caret" style="pointer-events: none;"><i class="ti ti-chevron-right ti-fw"></i></span>
-					</div>
-				</button>
-				<button
-					v-else role="menuitem"
-					tabindex="0"
-					:class="['_button', $style.item, { [$style.danger]: item.danger, [$style.active]: unref(item.active) }]"
-					@click.prevent="unref(item.active) ? close(false) : clicked(item.action, $event)"
-					@mouseenter.passive="onItemMouseEnter"
-					@mouseleave.passive="onItemMouseLeave"
-				>
-					<i v-if="item.icon" class="ti-fw" :class="[$style.icon, item.icon]"></i>
-					<MkAvatar v-if="item.avatar" :user="item.avatar" :class="$style.avatar"/>
-					<div :class="$style.item_content">
-						<span :class="$style.item_content_text">{{ item.text }}</span>
-						<span v-if="item.indicate" :class="$style.indicator" class="_blink"><i class="_indicatorCircle"></i></span>
-					</div>
-				</button>
-			</template>
-			<span v-if="items2 == null || items2.length === 0" tabindex="-1" :class="[$style.none, $style.item]">
-				<span>{{ i18n.ts.none }}</span>
+		<template v-for="item in (items2 ?? [])">
+			<div v-if="item.type === 'divider'" role="separator" tabindex="-1" :class="$style.divider"></div>
+			<span v-else-if="item.type === 'label'" role="menuitem" tabindex="-1" :class="[$style.label, $style.item]">
+				<span style="opacity: 0.7;">{{ item.text }}</span>
 			</span>
-		</div>
-		<slot name="footer"></slot>
+			<span v-else-if="item.type === 'pending'" role="menuitem" tabindex="0" :class="[$style.pending, $style.item]">
+				<span><MkEllipsis/></span>
+			</span>
+			<MkA
+				v-else-if="item.type === 'link'"
+				role="menuitem"
+				tabindex="0"
+				:class="['_button', $style.item]"
+				:to="item.to"
+				@click.passive="close(true)"
+				@mouseenter.passive="onItemMouseEnter"
+				@mouseleave.passive="onItemMouseLeave"
+			>
+				<i v-if="item.icon" class="ti-fw" :class="[$style.icon, item.icon]"></i>
+				<MkAvatar v-if="item.avatar" :user="item.avatar" :class="$style.avatar"/>
+				<div :class="$style.item_content">
+					<span :class="$style.item_content_text">{{ item.text }}</span>
+					<span v-if="item.indicate" :class="$style.indicator" class="_blink"><i class="_indicatorCircle"></i></span>
+				</div>
+			</MkA>
+			<a
+				v-else-if="item.type === 'a'"
+				role="menuitem"
+				tabindex="0"
+				:class="['_button', $style.item]"
+				:href="item.href"
+				:target="item.target"
+				:rel="item.target === '_blank' ? 'noopener noreferrer' : undefined"
+				:download="item.download"
+				@click.passive="close(true)"
+				@mouseenter.passive="onItemMouseEnter"
+				@mouseleave.passive="onItemMouseLeave"
+			>
+				<i v-if="item.icon" class="ti-fw" :class="[$style.icon, item.icon]"></i>
+				<div :class="$style.item_content">
+					<span :class="$style.item_content_text">{{ item.text }}</span>
+					<span v-if="item.indicate" :class="$style.indicator" class="_blink"><i class="_indicatorCircle"></i></span>
+				</div>
+			</a>
+			<button
+				v-else-if="item.type === 'user'"
+				role="menuitem"
+				tabindex="0"
+				:class="['_button', $style.item, { [$style.active]: item.active }]"
+				@click.prevent="item.active ? close(false) : clicked(item.action, $event)"
+				@mouseenter.passive="onItemMouseEnter"
+				@mouseleave.passive="onItemMouseLeave"
+			>
+				<MkAvatar :user="item.user" :class="$style.avatar"/><MkUserName :user="item.user"/>
+				<div v-if="item.indicate" :class="$style.item_content">
+					<span :class="$style.indicator" class="_blink"><i class="_indicatorCircle"></i></span>
+				</div>
+			</button>
+			<button
+				v-else-if="item.type === 'switch'"
+				role="menuitemcheckbox"
+				tabindex="0"
+				:class="['_button', $style.item]"
+				:disabled="unref(item.disabled)"
+				@click.prevent="switchItem(item)"
+				@mouseenter.passive="onItemMouseEnter"
+				@mouseleave.passive="onItemMouseLeave"
+			>
+				<i v-if="item.icon" class="ti-fw" :class="[$style.icon, item.icon]"></i>
+				<MkSwitchButton v-else :class="$style.switchButton" :checked="item.ref" :disabled="item.disabled" @toggle="switchItem(item)"/>
+				<div :class="$style.item_content">
+					<span :class="[$style.item_content_text, { [$style.switchText]: !item.icon }]">{{ item.text }}</span>
+					<MkSwitchButton v-if="item.icon" :class="[$style.switchButton, $style.caret]" :checked="item.ref" :disabled="item.disabled" @toggle="switchItem(item)"/>
+				</div>
+			</button>
+			<button
+				v-else-if="item.type === 'radio'"
+				role="menuitem"
+				tabindex="0"
+				:class="['_button', $style.item, $style.parent, { [$style.active]: childShowingItem === item }]"
+				:disabled="unref(item.disabled)"
+				@mouseenter.prevent="preferClick ? null : showRadioOptions(item, $event)"
+				@keydown.enter.prevent="preferClick ? null : showRadioOptions(item, $event)"
+				@click.prevent="!preferClick ? null : showRadioOptions(item, $event)"
+			>
+				<i v-if="item.icon" class="ti-fw" :class="[$style.icon, item.icon]" style="pointer-events: none;"></i>
+				<div :class="$style.item_content">
+					<span :class="$style.item_content_text" style="pointer-events: none;">{{ item.text }}</span>
+					<span :class="$style.caret" style="pointer-events: none;"><i class="ti ti-chevron-right ti-fw"></i></span>
+				</div>
+			</button>
+			<button
+				v-else-if="item.type === 'radioOption'"
+				role="menuitemradio"
+				tabindex="0"
+				:class="['_button', $style.item, $style.radio, { [$style.active]: unref(item.active) }]"
+				@click.prevent="unref(item.active) ? null : clicked(item.action, $event, false)"
+				@mouseenter.passive="onItemMouseEnter"
+				@mouseleave.passive="onItemMouseLeave"
+			>
+				<div :class="$style.icon">
+					<span :class="[$style.radioIcon, { [$style.radioChecked]: unref(item.active) }]"></span>
+				</div>
+				<div :class="$style.item_content">
+					<span :class="$style.item_content_text">{{ item.text }}</span>
+				</div>
+			</button>
+			<button
+				v-else-if="item.type === 'parent'"
+				role="menuitem"
+				tabindex="0"
+				:class="['_button', $style.item, $style.parent, { [$style.active]: childShowingItem === item }]"
+				@mouseenter.prevent="preferClick ? null : showChildren(item, $event)"
+				@keydown.enter.prevent="preferClick ? null : showChildren(item, $event)"
+				@click.prevent="!preferClick ? null : showChildren(item, $event)"
+			>
+				<i v-if="item.icon" class="ti-fw" :class="[$style.icon, item.icon]" style="pointer-events: none;"></i>
+				<div :class="$style.item_content">
+					<span :class="$style.item_content_text" style="pointer-events: none;">{{ item.text }}</span>
+					<span :class="$style.caret" style="pointer-events: none;"><i class="ti ti-chevron-right ti-fw"></i></span>
+				</div>
+			</button>
+			<button
+				v-else role="menuitem"
+				tabindex="0"
+				:class="['_button', $style.item, { [$style.danger]: item.danger, [$style.active]: unref(item.active) }]"
+				@click.prevent="unref(item.active) ? close(false) : clicked(item.action, $event)"
+				@mouseenter.passive="onItemMouseEnter"
+				@mouseleave.passive="onItemMouseLeave"
+			>
+				<i v-if="item.icon" class="ti-fw" :class="[$style.icon, item.icon]"></i>
+				<MkAvatar v-if="item.avatar" :user="item.avatar" :class="$style.avatar"/>
+				<div :class="$style.item_content">
+					<span :class="$style.item_content_text">{{ item.text }}</span>
+					<span v-if="item.indicate" :class="$style.indicator" class="_blink"><i class="_indicatorCircle"></i></span>
+				</div>
+			</button>
+		</template>
+		<span v-if="items2 == null || items2.length === 0" tabindex="-1" :class="[$style.none, $style.item]">
+			<span>{{ i18n.ts.none }}</span>
+		</span>
 	</div>
 	<div v-if="childMenu">
 		<XChild ref="child" :items="childMenu" :targetElement="childTarget!" :rootElement="itemsEl!" @actioned="childActioned" @closed="closeChild"/>
@@ -439,40 +433,38 @@ onBeforeUnmount(() => {
 });
 </script>
 
-<style lang="scss" module>
-.root {
-	&.center {
-		> .menu {
-			.item {
-				text-align: center;
+	<style lang="scss" module>
+	.root {
+		&.center {
+			> .menu {
+				> .item {
+					text-align: center;
+				}
 			}
 		}
-	}
 
-	&.big:not(.asDrawer) {
-		> .menu {
-			min-width: 230px;
+		&.big:not(.asDrawer) {
+			> .menu {
+				min-width: 230px;
 
-			.item {
-				padding: 6px 20px;
-				font-size: 0.95em;
-				line-height: 24px;
+				> .item {
+					padding: 6px 20px;
+					font-size: 0.95em;
+					line-height: 24px;
+				}
 			}
 		}
-	}
 
-	&.asDrawer {
-		max-width: 600px;
-		margin: auto;
+		&.asDrawer {
+			max-width: 600px;
+			margin: auto;
 
-		> .menu {
-			width: 100%;
-			border-radius: 24px;
-			border-bottom-right-radius: 0;
-			border-bottom-left-radius: 0;
-
-			> .menuItems {
+			> .menu {
 				padding: 12px 0 max(env(safe-area-inset-bottom, 0px), 12px) 0;
+				width: 100%;
+				border-radius: 24px;
+				border-bottom-right-radius: 0;
+				border-bottom-left-radius: 0;
 
 				> .item {
 					font-size: 1em;
@@ -495,203 +487,198 @@ onBeforeUnmount(() => {
 			}
 		}
 	}
-}
 
-.menu {
-	box-sizing: border-box;
-	max-width: 100vw;
-	min-width: 200px;
-	overflow: auto;
-	overscroll-behavior: contain;
+	.menu {
+		padding: 8px 0;
+		box-sizing: border-box;
+		max-width: 100vw;
+		min-width: 200px;
+		overflow: auto;
+		overscroll-behavior: contain;
 
-	&:focus-visible {
-		outline: none;
-	}
-}
-
-.menuItems {
-	padding: 8px 0;
-	box-sizing: border-box;
-}
-
-.item {
-	display: flex;
-	align-items: center;
-	position: relative;
-	padding: 5px 16px;
-	width: 100%;
-	box-sizing: border-box;
-	white-space: nowrap;
-	font-size: 0.9em;
-	line-height: 20px;
-	text-align: left;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	text-decoration: none !important;
-	color: var(--menuFg, var(--MI_THEME-fg));
-
-	&::before {
-		content: "";
-		display: block;
-		position: absolute;
-		z-index: -1;
-		top: 0;
-		left: 0;
-		right: 0;
-		margin: auto;
-		width: calc(100% - 16px);
-		height: 100%;
-		border-radius: 6px;
-	}
-
-	&:focus-visible {
-		outline: none;
-
-		&:not(:hover):not(:active)::before {
-			outline: var(--MI_THEME-focus) solid 2px;
-			outline-offset: -2px;
+		&:focus-visible {
+			outline: none;
 		}
 	}
 
-	&:not(:disabled) {
-		&:hover,
-		&:focus-visible:active,
-		&:focus-visible.active {
-			color: var(--menuHoverFg, var(--MI_THEME-accent));
+	.item {
+		display: flex;
+		align-items: center;
+		position: relative;
+		padding: 5px 16px;
+		width: 100%;
+		box-sizing: border-box;
+		white-space: nowrap;
+		font-size: 0.9em;
+		line-height: 20px;
+		text-align: left;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		text-decoration: none !important;
+		color: var(--menuFg, var(--MI_THEME-fg));
 
-			&::before {
-				background-color: var(--menuHoverBg, var(--MI_THEME-accentedBg));
-			}
-		}
-
-		&:not(:focus-visible):active,
-		&:not(:focus-visible).active {
-			color: var(--menuActiveFg, var(--MI_THEME-fgOnAccent));
-
-			&::before {
-				background-color: var(--menuActiveBg, var(--MI_THEME-accent));
-			}
-		}
-	}
-
-	&:disabled {
-		cursor: not-allowed;
-	}
-
-	&.danger {
-		--menuFg: #ff2a2a;
-		--menuHoverFg: #fff;
-		--menuHoverBg: #ff4242;
-		--menuActiveFg: #fff;
-		--menuActiveBg: #d42e2e;
-	}
-
-	&.radio {
-		--menuActiveFg: var(--MI_THEME-accent);
-		--menuActiveBg: var(--MI_THEME-accentedBg);
-	}
-
-	&.parent {
-		--menuActiveFg: var(--MI_THEME-accent);
-		--menuActiveBg: var(--MI_THEME-accentedBg);
-	}
-
-	&.label {
-		pointer-events: none;
-		font-size: 0.7em;
-		padding-bottom: 4px;
-	}
-
-	&.pending {
-		pointer-events: none;
-		opacity: 0.7;
-	}
-
-	&.none {
-		pointer-events: none;
-		opacity: 0.7;
-	}
-}
-
-.item_content {
-	width: 100%;
-	max-width: 100vw;
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 8px;
-	text-overflow: ellipsis;
-}
-
-.item_content_text {
-	max-width: calc(100vw - 4rem);
-	text-overflow: ellipsis;
-	overflow: hidden;
-}
-
-.switchButton {
-	margin-left: -2px;
-	--height: 1.35em;
-}
-
-.switchText {
-	margin-left: 8px;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-
-.icon {
-	margin-right: 8px;
-	line-height: 1;
-}
-
-.caret {
-	margin-left: auto;
-}
-
-.avatar {
-	margin-right: 5px;
-	width: 20px;
-	height: 20px;
-}
-
-.indicator {
-	display: flex;
-	align-items: center;
-	color: var(--MI_THEME-indicator);
-	font-size: 12px;
-}
-
-.divider {
-	margin: 8px 0;
-	border-top: solid 0.5px var(--MI_THEME-divider);
-}
-
-.radioIcon {
-	display: inline-block;
-	position: relative;
-	width: 1em;
-	height: 1em;
-	vertical-align: -0.125em;
-	border-radius: 50%;
-	border: solid 2px var(--MI_THEME-divider);
-	background-color: var(--MI_THEME-panel);
-
-	&.radioChecked {
-		border-color: var(--MI_THEME-accent);
-
-		&::after {
+		&::before {
 			content: "";
 			display: block;
 			position: absolute;
-			top: 50%;
-			left: 50%;
-			transform: translate(-50%, -50%);
-			width: 50%;
-			height: 50%;
-			border-radius: 50%;
-			background-color: var(--MI_THEME-accent);
+			z-index: -1;
+			top: 0;
+			left: 0;
+			right: 0;
+			margin: auto;
+			width: calc(100% - 16px);
+			height: 100%;
+			border-radius: 6px;
+		}
+
+		&:focus-visible {
+			outline: none;
+
+			&:not(:hover):not(:active)::before {
+				outline: var(--MI_THEME-focus) solid 2px;
+				outline-offset: -2px;
+			}
+		}
+
+		&:not(:disabled) {
+			&:hover,
+			&:focus-visible:active,
+			&:focus-visible.active {
+				color: var(--menuHoverFg, var(--MI_THEME-accent));
+
+				&::before {
+					background-color: var(--menuHoverBg, var(--MI_THEME-accentedBg));
+				}
+			}
+
+			&:not(:focus-visible):active,
+			&:not(:focus-visible).active {
+				color: var(--menuActiveFg, var(--MI_THEME-fgOnAccent));
+
+				&::before {
+					background-color: var(--menuActiveBg, var(--MI_THEME-accent));
+				}
+			}
+		}
+
+		&:disabled {
+			cursor: not-allowed;
+		}
+
+		&.danger {
+			--menuFg: #ff2a2a;
+			--menuHoverFg: #fff;
+			--menuHoverBg: #ff4242;
+			--menuActiveFg: #fff;
+			--menuActiveBg: #d42e2e;
+		}
+
+		&.radio {
+			--menuActiveFg: var(--MI_THEME-accent);
+			--menuActiveBg: var(--MI_THEME-accentedBg);
+		}
+
+		&.parent {
+			--menuActiveFg: var(--MI_THEME-accent);
+			--menuActiveBg: var(--MI_THEME-accentedBg);
+		}
+
+		&.label {
+			pointer-events: none;
+			font-size: 0.7em;
+			padding-bottom: 4px;
+		}
+
+		&.pending {
+			pointer-events: none;
+			opacity: 0.7;
+		}
+
+		&.none {
+			pointer-events: none;
+			opacity: 0.7;
 		}
 	}
-}
-</style>
+
+	.item_content {
+		width: 100%;
+		max-width: 100vw;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+		text-overflow: ellipsis;
+	}
+
+	.item_content_text {
+		max-width: calc(100vw - 4rem);
+		text-overflow: ellipsis;
+		overflow: hidden;
+	}
+
+	.switchButton {
+		margin-left: -2px;
+		--height: 1.35em;
+	}
+
+	.switchText {
+		margin-left: 8px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.icon {
+		margin-right: 8px;
+		line-height: 1;
+	}
+
+	.caret {
+		margin-left: auto;
+	}
+
+	.avatar {
+		margin-right: 5px;
+		width: 20px;
+		height: 20px;
+	}
+
+	.indicator {
+		display: flex;
+		align-items: center;
+		color: var(--MI_THEME-indicator);
+		font-size: 12px;
+	}
+
+	.divider {
+		margin: 8px 0;
+		border-top: solid 0.5px var(--MI_THEME-divider);
+	}
+
+	.radioIcon {
+		display: inline-block;
+		position: relative;
+		width: 1em;
+		height: 1em;
+		vertical-align: -0.125em;
+		border-radius: 50%;
+		border: solid 2px var(--MI_THEME-divider);
+		background-color: var(--MI_THEME-panel);
+
+		&.radioChecked {
+			border-color: var(--MI_THEME-accent);
+
+			&::after {
+				content: "";
+				display: block;
+				position: absolute;
+				top: 50%;
+				left: 50%;
+				transform: translate(-50%, -50%);
+				width: 50%;
+				height: 50%;
+				border-radius: 50%;
+				background-color: var(--MI_THEME-accent);
+			}
+		}
+	}
+	</style>

--- a/packages/frontend/src/components/MkPostFormSimple.vue
+++ b/packages/frontend/src/components/MkPostFormSimple.vue
@@ -44,10 +44,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 						<span :class="$style.headerRightButtonText">{{ targetChannel.name }}</span>
 					</button>
 				</template>
-				<button v-click-anime v-tooltip="i18n.ts._visibility.disableFederation" class="_button" :class="[$style.headerRightItem, { [$style.danger]: localOnly }]" :disabled="targetChannel != null || visibility === 'specified'" @click="toggleLocalOnly">
-					<span v-if="!localOnly"><i class="ti ti-rocket"></i></span>
-					<span v-else><i class="ti ti-rocket-off"></i></span>
-				</button>
 				<button ref="otherSettingsButton" v-tooltip="i18n.ts.other" class="_button" :class="$style.headerRightItem" @click="showOtherSettings"><i class="ti ti-dots"></i></button>
 				<div :class="$style.submit">
 					<button v-click-anime class="_button" :class="$style.submitButton" :disabled="!canPost" data-cy-open-post-form-submit @click="post">
@@ -56,11 +52,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 							<template v-else-if="posting"><MkEllipsis/></template>
 							<template v-else>{{ submitText }}</template>
 							<i style="margin-left: 6px;" :class="posted ? 'ti ti-check' : saveAsDraft ? 'ti ti-pencil-minus' : replyTargetNote ? 'ti ti-arrow-back-up' : renoteTargetNote ? 'ti ti-quote' : updateMode ? 'ti ti-pencil' : defaultStore.state.renameTheButtonInPostFormToNya ? 'ti ti-paw-filled' : 'ti ti-send'"></i>
-						</div>
-					</button>
-					<button v-click-anime class="_button" style="margin-left: 2px;" :class="$style.submitButton" @click="showPostMenu">
-						<div :class="$style.submitInnerMenu">
-							<i class="ti ti-caret-down-filled"></i>
 						</div>
 					</button>
 				</div>
@@ -95,11 +86,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<template v-else-if="posting"><MkEllipsis/></template>
 					<template v-else>{{ submitText }}</template>
 					<i v-if="$i" style="margin-left: 6px;" :class="posted ? 'ti ti-check' : saveAsDraft ? 'ti ti-pencil-minus' : replyTargetNote ? 'ti ti-arrow-back-up' : renoteTargetNote ? 'ti ti-quote' : updateMode ? 'ti ti-pencil' : defaultStore.state.renameTheButtonInPostFormToNya ? 'ti ti-paw-filled' : 'ti ti-send'"></i>
-				</div>
-			</button>
-			<button v-click-anime class="_button" style="margin-left: 2px;" :class="$style.submitButton" @click="showPostMenu">
-				<div :class="$style.submitInnerMenu">
-					<i class="ti ti-caret-down-filled"></i>
 				</div>
 			</button>
 		</div>
@@ -214,7 +200,7 @@ const cwInputEl = shallowRef<HTMLInputElement | null>(null);
 const hashtagsInputEl = shallowRef<HTMLInputElement | null>(null);
 const visibilityButton = shallowRef<HTMLElement>();
 const otherSettingsButton = shallowRef<HTMLElement>();
-const searchableByButton = shallowRef<HTMLElement | null>(null);
+const searchbilityButton = shallowRef<HTMLElement>();
 
 const showForm = ref(false);
 
@@ -546,7 +532,7 @@ function setVisibility() {
 function setSearchbility() {
 	const { dispose } = os.popup(defineAsyncComponent(() => import('@/components/CPSearchbilityPicker.vue')), {
 		currentSearchbility: searchableBy.value,
-		src: searchableByButton.value,
+		src: searchbilityButton.value,
 	}, {
 		changeSearchbility: v => {
 			searchableBy.value = v;
@@ -584,13 +570,24 @@ function showOtherSettings() {
 		reactionAcceptanceIcon = 'ti ti-heart-plus';
 	}
 
-	const menuDef = [{
+	const menuItems:MenuItem[] = [];
+	menuItems.push({
 		icon: reactionAcceptanceIcon,
 		text: i18n.ts.reactionAcceptance,
 		action: () => {
 			toggleReactionAcceptance();
 		},
-	}, { type: 'divider' }, {
+	});
+
+	if ($i.policies.noteDraftLimit > 0) {
+		menuItems.push({ type: 'divider' }, {
+			type: 'switch',
+			text: i18n.ts.saveAsDraft,
+			icon: 'ti ti-pencil-minus',
+			ref: saveAsDraft,
+		});
+	}
+	menuItems.push({ type: 'divider' }, {
 		icon: 'ti ti-help-circle',
 		text: i18n.ts._mfc.cheatSheet,
 		action: () => {
@@ -609,10 +606,9 @@ function showOtherSettings() {
 			if (canceled) return;
 			clear();
 		},
-	}] satisfies MenuItem[];
-
+	});
 	const { dispose } = os.popup(defineAsyncComponent(() => import('@/components/MkPostFormOtherMenu.vue')), {
-		items: menuDef,
+		items: menuItems,
 		textLength: textLength.value,
 		src: otherSettingsButton.value,
 	}, {
@@ -1298,15 +1294,29 @@ function toggleScheduleNote() {
 function showOtherMenu(ev: MouseEvent) {
 	const menuItems: MenuItem[] = [];
 
+	menuItems.push(
+		{
+			type: 'switch',
+			text: i18n.ts.disableRightClick,
+			icon: 'ti ti-mouse-off',
+			ref: disableRightClick,
+		}, {
+			type: 'button',
+			text: i18n.ts.event,
+			icon: 'ti ti-calendar',
+			action: toggleEvent,
+		}, { type: 'divider' },
+	);
+
 	menuItems.push({
 		type: 'button',
-		text: i18n.ts.event,
-		icon: 'ti ti-calendar',
-		action: toggleEvent,
+		text: i18n.ts.scheduledNoteDelete,
+		icon: 'ti ti-clock-hour-9',
+		action: toggleScheduledNoteDelete,
 	});
 
 	if ($i.policies.scheduleNoteMax > 0) {
-		menuItems.push({ type: 'divider' }, {
+		menuItems.push({
 			type: 'button',
 			text: i18n.ts.schedulePost,
 			icon: 'ti ti-calendar-time',
@@ -1318,16 +1328,8 @@ function showOtherMenu(ev: MouseEvent) {
 			action: os.listScheduleNotePost,
 		});
 	}
-
-	menuItems.push({
-		type: 'button',
-		text: i18n.ts.scheduledNoteDelete,
-		icon: 'ti ti-clock-hour-9',
-		action: toggleScheduledNoteDelete,
-	});
-
 	if ($i.policies.noteDraftLimit > 0) {
-		menuItems.push({ type: 'divider' }, {
+		menuItems.push({
 			type: 'button',
 			text: i18n.ts.draftNoteList,
 			icon: 'ti ti-pencil-minus',
@@ -1628,7 +1630,7 @@ defineExpose({
 	padding: 0 12px;
 	line-height: 34px;
 	font-weight: bold;
-	border-radius: 6px 0 0 6px;
+	border-radius: 6px;
 	min-width: 90px;
 	box-sizing: border-box;
 	color: var(--MI_THEME-fgOnAccent);

--- a/packages/frontend/src/components/global/MkCustomEmoji.vue
+++ b/packages/frontend/src/components/global/MkCustomEmoji.vue
@@ -20,7 +20,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 	decoding="async"
 	@error="errored = true"
 	@load="errored = false"
-	@click.stop="onClick"
+	@click="onClick"
 	@mouseover="defaultStore.state.showingAnimatedImages === 'interaction' ? playAnimation = true : ''"
 	@mouseout="defaultStore.state.showingAnimatedImages === 'interaction' ? playAnimation = false : ''"
 	@touchstart="defaultStore.state.showingAnimatedImages === 'interaction' ? playAnimation = true : ''"

--- a/packages/frontend/src/components/global/MkCustomEmoji.vue
+++ b/packages/frontend/src/components/global/MkCustomEmoji.vue
@@ -121,13 +121,18 @@ function onClick(ev: MouseEvent) {
 		}
 
 		if (props.menuReaction && react) {
-			menuItems.push({
-				text: i18n.ts.doReaction,
-				icon: 'ti ti-mood-plus',
-				action: () => {
-					react(`:${props.name}:`);
-				},
-			});
+			if (props.host && !customEmojisMap.get(props.name)) {
+				//ローカルに絵文字が無い時メニューに追加しない
+				//https://github.com/yojo-art/cherrypick/pull/683
+			} else {
+				menuItems.push({
+					text: i18n.ts.doReaction,
+					icon: 'ti ti-mood-plus',
+					action: () => {
+						react(`:${props.name}:`);
+					},
+				});
+			}
 		}
 
 		menuItems.push({

--- a/packages/frontend/src/pages/note.vue
+++ b/packages/frontend/src/pages/note.vue
@@ -11,7 +11,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 			<Transition :name="defaultStore.state.animation ? 'fade' : ''" mode="out-in">
 				<div v-if="note">
 					<div v-if="showNext" class="_margin">
-						<MkNotes class="" :pagination="showNext === 'channel' ? nextChannelPagination : nextUserPagination" :noGap="!defaultStore.state.showGapBetweenNotesInTimeline" :disableAutoLoad="true"/>
+						<MkNotes class="" :pagination="showNext" :noGap="!defaultStore.state.showGapBetweenNotesInTimeline" :disableAutoLoad="true"/>
 					</div>
 
 					<div class="_margin">
@@ -40,7 +40,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					</div>
 
 					<div v-if="showPrev" class="_margin">
-						<MkNotes class="" :pagination="showPrev === 'channel' ? prevChannelPagination : prevUserPagination" :noGap="!defaultStore.state.showGapBetweenNotesInTimeline"/>
+						<MkNotes class="" :pagination="showPrev" :noGap="!defaultStore.state.showGapBetweenNotesInTimeline"/>
 					</div>
 				</div>
 				<MkError v-else-if="error" @retry="fetchNote()"/>
@@ -83,8 +83,8 @@ const props = defineProps<{
 const note = ref<null | Misskey.entities.Note>(CTX_NOTE);
 const clips = ref<Misskey.entities.Clip[]>();
 type TimelineType = 'user' | 'home' | 'local' | 'channel' | false;
-const showPrev = ref<Paging | false>(false);
-const showNext = ref<Paging | false>(false);
+const showPrev = ref<Paging>();
+const showNext = ref<Paging>();
 const error = ref();
 
 function showPrevPagination(tl:TimelineType): Paging {
@@ -178,8 +178,8 @@ function showNextPagination(tl:TimelineType):Paging {
 }
 
 function fetchNote() {
-	showPrev.value = false;
-	showNext.value = false;
+	showPrev.value = undefined;
+	showNext.value = undefined;
 	note.value = null;
 
 	if (CTX_NOTE && CTX_NOTE.id === props.noteId) {

--- a/packages/frontend/src/scripts/check-reaction-create.ts
+++ b/packages/frontend/src/scripts/check-reaction-create.ts
@@ -12,7 +12,7 @@ export async function notesReactionsCreate(data:{ noteId: string, reaction: stri
 	if (defaultStore.state.checkReactionDialog === true ) {
 		const { canceled } = await os.confirm({
 			type: 'warning',
-			title: i18n.tsx._reactionConfirm.title({ emoji: data.reaction }),
+			title: i18n.tsx._reactionConfirm.title({ emoji: data.reaction.replace('@.', '') }),
 			caption: i18n.ts._reactionConfirm.caption,
 			okText: i18n.ts._reactionConfirm.confirm,
 			cancelText: i18n.ts.cancel,


### PR DESCRIPTION
## 1.4.1
Cherrypick 4.15.0  
Misskey 2025.2.0

### Release Date
2025-03-29

### General

### Client
- Fix: ノート詳細から前後TL見る機能の修正 [#677](https://github.com/yojo-art/cherrypick/pull/677)
- Fix: 返信用投稿フォームを通常投稿フォームと統一 [#676](https://github.com/yojo-art/cherrypick/pull/676)
- Fix: 右クリックメニューにスクロールバーがある時、派生メニューで考慮されない不具合の修正 [#680](https://github.com/yojo-art/cherrypick/pull/680)
  - 問題が起きていた変更部分を1.3.1時点に戻しました
- Fix: ローカルのリアクションに相乗りする時の確認ダイアログを修正 [#682](https://github.com/yojo-art/cherrypick/pull/682)
- Fix: ノート内絵文字を付ける機能でローカルに無い絵文字は機能を非表示に [#683](https://github.com/yojo-art/cherrypick/pull/683)
- Fix: ノート詳細リアクションタブ内のリアクションボタンの画像部分にクリック判定が無い問題を修正 [#684](https://github.com/yojo-art/cherrypick/pull/684)

### Server