### PR TITLE
Revert "Fix(backend) : typecheck"

### DIFF
--- a/packages/backend/src/core/WebhookTestService.ts
+++ b/packages/backend/src/core/WebhookTestService.ts
@@ -180,7 +180,6 @@ function toPackedNote(note: MiNote, detail = true, override?: Packed<'Note'>): P
 		repliesCount: note.repliesCount,
 		uri: note.uri ?? undefined,
 		url: note.url ?? undefined,
-		favorite: false,
 		reactionAndUserPairCache: note.reactionAndUserPairCache,
 		...(detail ? {
 			clippedCount: note.clippedCount,

--- a/packages/backend/src/core/entities/NoteEntityService.ts
+++ b/packages/backend/src/core/entities/NoteEntityService.ts
@@ -455,7 +455,6 @@ export class NoteEntityService implements OnModuleInit {
 			mentions: note.mentions.length > 0 ? note.mentions : undefined,
 			uri: note.uri ?? undefined,
 			url: note.url ?? undefined,
-			favorite: meId ? (await this.cacheService.userNoteFavoritesCache.fetch(meId)).has(note.id) : false,
 
 			...(opts.detail ? {
 				clippedCount: note.clippedCount,
@@ -484,6 +483,7 @@ export class NoteEntityService implements OnModuleInit {
 						reactionAndUserPairCache: reactionAndUserPairCache,
 					}, meId, options?._hint_),
 				} : {}),
+				favorite: meId ? (await this.cacheService.userNoteFavoritesCache.fetch(meId)).has(note.id) : false,
 			} : {}),
 		});
 


### PR DESCRIPTION
Reverts yojo-art/cherrypick#721

#710 は状況次第でTLが読み込めなくなるなどパフォーマンス面に課題があり、次リリースから外したい