### PR TITLE
enhance(backend): botをハッシュタグトレンドから除外できるように

### DIFF
--- a/.config/docker_example.yml
+++ b/.config/docker_example.yml
@@ -278,6 +278,9 @@ proxyBypassHosts:
 # Upload or download file size limits (bytes)
 #maxFileSize: 262144000
 
+# Exclude bot users from hashtag trends
+#hashtagTrendExcludeBotUsers: true
+
 # Log settings
 # logging:
 #   sql:

--- a/.config/example.yml
+++ b/.config/example.yml
@@ -390,6 +390,9 @@ proxyBypassHosts:
 # PID File of master process
 #pidFile: /tmp/cherrypick.pid
 
+# Exclude bot users from hashtag trends
+#hashtagTrendExcludeBotUsers: true
+
 # Log settings
 # logging:
 #   sql:

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -128,6 +128,8 @@ type Source = {
 	deactivateAntennaThreshold?: number;
 	pidFile: string;
 
+	hashtagTrendExcludeBotUsers?: boolean;
+
 	logging?: {
 		sql?: {
 			disableQueryTruncation?: boolean,
@@ -250,6 +252,7 @@ export type Config = {
 	perUserNotificationsMaxCount: number;
 	deactivateAntennaThreshold: number;
 	pidFile: string;
+	hashtagTrendExcludeBotUsers: boolean | undefined;
 };
 
 export type FulltextSearchProvider = 'sqlLike' | 'sqlPgroonga' | 'meilisearch' | 'opensearch';
@@ -376,6 +379,7 @@ export function loadConfig(): Config {
 		perUserNotificationsMaxCount: config.perUserNotificationsMaxCount ?? 500,
 		deactivateAntennaThreshold: config.deactivateAntennaThreshold ?? (1000 * 60 * 60 * 24 * 7),
 		pidFile: config.pidFile,
+		hashtagTrendExcludeBotUsers: config.hashtagTrendExcludeBotUsers,
 		logging: config.logging,
 	};
 }

--- a/packages/backend/src/core/HashtagService.ts
+++ b/packages/backend/src/core/HashtagService.ts
@@ -15,10 +15,14 @@ import { UserEntityService } from '@/core/entities/UserEntityService.js';
 import { bindThis } from '@/decorators.js';
 import { FeaturedService } from '@/core/FeaturedService.js';
 import { UtilityService } from '@/core/UtilityService.js';
+import type { Config } from '@/config.js';
 
 @Injectable()
 export class HashtagService {
 	constructor(
+		@Inject(DI.config)
+		private config: Config,
+
 		@Inject(DI.meta)
 		private meta: MiMeta,
 
@@ -57,7 +61,7 @@ export class HashtagService {
 	public async updateHashtag(user: { id: MiUser['id']; host: MiUser['host']; isBot: MiUser['isBot']; }, tag: string, isUserAttached = false, inc = true) {
 		tag = normalizeForSearch(tag);
 
-		if (!(user.isBot && process.env.HASHTAG_TREND_EXCLUDE_BOT_USERS === 'true')) {
+		if (!(user.isBot && this.config.hashtagTrendExcludeBotUsers)) {
 			// TODO: サンプリング
 			this.updateHashtagsRanking(tag, user.id);
 		}

--- a/packages/backend/src/core/HashtagService.ts
+++ b/packages/backend/src/core/HashtagService.ts
@@ -36,7 +36,7 @@ export class HashtagService {
 	}
 
 	@bindThis
-	public async updateHashtags(user: { id: MiUser['id']; host: MiUser['host']; }, tags: string[]) {
+	public async updateHashtags(user: { id: MiUser['id']; host: MiUser['host']; isBot: MiUser['isBot']; }, tags: string[]) {
 		for (const tag of tags) {
 			await this.updateHashtag(user, tag);
 		}
@@ -54,11 +54,13 @@ export class HashtagService {
 	}
 
 	@bindThis
-	public async updateHashtag(user: { id: MiUser['id']; host: MiUser['host']; }, tag: string, isUserAttached = false, inc = true) {
+	public async updateHashtag(user: { id: MiUser['id']; host: MiUser['host']; isBot: MiUser['isBot']; }, tag: string, isUserAttached = false, inc = true) {
 		tag = normalizeForSearch(tag);
 
-		// TODO: サンプリング
-		this.updateHashtagsRanking(tag, user.id);
+		if (!(user.isBot && process.env.HASHTAG_TREND_EXCLUDE_BOT_USERS === 'true')) {
+			// TODO: サンプリング
+			this.updateHashtagsRanking(tag, user.id);
+		}
 
 		const index = await this.hashtagsRepository.findOneBy({ name: tag });
 


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
botのハッシュタグをトレンドから除外できるように。
~~とりあえず環境変数から設定できる（コンパネから変更できたほうがいいかもしれない~~
default.ymlでhashtagTrendExcludeBotUsers: trueで有効にできるように

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Resolve: #857 

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [ ] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
