### PR TITLE
fix(frontend): リアクション確認ダイアログが正しく動作していないのを修正

### DIFF
--- a/packages/frontend/src/components/MkNote.vue
+++ b/packages/frontend/src/components/MkNote.vue
@@ -666,7 +666,8 @@ provide(DI.mfmEmojiReactCallback, (reaction) => {
 	notesReactionsCreate({
 		noteId: appearNote.id,
 		reaction: reaction,
-	}).then(() => {
+	}).then(({ canceled }) => {
+		if (canceled) return;
 		noteEvents.emit(`reacted:${appearNote.id}`, {
 			userId: $i!.id,
 			reaction: reaction,
@@ -815,7 +816,8 @@ function react(): void {
 		notesReactionsCreate({
 			noteId: appearNote.id,
 			reaction: '❤️',
-		}).then(() => {
+		}).then(({ canceled }) => {
+			if (canceled) return;
 			noteEvents.emit(`reacted:${appearNote.id}`, {
 				userId: $i!.id,
 				reaction: '❤️',
@@ -871,10 +873,20 @@ async function toggleReaction(reaction) {
 		misskeyApi('notes/reactions/delete', {
 			noteId: note.id,
 		}).then(() => {
+			noteEvents.emit(`unreacted:${appearNote.id}`, {
+				userId: $i!.id,
+				reaction: oldReaction,
+			});
+
 			if (oldReaction !== reaction) {
 				misskeyApi('notes/reactions/create', {
 					noteId: note.id,
 					reaction: reaction,
+				}).then(() => {
+					noteEvents.emit(`reacted:${appearNote.id}`, {
+						userId: $i!.id,
+						reaction: reaction,
+					});
 				});
 			}
 		});
@@ -882,7 +894,8 @@ async function toggleReaction(reaction) {
 		notesReactionsCreate({
 			noteId: appearNote.id,
 			reaction: reaction,
-		}).then(() => {
+		}).then(({ canceled }) => {
+			if (canceled) return;
 			noteEvents.emit(`reacted:${appearNote.id}`, {
 				userId: $i!.id,
 				reaction: reaction,
@@ -907,21 +920,28 @@ function heartReact(): void {
 	notesReactionsCreate({
 		noteId: appearNote.id,
 		reaction: prefer.s.selectReaction,
-	});
+	}).then(({ canceled }) => {
+		if (canceled) return;
 
-	if (appearNote.text && appearNote.text.length > 100 && (Date.now() - new Date(appearNote.createdAt).getTime() < 1000 * 3)) {
-		claimAchievement('reactWithoutRead');
-	}
-
-	const el = heartReactButton.value;
-	if (el && prefer.s.animation) {
-		const rect = el.getBoundingClientRect();
-		const x = rect.left + (el.offsetWidth / 2);
-		const y = rect.top + (el.offsetHeight / 2);
-		const { dispose } = os.popup(MkRippleEffect, { x, y }, {
-			end: () => dispose(),
+		noteEvents.emit(`reacted:${props.note.id}`, {
+			userId: $i!.id,
+			reaction: prefer.s.selectReaction,
 		});
-	}
+
+		if (appearNote.text && appearNote.text.length > 100 && (Date.now() - new Date(appearNote.createdAt).getTime() < 1000 * 3)) {
+			claimAchievement('reactWithoutRead');
+		}
+
+		const el = heartReactButton.value;
+		if (el && prefer.s.animation) {
+			const rect = el.getBoundingClientRect();
+			const x = rect.left + (el.offsetWidth / 2);
+			const y = rect.top + (el.offsetHeight / 2);
+			const { dispose } = os.popup(MkRippleEffect, { x, y }, {
+				end: () => dispose(),
+			});
+		}
+	});
 }
 
 function undoReact(): void {

--- a/packages/frontend/src/components/MkNoteDetailed.vue
+++ b/packages/frontend/src/components/MkNoteDetailed.vue
@@ -673,7 +673,8 @@ function react(): void {
 		notesReactionsCreate({
 			noteId: appearNote.id,
 			reaction: '❤️',
-		}).then(() => {
+		}).then(({ canceled }) => {
+			if (canceled) return;
 			noteEvents.emit(`reacted:${appearNote.id}`, {
 				userId: $i!.id,
 				reaction: '❤️',
@@ -721,10 +722,19 @@ async function toggleReaction(reaction) {
 		misskeyApi('notes/reactions/delete', {
 			noteId: note.id,
 		}).then(() => {
+			noteEvents.emit(`unreacted:${appearNote.id}`, {
+				userId: $i!.id,
+				reaction: oldReaction,
+			});
 			if (oldReaction !== reaction) {
 				misskeyApi('notes/reactions/create', {
 					noteId: note.id,
 					reaction: reaction,
+				}).then(() => {
+					noteEvents.emit(`reacted:${appearNote.id}`, {
+						userId: $i!.id,
+						reaction: reaction,
+					});
 				});
 			}
 		});
@@ -732,7 +742,9 @@ async function toggleReaction(reaction) {
 		notesReactionsCreate({
 			noteId: appearNote.id,
 			reaction: reaction,
-		}).then(() => {
+		}).then(({ canceled }) => {
+			if (canceled) return;
+
 			noteEvents.emit(`reacted:${appearNote.id}`, {
 				userId: $i!.id,
 				reaction: reaction,
@@ -753,21 +765,28 @@ function heartReact(): void {
 	notesReactionsCreate({
 		noteId: appearNote.id,
 		reaction: prefer.s.selectReaction,
-	});
+	}).then(({ canceled }) => {
+		if (canceled) return;
 
-	if (appearNote.text && appearNote.text.length > 100 && (Date.now() - new Date(appearNote.createdAt).getTime() < 1000 * 3)) {
-		claimAchievement('reactWithoutRead');
-	}
-
-	const el = heartReactButton.value;
-	if (el && prefer.s.animation) {
-		const rect = el.getBoundingClientRect();
-		const x = rect.left + (el.offsetWidth / 2);
-		const y = rect.top + (el.offsetHeight / 2);
-		const { dispose } = os.popup(MkRippleEffect, { x, y }, {
-			end: () => dispose(),
+		noteEvents.emit(`reacted:${appearNote.id}`, {
+			userId: $i!.id,
+			reaction: prefer.s.selectReaction,
 		});
-	}
+
+		if (appearNote.text && appearNote.text.length > 100 && (Date.now() - new Date(appearNote.createdAt).getTime() < 1000 * 3)) {
+			claimAchievement('reactWithoutRead');
+		}
+
+		const el = heartReactButton.value;
+		if (el && prefer.s.animation) {
+			const rect = el.getBoundingClientRect();
+			const x = rect.left + (el.offsetWidth / 2);
+			const y = rect.top + (el.offsetHeight / 2);
+			const { dispose } = os.popup(MkRippleEffect, { x, y }, {
+				end: () => dispose(),
+			});
+		}
+	});
 }
 
 function undoReact(targetNote: Misskey.entities.Note): void {

--- a/packages/frontend/src/components/MkReactionsViewer.reaction.vue
+++ b/packages/frontend/src/components/MkReactionsViewer.reaction.vue
@@ -168,7 +168,8 @@ async function toggleReaction(ev: MouseEvent) {
 		notesReactionsCreate({
 			noteId: props.noteId,
 			reaction: props.reaction,
-		}).then(() => {
+		}).then(({ canceled }) => {
+			if (canceled) return;
 			const emoji = customEmojisMap.get(emojiName.value);
 			if (emoji == null && getUnicodeEmojiOrNull(props.reaction) == null) {
 				return;
@@ -414,7 +415,8 @@ function chooseAlternative(ev) {
 	notesReactionsCreate({
 		noteId: props.noteId,
 		reaction: `:${alternative.value}:`,
-	}).then(() => {
+	}).then(({ canceled }) => {
+		if (canceled) return;
 		noteEvents.emit(`reacted:${props.noteId}`, {
 			userId: $i!.id,
 			reaction: `:${alternative.value}:`,

--- a/packages/frontend/src/components/MkSubNoteContent.vue
+++ b/packages/frontend/src/components/MkSubNoteContent.vue
@@ -415,7 +415,8 @@ function react(): void {
 		notesReactionsCreate({
 			noteId: props.note.id,
 			reaction: '❤️',
-		}).then(() => {
+		}).then(({ canceled }) => {
+			if (canceled) return;
 			noteEvents.emit(`reacted:${props.note.id}`, {
 				userId: $i!.id,
 				reaction: '❤️',
@@ -482,7 +483,8 @@ async function toggleReaction(reaction) {
 		notesReactionsCreate({
 			noteId: note.id,
 			reaction: reaction,
-		}).then(() => {
+		}).then(({ canceled }) => {
+			if (canceled) return;
 			noteEvents.emit(`reacted:${note.id}`, {
 				userId: $i!.id,
 				reaction: reaction,
@@ -507,19 +509,26 @@ function heartReact(): void {
 	notesReactionsCreate({
 		noteId: props.note.id,
 		reaction: prefer.s.selectReaction,
-	});
-	if (props.note.text && props.note.text.length > 100 && (Date.now() - new Date(props.note.createdAt).getTime() < 1000 * 3)) {
-		claimAchievement('reactWithoutRead');
-	}
-	const el = heartReactButton.value;
-	if (el && prefer.s.animation) {
-		const rect = el.getBoundingClientRect();
-		const x = rect.left + (el.offsetWidth / 2);
-		const y = rect.top + (el.offsetHeight / 2);
-		const { dispose } = os.popup(MkRippleEffect, { x, y }, {
-			end: () => dispose(),
+	}).then(({ canceled }) => {
+		if (canceled) return;
+
+		noteEvents.emit(`reacted:${props.note.id}`, {
+			userId: $i!.id,
+			reaction: prefer.s.selectReaction,
 		});
-	}
+		if (props.note.text && props.note.text.length > 100 && (Date.now() - new Date(props.note.createdAt).getTime() < 1000 * 3)) {
+			claimAchievement('reactWithoutRead');
+		}
+		const el = heartReactButton.value;
+		if (el && prefer.s.animation) {
+			const rect = el.getBoundingClientRect();
+			const x = rect.left + (el.offsetWidth / 2);
+			const y = rect.top + (el.offsetHeight / 2);
+			const { dispose } = os.popup(MkRippleEffect, { x, y }, {
+				end: () => dispose(),
+			});
+		}
+	});
 }
 
 function undoReact(): void {

--- a/packages/frontend/src/utility/check-reaction-create.ts
+++ b/packages/frontend/src/utility/check-reaction-create.ts
@@ -8,7 +8,7 @@ import * as sound from '@/utility/sound.js';
 import { prefer } from '@/preferences.js';
 import { misskeyApi } from '@/utility/misskey-api.js';
 
-export async function notesReactionsCreate(data:{ noteId: string, reaction: string }, opt = { mute: false }) {
+export async function notesReactionsCreate(data:{ noteId: string, reaction: string }, opt = { mute: false }) : Promise<{ canceled: boolean }> {
 	if (prefer.s.checkReactionDialog === true ) {
 		const { canceled } = await os.confirm({
 			type: 'warning',
@@ -17,8 +17,9 @@ export async function notesReactionsCreate(data:{ noteId: string, reaction: stri
 			okText: i18n.ts._reactionConfirm.confirm,
 			cancelText: i18n.ts.cancel,
 		});
-		if (canceled) return;
+		if (canceled) return { canceled: true };
 	}
 	if (!opt.mute) sound.playMisskeySfx('reaction');
 	await misskeyApi('notes/reactions/create', data);
+	return { canceled: false };
 }


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
fix  #889

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
