### PR TITLE
fix(frontend): リアクション変更時に古いリアクションが削除されないことがある問題の修正

### DIFF
--- a/packages/frontend/src/components/MkNote.vue
+++ b/packages/frontend/src/components/MkNote.vue
@@ -860,7 +860,7 @@ function react(): void {
 }
 
 async function toggleReaction(reaction) {
-	const oldReaction = note.myReaction;
+	const oldReaction = $appearNote.myReaction;
 	if (oldReaction) {
 		const confirm = await os.confirm({
 			type: 'warning',

--- a/packages/frontend/src/components/MkNoteDetailed.vue
+++ b/packages/frontend/src/components/MkNoteDetailed.vue
@@ -709,7 +709,7 @@ function react(): void {
 }
 
 async function toggleReaction(reaction) {
-	const oldReaction = note.myReaction;
+	const oldReaction = $appearNote.myReaction;
 	if (oldReaction) {
 		const confirm = await os.confirm({
 			type: 'warning',

--- a/packages/frontend/src/components/MkReactionsViewer.reaction.vue
+++ b/packages/frontend/src/components/MkReactionsViewer.reaction.vue
@@ -100,7 +100,7 @@ async function toggleReaction(ev: MouseEvent) {
 	haptic();
 
 	if (!canToggle.value) {
-		chooseAlternative(ev);
+		await chooseAlternative(ev);
 		return;
 	}
 	if ($i == null) return;
@@ -408,20 +408,53 @@ function anime() {
 	});
 }
 
-function chooseAlternative(ev) {
+async function chooseAlternative(ev) {
 	// メニュー表示にして、モデレーター以上の場合は登録もできるように
 	if (!alternative.value) return;
+
 	console.log(alternative.value);
-	notesReactionsCreate({
-		noteId: props.noteId,
-		reaction: `:${alternative.value}:`,
-	}).then(({ canceled }) => {
-		if (canceled) return;
-		noteEvents.emit(`reacted:${props.noteId}`, {
-			userId: $i!.id,
-			reaction: `:${alternative.value}:`,
+	const oldReaction = props.myReaction;
+	const reaction = `:${alternative.value}:`;
+
+	if (oldReaction) {
+		const confirm = await os.confirm({
+			type: 'warning',
+			text: oldReaction !== reaction ? i18n.ts.changeReactionConfirm : i18n.ts.cancelReactionConfirm,
 		});
-	});
+		if (confirm.canceled) return;
+
+		misskeyApi('notes/reactions/delete', {
+			noteId: props.noteId,
+		}).then(() => {
+			noteEvents.emit(`unreacted:${props.noteId}`, {
+				userId: $i!.id,
+				reaction: oldReaction,
+			});
+
+			if (oldReaction !== reaction) {
+				misskeyApi('notes/reactions/create', {
+					noteId: props.noteId,
+					reaction: reaction,
+				}).then(() => {
+					noteEvents.emit(`reacted:${props.noteId}`, {
+						userId: $i!.id,
+						reaction: reaction,
+					});
+				});
+			}
+		});
+	}	else {
+		notesReactionsCreate({
+			noteId: props.noteId,
+			reaction: `:${alternative.value}:`,
+		}).then(({ canceled }) => {
+			if (canceled) return;
+			noteEvents.emit(`reacted:${props.noteId}`, {
+				userId: $i!.id,
+				reaction: `:${alternative.value}:`,
+			});
+		});
+	}
 }
 
 async function openEmojiMenu(ev) {

--- a/packages/frontend/src/components/MkSubNoteContent.vue
+++ b/packages/frontend/src/components/MkSubNoteContent.vue
@@ -459,7 +459,7 @@ function react(): void {
 }
 
 async function toggleReaction(reaction) {
-	const oldReaction = note.myReaction;
+	const oldReaction = $note.myReaction;
 	if (oldReaction) {
 		const confirm = await os.confirm({
 			type: 'warning',


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
fix #896

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [ ] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
