### PR TITLE
test(backend): APIエンドポイントparamDefバリデーションテスト追加 [3/5]

### DIFF
--- a/packages/backend/scripts/generate-endpoint-tests.cjs
+++ b/packages/backend/scripts/generate-endpoint-tests.cjs
@@ -1,0 +1,189 @@
+/**
+ * Generates .test.ts files for API endpoint paramDef validation.
+ * Run: node scripts/generate-endpoint-tests.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function walkDir(dir) {
+	const files = [];
+	for (const f of fs.readdirSync(dir, { withFileTypes: true })) {
+		if (f.isDirectory()) {
+			files.push(...walkDir(path.join(dir, f.name)));
+		} else if (f.name.endsWith('.ts') && !f.name.endsWith('.test.ts')) {
+			files.push(path.join(dir, f.name));
+		}
+	}
+	return files;
+}
+
+function getRelativeTestImportPath(testFilePath, endpointsDir) {
+	const rel = path.relative(path.dirname(testFilePath), 'test/prelude');
+	return rel.replace(/\\/g, '/');
+}
+
+function generateValidValue(propSchema) {
+	if (!propSchema) return undefined;
+	const type = propSchema.type;
+	if (propSchema.enum && propSchema.enum.length > 0) return JSON.stringify(propSchema.enum[0]);
+	if (propSchema.const !== undefined) return JSON.stringify(propSchema.const);
+	if (type === 'string') {
+		if (propSchema.format === 'misskey:id') return "'aaaaaaaaaaa'";
+		if (propSchema.format === 'url') return "'https://example.com'";
+		if (propSchema.format === 'uri') return "'https://example.com'";
+		if (propSchema.format === 'email') return "'test@example.com'";
+		if (propSchema.format === 'date-time') return "'2024-01-01T00:00:00.000Z'";
+		return "'test'";
+	}
+	if (type === 'number' || type === 'integer') return '1';
+	if (type === 'boolean') return 'true';
+	if (type === 'array') return '[]';
+	if (type === 'object') return '{}';
+	if (Array.isArray(type)) {
+		// nullable types like ['string', 'null']
+		const nonNull = type.find(t => t !== 'null');
+		if (nonNull === 'string') return "'test'";
+		if (nonNull === 'number' || nonNull === 'integer') return '1';
+		if (nonNull === 'boolean') return 'true';
+	}
+	return "'test'";
+}
+
+function parseParamDef(content) {
+	// Extract the paramDef object
+	const match = content.match(/export const paramDef\s*=\s*(\{[\s\S]*?\})\s*as\s*const/);
+	if (!match) return null;
+
+	try {
+		// Simple extraction of required and properties
+		const defStr = match[1];
+
+		// Extract required array
+		const requiredMatch = defStr.match(/required\s*:\s*\[([\s\S]*?)\]/);
+		const required = [];
+		if (requiredMatch && requiredMatch[1].trim()) {
+			const items = requiredMatch[1].match(/'([^']+)'/g);
+			if (items) {
+				for (const item of items) {
+					required.push(item.replace(/'/g, ''));
+				}
+			}
+		}
+
+		// Extract properties
+		const properties = {};
+		// Find properties block
+		const propsMatch = defStr.match(/properties\s*:\s*\{/);
+		if (propsMatch) {
+			const propsStart = defStr.indexOf(propsMatch[0]) + propsMatch[0].length;
+			let depth = 1;
+			let i = propsStart;
+			while (i < defStr.length && depth > 0) {
+				if (defStr[i] === '{') depth++;
+				if (defStr[i] === '}') depth--;
+				i++;
+			}
+			const propsBlock = defStr.slice(propsStart, i - 1);
+
+			// Extract each property name and its type
+			const propRegex = /(\w+)\s*:\s*\{([^}]*(?:\{[^}]*\}[^}]*)*)\}/g;
+			let propMatch;
+			while ((propMatch = propRegex.exec(propsBlock)) !== null) {
+				const propName = propMatch[1];
+				const propBody = propMatch[2];
+
+				const typeMatch = propBody.match(/type\s*:\s*'(\w+)'/);
+				const formatMatch = propBody.match(/format\s*:\s*'([^']+)'/);
+				const enumMatch = propBody.match(/enum\s*:\s*\[([^\]]+)\]/);
+
+				const prop = {};
+				if (typeMatch) prop.type = typeMatch[1];
+				if (formatMatch) prop.format = formatMatch[1];
+				if (enumMatch) {
+					const enumValues = enumMatch[1].match(/'([^']+)'/g);
+					if (enumValues) prop.enum = enumValues.map(v => v.replace(/'/g, ''));
+				}
+
+				properties[propName] = prop;
+			}
+		}
+
+		return { required, properties };
+	} catch (e) {
+		return null;
+	}
+}
+
+function generateTestContent(file, endpointName, paramInfo) {
+	const baseName = path.basename(file, '.ts');
+	const testPreludePath = path.relative(path.dirname(file), 'test/prelude').replace(/\\/g, '/');
+	const importSuffix = './' + baseName + '.js';
+
+	const lines = [];
+	lines.push(`/*`);
+	lines.push(` * SPDX-FileCopyrightText: syuilo and misskey-project`);
+	lines.push(` * SPDX-License-Identifier: AGPL-3.0-only`);
+	lines.push(` */`);
+	lines.push(``);
+	lines.push(`process.env.NODE_ENV = 'test';`);
+	lines.push(``);
+	lines.push(`import { getValidator } from '${testPreludePath}/get-api-validator.js';`);
+	lines.push(`import { paramDef } from '${importSuffix}';`);
+	lines.push(``);
+	lines.push(`const VALID = true;`);
+	lines.push(`const INVALID = false;`);
+	lines.push(``);
+	lines.push(`describe('api:${endpointName}', () => {`);
+	lines.push(`\tdescribe('validation', () => {`);
+	lines.push(`\t\tconst v = getValidator(paramDef);`);
+	lines.push(``);
+
+	if (!paramInfo || !paramInfo.required || paramInfo.required.length === 0) {
+		lines.push(`\t\ttest('accept empty', () => expect(v({})).toBe(VALID));`);
+	} else {
+		lines.push(`\t\ttest('reject empty', () => expect(v({})).toBe(INVALID));`);
+	}
+
+	// Always test that the validator is a function (ensures paramDef is valid schema)
+	lines.push(`\t\ttest('validator is a function', () => expect(typeof v).toBe('function'));`);
+
+	lines.push(`\t});`);
+	lines.push(`});`);
+	lines.push(``);
+
+	return lines.join('\n');
+}
+
+// Main
+const endpointsDir = 'src/server/api/endpoints';
+const allFiles = walkDir(endpointsDir);
+let generated = 0;
+let skipped = 0;
+
+for (const file of allFiles) {
+	const testFile = file.replace('.ts', '.test.ts');
+	if (fs.existsSync(testFile)) {
+		skipped++;
+		continue;
+	}
+
+	const content = fs.readFileSync(file, 'utf-8');
+	if (!content.includes('paramDef')) {
+		continue;
+	}
+
+	// Determine endpoint name from file path
+	const endpointName = file
+		.replace(endpointsDir + '/', '')
+		.replace('.ts', '')
+		.replace(/\//g, '/');
+
+	const paramInfo = parseParamDef(content);
+	const testContent = generateTestContent(file, endpointName, paramInfo);
+
+	fs.writeFileSync(testFile, testContent);
+	generated++;
+}
+
+console.log(`Generated: ${generated}, Skipped (already exist): ${skipped}`);

--- a/packages/backend/scripts/move-endpoint-tests.cjs
+++ b/packages/backend/scripts/move-endpoint-tests.cjs
@@ -1,0 +1,95 @@
+/**
+ * Move endpoint test files from src/ to test/unit/ and fix import paths.
+ * Run: node scripts/move-endpoint-tests.cjs
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const srcBase = 'src/server/api/endpoints';
+const destBase = 'test/unit/server/api/endpoints';
+
+// 既存のテスト(upstream由来)は除外
+const exclude = new Set([
+	'src/server/api/endpoints/notes/create.test.ts',
+	'src/server/api/endpoints/users/show.test.ts',
+]);
+
+function walkDir(dir) {
+	const files = [];
+	if (!fs.existsSync(dir)) return files;
+	for (const f of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, f.name);
+		if (f.isDirectory()) {
+			files.push(...walkDir(full));
+		} else if (f.name.endsWith('.test.ts')) {
+			files.push(full);
+		}
+	}
+	return files;
+}
+
+const testFiles = walkDir(srcBase).filter(f => !exclude.has(f));
+let moved = 0;
+
+for (const srcFile of testFiles) {
+	// 移動先パスを計算
+	const relFromSrcBase = path.relative(srcBase, srcFile);
+	const destFile = path.join(destBase, relFromSrcBase);
+
+	// 読み込み
+	let content = fs.readFileSync(srcFile, 'utf-8');
+
+	// 1. getValidatorのimportパスを修正
+	// 古いパス: 相対パスで test/prelude/ を指している (例: '../../../../../../test/prelude/get-api-validator.js')
+	// 新しいパス: test/unit/server/api/endpoints/xxx/ から test/prelude/ への相対パス
+	const destDir = path.dirname(destFile);
+	const preludePath = path.relative(destDir, 'test/prelude').replace(/\\/g, '/');
+	content = content.replace(
+		/import \{ getValidator \} from '[^']+\/get-api-validator\.js';/,
+		`import { getValidator } from '${preludePath}/get-api-validator.js';`
+	);
+
+	// 2. paramDefのimportパスを修正
+	// 古いパス: './create.js' (同じディレクトリの相対パス)
+	// 新しいパス: '@/server/api/endpoints/xxx/create.js' (エイリアスパス)
+	const srcDir = path.dirname(srcFile);
+	content = content.replace(
+		/import \{ paramDef \} from '\.\/([^']+)';/,
+		(match, filename) => {
+			const srcModule = path.join(srcDir, filename).replace(/\\/g, '/');
+			// src/ を @/ に変換
+			const aliasPath = srcModule.replace(/^src\//, '@/');
+			return `import { paramDef } from '${aliasPath}';`;
+		}
+	);
+
+	// ディレクトリ作成 & 書き込み
+	fs.mkdirSync(path.dirname(destFile), { recursive: true });
+	fs.writeFileSync(destFile, content);
+
+	// 元ファイル削除
+	fs.unlinkSync(srcFile);
+	moved++;
+}
+
+// 空ディレクトリを再帰的に削除
+function removeEmptyDirs(dir) {
+	if (!fs.existsSync(dir)) return;
+	const entries = fs.readdirSync(dir);
+	for (const entry of entries) {
+		const full = path.join(dir, entry);
+		if (fs.statSync(full).isDirectory()) {
+			removeEmptyDirs(full);
+		}
+	}
+	if (fs.readdirSync(dir).length === 0) {
+		fs.rmdirSync(dir);
+	}
+}
+
+// src側の空ディレクトリ掃除 (テストファイルだけあったディレクトリ)
+// ※ソースファイルがあるディレクトリは消さない
+
+console.log(`Moved: ${moved} files`);
+console.log(`From: ${srcBase} → To: ${destBase}`);

--- a/packages/backend/test/unit/server/api/endpoints/admin/abuse-report-resolver/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/abuse-report-resolver/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/abuse-report-resolver/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/abuse-report-resolver/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ name: 'test', targetUserPattern: 'test', reporterPattern: 'test', reportContentPattern: 'test', expiresAt: "1hour", forward: true })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/abuse-report-resolver/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/abuse-report-resolver/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/abuse-report-resolver/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/abuse-report-resolver/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/abuse-report-resolver/list.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/abuse-report-resolver/list.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/abuse-report-resolver/list.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/abuse-report-resolver/list', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/abuse-report-resolver/update.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/abuse-report-resolver/update.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/abuse-report-resolver/update.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/abuse-report-resolver/update', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/abuse-report/notification-recipient/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/abuse-report/notification-recipient/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/abuse-report/notification-recipient/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/abuse-report/notification-recipient/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ isActive: true, name: 'test', method: "email" })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/abuse-report/notification-recipient/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/abuse-report/notification-recipient/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/abuse-report/notification-recipient/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/abuse-report/notification-recipient/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/abuse-report/notification-recipient/list.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/abuse-report/notification-recipient/list.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/abuse-report/notification-recipient/list.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/abuse-report/notification-recipient/list', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/abuse-report/notification-recipient/show.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/abuse-report/notification-recipient/show.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/abuse-report/notification-recipient/show.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/abuse-report/notification-recipient/show', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ id: 'aaaaaaaaaaa' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/abuse-report/notification-recipient/update.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/abuse-report/notification-recipient/update.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/abuse-report/notification-recipient/update.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/abuse-report/notification-recipient/update', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/abuse-user-reports.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/abuse-user-reports.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/abuse-user-reports.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/abuse-user-reports', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/accounts/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/accounts/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/accounts/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/accounts/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/accounts/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/accounts/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/accounts/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/accounts/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/accounts/find-by-email.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/accounts/find-by-email.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/accounts/find-by-email.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/accounts/find-by-email', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/ad/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/ad/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/ad/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/ad/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ url: 'test', memo: 'test', place: 'test', priority: 'test', ratio: 1, expiresAt: 1, startsAt: 1, imageUrl: 'test', dayOfWeek: 1 })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/ad/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/ad/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/ad/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/ad/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/ad/list.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/ad/list.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/ad/list.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/ad/list', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/ad/update.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/ad/update.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/ad/update.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/ad/update', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/announcements/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/announcements/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/announcements/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/announcements/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ title: 'test', text: 'test', imageUrl: 'test' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/announcements/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/announcements/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/announcements/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/announcements/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/announcements/list.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/announcements/list.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/announcements/list.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/announcements/list', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/announcements/update.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/announcements/update.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/announcements/update.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/announcements/update', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/avatar-decorations/copy.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/avatar-decorations/copy.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/avatar-decorations/copy.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/avatar-decorations/copy', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/avatar-decorations/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/avatar-decorations/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/avatar-decorations/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/avatar-decorations/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ name: 'test', description: 'test', url: 'test' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/avatar-decorations/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/avatar-decorations/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/avatar-decorations/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/avatar-decorations/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/avatar-decorations/list-remote.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/avatar-decorations/list-remote.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/avatar-decorations/list-remote.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/avatar-decorations/list-remote', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/avatar-decorations/list.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/avatar-decorations/list.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/avatar-decorations/list.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/avatar-decorations/list', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/avatar-decorations/update.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/avatar-decorations/update.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/avatar-decorations/update.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/avatar-decorations/update', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/captcha/current.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/captcha/current.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/captcha/current.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/captcha/current', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/captcha/save.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/captcha/save.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/captcha/save.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/captcha/save', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/delete-account.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/delete-account.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/delete-account.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/delete-account', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/delete-all-files-of-a-user.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/delete-all-files-of-a-user.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/delete-all-files-of-a-user.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/delete-all-files-of-a-user', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/drive/clean-remote-files.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/drive/clean-remote-files.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/drive/clean-remote-files.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/drive/clean-remote-files', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/drive/cleanup.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/drive/cleanup.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/drive/cleanup.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/drive/cleanup', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/drive/files.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/drive/files.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/drive/files.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/drive/files', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/drive/show-file.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/drive/show-file.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/drive/show-file.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/drive/show-file', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/emoji/add-aliases-bulk.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/emoji/add-aliases-bulk.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/emoji/add-aliases-bulk.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/emoji/add-aliases-bulk', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/emoji/add.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/emoji/add.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/emoji/add.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/emoji/add', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/emoji/copy.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/emoji/copy.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/emoji/copy.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/emoji/copy', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/emoji/delete-bulk.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/emoji/delete-bulk.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/emoji/delete-bulk.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/emoji/delete-bulk', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/emoji/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/emoji/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/emoji/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/emoji/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/emoji/import-zip.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/emoji/import-zip.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/emoji/import-zip.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/emoji/import-zip', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/emoji/list-remote.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/emoji/list-remote.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/emoji/list-remote.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/emoji/list-remote', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/emoji/list.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/emoji/list.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/emoji/list.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/emoji/list', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/emoji/remove-aliases-bulk.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/emoji/remove-aliases-bulk.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/emoji/remove-aliases-bulk.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/emoji/remove-aliases-bulk', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/emoji/set-aliases-bulk.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/emoji/set-aliases-bulk.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/emoji/set-aliases-bulk.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/emoji/set-aliases-bulk', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/emoji/set-category-bulk.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/emoji/set-category-bulk.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/emoji/set-category-bulk.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/emoji/set-category-bulk', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/emoji/set-license-bulk.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/emoji/set-license-bulk.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/emoji/set-license-bulk.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/emoji/set-license-bulk', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/emoji/steal.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/emoji/steal.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/emoji/steal.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/emoji/steal', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/emoji/update.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/emoji/update.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/emoji/update.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/emoji/update', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/federation/delete-all-files.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/federation/delete-all-files.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/federation/delete-all-files.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/federation/delete-all-files', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/federation/refresh-remote-instance-metadata.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/federation/refresh-remote-instance-metadata.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/federation/refresh-remote-instance-metadata.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/federation/refresh-remote-instance-metadata', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/federation/remove-all-following.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/federation/remove-all-following.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/federation/remove-all-following.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/federation/remove-all-following', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/federation/update-instance.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/federation/update-instance.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/federation/update-instance.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/federation/update-instance', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/forward-abuse-user-report.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/forward-abuse-user-report.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/forward-abuse-user-report.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/forward-abuse-user-report', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/full-index.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/full-index.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/full-index.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/full-index', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/get-index-stats.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/get-index-stats.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/get-index-stats.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/get-index-stats', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/get-table-stats.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/get-table-stats.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/get-table-stats.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/get-table-stats', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/get-user-ips.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/get-user-ips.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/get-user-ips.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/get-user-ips', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/invite/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/invite/create.test.ts
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/invite/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/invite/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/invite/list.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/invite/list.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/invite/list.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/invite/list', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/invite/revoke.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/invite/revoke.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/invite/revoke.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/invite/revoke', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/meta.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/meta.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/meta.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/meta', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/promo/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/promo/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/promo/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/promo/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ noteId: 'aaaaaaaaaaa', expiresAt: 1 })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/queue/clear.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/queue/clear.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/queue/clear.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/queue/clear', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/queue/deliver-delayed.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/queue/deliver-delayed.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/queue/deliver-delayed.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/queue/deliver-delayed', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/queue/inbox-delayed.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/queue/inbox-delayed.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/queue/inbox-delayed.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/queue/inbox-delayed', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/queue/jobs.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/queue/jobs.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/queue/jobs.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/queue/jobs', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/queue/promote-jobs.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/queue/promote-jobs.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/queue/promote-jobs.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/queue/promote-jobs', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/queue/queue-stats.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/queue/queue-stats.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/queue/queue-stats.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/queue/queue-stats', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/queue/queues.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/queue/queues.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/queue/queues.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/queue/queues', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/queue/remove-job.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/queue/remove-job.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/queue/remove-job.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/queue/remove-job', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/queue/retry-job.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/queue/retry-job.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/queue/retry-job.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/queue/retry-job', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/queue/show-job-logs.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/queue/show-job-logs.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/queue/show-job-logs.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/queue/show-job-logs', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/queue/show-job.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/queue/show-job.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/queue/show-job.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/queue/show-job', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/queue/stats.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/queue/stats.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/queue/stats.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/queue/stats', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/recreate-index.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/recreate-index.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/recreate-index.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/recreate-index', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/relays/add.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/relays/add.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/relays/add.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/relays/add', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/relays/list.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/relays/list.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/relays/list.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/relays/list', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/relays/remove.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/relays/remove.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/relays/remove.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/relays/remove', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/reset-password.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/reset-password.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/reset-password.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/reset-password', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/resolve-abuse-user-report.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/resolve-abuse-user-report.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/resolve-abuse-user-report.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/resolve-abuse-user-report', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/roles/assign.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/roles/assign.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/roles/assign.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/roles/assign', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/roles/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/roles/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/roles/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/roles/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ name: 'test', description: 'test', color: 'test', iconUrl: 'test', target: "manual", condFormula: {}, isPublic: true, isModerator: true, isAdministrator: true, asBadge: true, canEditMembersByModerator: true, displayOrder: 1, policies: {} })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/roles/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/roles/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/roles/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/roles/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/roles/list.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/roles/list.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/roles/list.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/roles/list', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/roles/show.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/roles/show.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/roles/show.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/roles/show', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ roleId: 'aaaaaaaaaaa' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/roles/unassign.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/roles/unassign.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/roles/unassign.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/roles/unassign', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/roles/update-default-policies.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/roles/update-default-policies.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/roles/update-default-policies.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/roles/update-default-policies', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/roles/update.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/roles/update.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/roles/update.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/roles/update', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/roles/users.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/roles/users.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/roles/users.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/roles/users', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/send-email.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/send-email.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/send-email.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/send-email', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/server-info.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/server-info.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/server-info.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/server-info', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/show-moderation-logs.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/show-moderation-logs.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/show-moderation-logs.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/show-moderation-logs', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/show-user.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/show-user.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/show-user.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/show-user', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/show-users.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/show-users.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/show-users.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/show-users', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/suspend-user.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/suspend-user.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/suspend-user.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/suspend-user', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/system-webhook/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/system-webhook/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/system-webhook/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/system-webhook/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ isActive: true, name: 'test', on: [], url: 'test' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/system-webhook/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/system-webhook/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/system-webhook/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/system-webhook/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/system-webhook/list.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/system-webhook/list.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/system-webhook/list.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/system-webhook/list', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/system-webhook/show.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/system-webhook/show.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/system-webhook/show.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/system-webhook/show', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ id: 'aaaaaaaaaaa' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/system-webhook/test.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/system-webhook/test.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/system-webhook/test.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/system-webhook/test', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/system-webhook/update.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/system-webhook/update.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/system-webhook/update.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/system-webhook/update', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/unset-user-avatar.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/unset-user-avatar.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/unset-user-avatar.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/unset-user-avatar', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/unset-user-banner.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/unset-user-banner.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/unset-user-banner.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/unset-user-banner', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/unset-user-mutual-link.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/unset-user-mutual-link.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/unset-user-mutual-link.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/unset-user-mutual-link', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/unsuspend-user.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/unsuspend-user.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/unsuspend-user.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/unsuspend-user', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/update-abuse-user-report.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/update-abuse-user-report.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/update-abuse-user-report.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/update-abuse-user-report', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/update-meta.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/update-meta.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/update-meta.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/update-meta', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/update-proxy-account.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/update-proxy-account.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/update-proxy-account.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/update-proxy-account', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/admin/update-user-note.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/admin/update-user-note.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/admin/update-user-note.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:admin/update-user-note', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/announcements.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/announcements.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/announcements.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:announcements', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/announcements/show.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/announcements/show.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/announcements/show.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:announcements/show', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ announcementId: 'aaaaaaaaaaa' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/antennas/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/antennas/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/antennas/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:antennas/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ name: 'test', src: "home", keywords: [], excludeKeywords: [], users: [], caseSensitive: true, withReplies: true, withFile: true, notify: true })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/antennas/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/antennas/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/antennas/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:antennas/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/antennas/list.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/antennas/list.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/antennas/list.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:antennas/list', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/antennas/notes.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/antennas/notes.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/antennas/notes.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:antennas/notes', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/antennas/show.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/antennas/show.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/antennas/show.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:antennas/show', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ antennaId: 'aaaaaaaaaaa' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/antennas/update.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/antennas/update.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/antennas/update.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:antennas/update', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/ap/fetch-outbox.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/ap/fetch-outbox.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/ap/fetch-outbox.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:ap/fetch-outbox', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/ap/get.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/ap/get.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/ap/get.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:ap/get', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/ap/show.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/ap/show.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/ap/show.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:ap/show', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ uri: 'test' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/app/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/app/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/app/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:app/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ name: 'test', description: 'test', permission: [] })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/app/show.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/app/show.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/app/show.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:app/show', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ appId: 'aaaaaaaaaaa' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/auth/accept.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/auth/accept.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/auth/accept.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:auth/accept', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/auth/session/generate.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/auth/session/generate.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/auth/session/generate.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:auth/session/generate', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/auth/session/show.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/auth/session/show.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/auth/session/show.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:auth/session/show', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ token: 'test' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/auth/session/userkey.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/auth/session/userkey.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/auth/session/userkey.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:auth/session/userkey', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/blocking/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/blocking/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/blocking/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:blocking/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ userId: 'aaaaaaaaaaa' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/blocking/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/blocking/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/blocking/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:blocking/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/blocking/list.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/blocking/list.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/blocking/list.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:blocking/list', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/bubble-game/ranking.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/bubble-game/ranking.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/bubble-game/ranking.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:bubble-game/ranking', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/bubble-game/register.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/bubble-game/register.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/bubble-game/register.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:bubble-game/register', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/charts/active-users.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/charts/active-users.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/charts/active-users.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:charts/active-users', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/charts/ap-request.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/charts/ap-request.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/charts/ap-request.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:charts/ap-request', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/charts/drive.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/charts/drive.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/charts/drive.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:charts/drive', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/charts/federation.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/charts/federation.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/charts/federation.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:charts/federation', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/charts/instance.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/charts/instance.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/charts/instance.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:charts/instance', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/charts/notes.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/charts/notes.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/charts/notes.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:charts/notes', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/charts/user/drive.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/charts/user/drive.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/charts/user/drive.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:charts/user/drive', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/charts/user/following.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/charts/user/following.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/charts/user/following.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:charts/user/following', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/charts/user/notes.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/charts/user/notes.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/charts/user/notes.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:charts/user/notes', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/charts/user/pv.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/charts/user/pv.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/charts/user/pv.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:charts/user/pv', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/charts/user/reactions.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/charts/user/reactions.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/charts/user/reactions.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:charts/user/reactions', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/charts/users.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/charts/users.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/charts/users.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:charts/users', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/history.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/history.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/history.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/history', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/messages/create-to-room.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/messages/create-to-room.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/messages/create-to-room.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/messages/create-to-room', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/messages/create-to-user.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/messages/create-to-user.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/messages/create-to-user.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/messages/create-to-user', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/messages/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/messages/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/messages/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/messages/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/messages/react.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/messages/react.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/messages/react.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/messages/react', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/messages/room-timeline.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/messages/room-timeline.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/messages/room-timeline.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/messages/room-timeline', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/messages/search.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/messages/search.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/messages/search.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/messages/search', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/messages/show.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/messages/show.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/messages/show.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/messages/show', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ messageId: 'aaaaaaaaaaa' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/messages/unreact.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/messages/unreact.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/messages/unreact.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/messages/unreact', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/messages/user-timeline.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/messages/user-timeline.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/messages/user-timeline.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/messages/user-timeline', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/read-all.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/read-all.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/read-all.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/read-all', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/rooms/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/rooms/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/rooms/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/rooms/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ name: 'test' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/rooms/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/rooms/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/rooms/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/rooms/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/rooms/invitations/cancel.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/rooms/invitations/cancel.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/rooms/invitations/cancel.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/rooms/invitations/cancel', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/rooms/invitations/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/rooms/invitations/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/rooms/invitations/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/rooms/invitations/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ roomId: 'aaaaaaaaaaa', userId: 'aaaaaaaaaaa' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/rooms/invitations/ignore.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/rooms/invitations/ignore.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/rooms/invitations/ignore.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/rooms/invitations/ignore', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/rooms/invitations/inbox.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/rooms/invitations/inbox.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/rooms/invitations/inbox.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/rooms/invitations/inbox', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/rooms/invitations/outbox.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/rooms/invitations/outbox.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/rooms/invitations/outbox.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/rooms/invitations/outbox', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/rooms/invitations/reject.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/rooms/invitations/reject.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/rooms/invitations/reject.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/rooms/invitations/reject', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/rooms/join.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/rooms/join.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/rooms/join.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/rooms/join', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/rooms/joining.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/rooms/joining.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/rooms/joining.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/rooms/joining', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/rooms/leave.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/rooms/leave.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/rooms/leave.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/rooms/leave', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/rooms/members.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/rooms/members.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/rooms/members.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/rooms/members', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/rooms/mute.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/rooms/mute.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/rooms/mute.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/rooms/mute', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/rooms/owned.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/rooms/owned.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/rooms/owned.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/rooms/owned', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/rooms/show.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/rooms/show.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/rooms/show.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/rooms/show', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ roomId: 'aaaaaaaaaaa' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/chat/rooms/update.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/chat/rooms/update.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/chat/rooms/update.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:chat/rooms/update', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/clips/add-note.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/clips/add-note.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/clips/add-note.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:clips/add-note', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/clips/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/clips/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/clips/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:clips/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ name: 'test' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/clips/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/clips/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/clips/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:clips/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/clips/favorite.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/clips/favorite.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/clips/favorite.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:clips/favorite', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/clips/list.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/clips/list.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/clips/list.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:clips/list', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/clips/my-favorites.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/clips/my-favorites.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/clips/my-favorites.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:clips/my-favorites', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/clips/notes.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/clips/notes.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/clips/notes.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:clips/notes', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/clips/remove-note.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/clips/remove-note.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/clips/remove-note.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:clips/remove-note', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/clips/show.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/clips/show.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/clips/show.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:clips/show', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ clipId: 'test' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/clips/unfavorite.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/clips/unfavorite.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/clips/unfavorite.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:clips/unfavorite', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/clips/update.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/clips/update.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/clips/update.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:clips/update', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/drive.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/drive.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/drive.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:drive', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/drive/files.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/drive/files.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/drive/files.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:drive/files', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/drive/files/attached-chat-messages.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/drive/files/attached-chat-messages.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/drive/files/attached-chat-messages.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:drive/files/attached-chat-messages', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/drive/files/attached-notes.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/drive/files/attached-notes.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/drive/files/attached-notes.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:drive/files/attached-notes', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/drive/files/check-existence.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/drive/files/check-existence.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/drive/files/check-existence.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:drive/files/check-existence', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/drive/files/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/drive/files/create.test.ts
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/drive/files/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:drive/files/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/drive/files/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/drive/files/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/drive/files/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:drive/files/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/drive/files/find-by-hash.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/drive/files/find-by-hash.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/drive/files/find-by-hash.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:drive/files/find-by-hash', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/drive/files/find.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/drive/files/find.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/drive/files/find.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:drive/files/find', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/drive/files/move-bulk.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/drive/files/move-bulk.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/drive/files/move-bulk.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:drive/files/move-bulk', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/drive/files/show.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/drive/files/show.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/drive/files/show.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:drive/files/show', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ fileId: 'aaaaaaaaaaa' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/drive/files/update.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/drive/files/update.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/drive/files/update.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:drive/files/update', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/drive/files/upload-from-url.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/drive/files/upload-from-url.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/drive/files/upload-from-url.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:drive/files/upload-from-url', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/drive/folders.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/drive/folders.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/drive/folders.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:drive/folders', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/drive/folders/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/drive/folders/create.test.ts
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/drive/folders/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:drive/folders/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/drive/folders/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/drive/folders/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/drive/folders/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:drive/folders/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/drive/folders/find.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/drive/folders/find.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/drive/folders/find.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:drive/folders/find', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/drive/folders/show.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/drive/folders/show.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/drive/folders/show.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:drive/folders/show', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ folderId: 'aaaaaaaaaaa' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/drive/folders/update.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/drive/folders/update.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/drive/folders/update.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:drive/folders/update', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/drive/stream.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/drive/stream.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/drive/stream.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:drive/stream', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/email-address/available.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/email-address/available.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/email-address/available.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:email-address/available', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/emoji.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/emoji.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/emoji.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:emoji', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/emojis.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/emojis.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/emojis.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:emojis', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/endpoint.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/endpoint.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/endpoint.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:endpoint', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/endpoints.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/endpoints.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/endpoints.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:endpoints', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/export-custom-emojis.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/export-custom-emojis.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/export-custom-emojis.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:export-custom-emojis', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/federation/followers.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/federation/followers.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/federation/followers.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:federation/followers', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/federation/following.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/federation/following.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/federation/following.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:federation/following', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/federation/instances.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/federation/instances.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/federation/instances.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:federation/instances', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/federation/remote-software.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/federation/remote-software.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/federation/remote-software.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:federation/remote-software', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/federation/show-instance.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/federation/show-instance.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/federation/show-instance.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:federation/show-instance', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/federation/stats.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/federation/stats.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/federation/stats.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:federation/stats', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/federation/update-remote-user.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/federation/update-remote-user.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/federation/update-remote-user.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:federation/update-remote-user', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/federation/users.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/federation/users.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/federation/users.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:federation/users', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/fetch-external-resources.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/fetch-external-resources.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/fetch-external-resources.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:fetch-external-resources', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/fetch-rss.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/fetch-rss.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/fetch-rss.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:fetch-rss', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/flash/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/flash/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/flash/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:flash/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ title: 'test', summary: 'test', script: 'test', permissions: [] })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/flash/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/flash/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/flash/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:flash/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/flash/featured.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/flash/featured.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/flash/featured.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:flash/featured', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/flash/gen-token.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/flash/gen-token.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/flash/gen-token.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:flash/gen-token', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/flash/like.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/flash/like.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/flash/like.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:flash/like', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/flash/my-likes.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/flash/my-likes.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/flash/my-likes.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:flash/my-likes', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/flash/my.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/flash/my.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/flash/my.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:flash/my', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/flash/search.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/flash/search.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/flash/search.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:flash/search', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/flash/show.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/flash/show.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/flash/show.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:flash/show', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ flashId: 'test' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/flash/unlike.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/flash/unlike.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/flash/unlike.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:flash/unlike', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/flash/update.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/flash/update.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/flash/update.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:flash/update', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/following/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/following/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/following/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:following/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ userId: 'aaaaaaaaaaa' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/following/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/following/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/following/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:following/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/following/invalidate.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/following/invalidate.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/following/invalidate.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:following/invalidate', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/following/requests/accept.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/following/requests/accept.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/following/requests/accept.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:following/requests/accept', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/following/requests/cancel.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/following/requests/cancel.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/following/requests/cancel.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:following/requests/cancel', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/following/requests/list.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/following/requests/list.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/following/requests/list.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:following/requests/list', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/following/requests/reject.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/following/requests/reject.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/following/requests/reject.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:following/requests/reject', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/following/requests/sent.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/following/requests/sent.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/following/requests/sent.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:following/requests/sent', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/following/update-all.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/following/update-all.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/following/update-all.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:following/update-all', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/following/update.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/following/update.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/following/update.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:following/update', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/gallery/featured.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/gallery/featured.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/gallery/featured.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:gallery/featured', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/gallery/popular.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/gallery/popular.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/gallery/popular.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:gallery/popular', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/gallery/posts.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/gallery/posts.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/gallery/posts.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:gallery/posts', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/gallery/posts/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/gallery/posts/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/gallery/posts/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:gallery/posts/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/gallery/posts/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/gallery/posts/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/gallery/posts/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:gallery/posts/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/gallery/posts/like.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/gallery/posts/like.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/gallery/posts/like.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:gallery/posts/like', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/gallery/posts/show.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/gallery/posts/show.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/gallery/posts/show.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:gallery/posts/show', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ postId: 'aaaaaaaaaaa' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/gallery/posts/unlike.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/gallery/posts/unlike.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/gallery/posts/unlike.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:gallery/posts/unlike', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/gallery/posts/update.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/gallery/posts/update.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/gallery/posts/update.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:gallery/posts/update', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/get-avatar-decorations.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/get-avatar-decorations.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/get-avatar-decorations.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:get-avatar-decorations', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/get-online-users-count.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/get-online-users-count.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/get-online-users-count.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:get-online-users-count', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/hashtags/list.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/hashtags/list.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/hashtags/list.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:hashtags/list', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/hashtags/search.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/hashtags/search.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/hashtags/search.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:hashtags/search', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/hashtags/show.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/hashtags/show.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/hashtags/show.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:hashtags/show', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ tag: 'test' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/hashtags/trend.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/hashtags/trend.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/hashtags/trend.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:hashtags/trend', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/hashtags/users.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/hashtags/users.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/hashtags/users.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:hashtags/users', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/2fa/done.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/2fa/done.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/2fa/done.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/2fa/done', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/2fa/key-done.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/2fa/key-done.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/2fa/key-done.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/2fa/key-done', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/2fa/password-less.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/2fa/password-less.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/2fa/password-less.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/2fa/password-less', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/2fa/register-key.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/2fa/register-key.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/2fa/register-key.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/2fa/register-key', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/2fa/register.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/2fa/register.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/2fa/register.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/2fa/register', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/2fa/remove-key.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/2fa/remove-key.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/2fa/remove-key.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/2fa/remove-key', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/2fa/unregister.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/2fa/unregister.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/2fa/unregister.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/2fa/unregister', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/2fa/update-key.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/2fa/update-key.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/2fa/update-key.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/2fa/update-key', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/apps.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/apps.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/apps.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/apps', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/authorized-apps.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/authorized-apps.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/authorized-apps.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/authorized-apps', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/auto-delete-settings.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/auto-delete-settings.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/auto-delete-settings.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/auto-delete-settings', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/change-password.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/change-password.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/change-password.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/change-password', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/claim-achievement.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/claim-achievement.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/claim-achievement.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/claim-achievement', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/delete-account.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/delete-account.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/delete-account.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/delete-account', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/export-antennas.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/export-antennas.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/export-antennas.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/export-antennas', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/export-blocking.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/export-blocking.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/export-blocking.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/export-blocking', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/export-clips.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/export-clips.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/export-clips.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/export-clips', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/export-favorites.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/export-favorites.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/export-favorites.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/export-favorites', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/export-following.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/export-following.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/export-following.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/export-following', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/export-mute.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/export-mute.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/export-mute.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/export-mute', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/export-notes.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/export-notes.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/export-notes.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/export-notes', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/export-user-lists.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/export-user-lists.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/export-user-lists.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/export-user-lists', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/favorites.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/favorites.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/favorites.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/favorites', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/gallery/likes.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/gallery/likes.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/gallery/likes.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/gallery/likes', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/gallery/posts.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/gallery/posts.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/gallery/posts.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/gallery/posts', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/import-antennas.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/import-antennas.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/import-antennas.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/import-antennas', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/import-blocking.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/import-blocking.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/import-blocking.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/import-blocking', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/import-following.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/import-following.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/import-following.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/import-following', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/import-muting.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/import-muting.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/import-muting.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/import-muting', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/import-user-lists.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/import-user-lists.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/import-user-lists.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/import-user-lists', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/move.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/move.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/move.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/move', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/notifications-grouped.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/notifications-grouped.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/notifications-grouped.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/notifications-grouped', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/notifications.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/notifications.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/notifications.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/notifications', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/page-likes.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/page-likes.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/page-likes.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/page-likes', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/pages.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/pages.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/pages.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/pages', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/pin.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/pin.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/pin.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/pin', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/read-all-unread-notes.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/read-all-unread-notes.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/read-all-unread-notes.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/read-all-unread-notes', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/read-announcement.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/read-announcement.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/read-announcement.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/read-announcement', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/regenerate-token.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/regenerate-token.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/regenerate-token.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/regenerate-token', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/registry/get-all.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/registry/get-all.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/registry/get-all.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/registry/get-all', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/registry/get-detail.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/registry/get-detail.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/registry/get-detail.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/registry/get-detail', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/registry/get.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/registry/get.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/registry/get.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/registry/get', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/registry/keys-with-type.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/registry/keys-with-type.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/registry/keys-with-type.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/registry/keys-with-type', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/registry/keys.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/registry/keys.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/registry/keys.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/registry/keys', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/registry/remove.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/registry/remove.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/registry/remove.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/registry/remove', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/registry/scopes-with-domain.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/registry/scopes-with-domain.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/registry/scopes-with-domain.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/registry/scopes-with-domain', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/registry/set.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/registry/set.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/registry/set.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/registry/set', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/revoke-token.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/revoke-token.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/revoke-token.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/revoke-token', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/signin-history.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/signin-history.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/signin-history.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/signin-history', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/truncate-account.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/truncate-account.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/truncate-account.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/truncate-account', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/unpin.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/unpin.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/unpin.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/unpin', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/update-auto-delete-settings.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/update-auto-delete-settings.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/update-auto-delete-settings.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/update-auto-delete-settings', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/update-email.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/update-email.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/update-email.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/update-email', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/user-group-invites.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/user-group-invites.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/user-group-invites.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/user-group-invites', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/webhooks/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/webhooks/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/webhooks/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/webhooks/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ name: 'test', url: 'test', on: [] })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/webhooks/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/webhooks/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/webhooks/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/webhooks/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/webhooks/list.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/webhooks/list.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/webhooks/list.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/webhooks/list', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/webhooks/show.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/webhooks/show.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/webhooks/show.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/webhooks/show', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ webhookId: 'aaaaaaaaaaa' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/webhooks/test.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/webhooks/test.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/webhooks/test.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/webhooks/test', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/i/webhooks/update.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/i/webhooks/update.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/i/webhooks/update.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:i/webhooks/update', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/invite/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/invite/create.test.ts
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/invite/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:invite/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/invite/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/invite/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/invite/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:invite/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/invite/limit.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/invite/limit.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/invite/limit.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:invite/limit', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/invite/list.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/invite/list.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/invite/list.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:invite/list', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/meta.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/meta.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/meta.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:meta', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/miauth/gen-token.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/miauth/gen-token.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/miauth/gen-token.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:miauth/gen-token', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/mute/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/mute/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/mute/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:mute/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ userId: 'aaaaaaaaaaa' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/mute/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/mute/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/mute/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:mute/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/mute/list.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/mute/list.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/mute/list.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:mute/list', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/my/apps.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/my/apps.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/my/apps.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:my/apps', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/advanced-search.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/advanced-search.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/advanced-search.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/advanced-search', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/bubble-timeline.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/bubble-timeline.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/bubble-timeline.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/bubble-timeline', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/children.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/children.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/children.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/children', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/clips.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/clips.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/clips.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/clips', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/conversation.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/conversation.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/conversation.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/conversation', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/drafts/count.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/drafts/count.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/drafts/count.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/drafts/count', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/drafts/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/drafts/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/drafts/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/drafts/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/drafts/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/drafts/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/drafts/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/drafts/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/drafts/list.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/drafts/list.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/drafts/list.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/drafts/list', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/drafts/update.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/drafts/update.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/drafts/update.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/drafts/update', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/events/search.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/events/search.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/events/search.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/events/search', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/favorites/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/favorites/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/favorites/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/favorites/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ noteId: 'aaaaaaaaaaa' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/favorites/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/favorites/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/favorites/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/favorites/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/featured.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/featured.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/featured.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/featured', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/global-timeline.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/global-timeline.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/global-timeline.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/global-timeline', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/history.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/history.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/history.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/history', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/hybrid-timeline.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/hybrid-timeline.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/hybrid-timeline.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/hybrid-timeline', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/local-timeline.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/local-timeline.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/local-timeline.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/local-timeline', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/mentions.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/mentions.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/mentions.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/mentions', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/polls/recommendation.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/polls/recommendation.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/polls/recommendation.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/polls/recommendation', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/polls/translate.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/polls/translate.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/polls/translate.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/polls/translate', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/polls/vote.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/polls/vote.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/polls/vote.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/polls/vote', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/reactions.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/reactions.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/reactions.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/reactions', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/reactions/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/reactions/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/reactions/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/reactions/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ noteId: 'aaaaaaaaaaa', reaction: 'test' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/reactions/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/reactions/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/reactions/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/reactions/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/renotes.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/renotes.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/renotes.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/renotes', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/replies.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/replies.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/replies.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/replies', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/search-by-tag.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/search-by-tag.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/search-by-tag.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/search-by-tag', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/search.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/search.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/search.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/search', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/show-partial-bulk.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/show-partial-bulk.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/show-partial-bulk.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/show-partial-bulk', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/show.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/show.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/show.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/show', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ noteId: 'aaaaaaaaaaa' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/state.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/state.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/state.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/state', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/thread-muting/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/thread-muting/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/thread-muting/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/thread-muting/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ noteId: 'aaaaaaaaaaa' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/thread-muting/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/thread-muting/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/thread-muting/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/thread-muting/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/timeline.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/timeline.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/timeline.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/timeline', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/translate.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/translate.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/translate.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/translate', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/unrenote.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/unrenote.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/unrenote.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/unrenote', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/update.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/update.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/update.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/update', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notes/user-list-timeline.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notes/user-list-timeline.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notes/user-list-timeline.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notes/user-list-timeline', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notifications/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notifications/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notifications/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notifications/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ body: 'test' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notifications/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notifications/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notifications/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notifications/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notifications/flush.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notifications/flush.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notifications/flush.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notifications/flush', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notifications/mark-all-as-read.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notifications/mark-all-as-read.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notifications/mark-all-as-read.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notifications/mark-all-as-read', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/notifications/test-notification.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/notifications/test-notification.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/notifications/test-notification.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:notifications/test-notification', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/official-tags/show.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/official-tags/show.test.ts
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/official-tags/show.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:official-tags/show', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/official-tags/update.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/official-tags/update.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/official-tags/update.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:official-tags/update', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/page-push.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/page-push.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/page-push.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:page-push', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/pages/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/pages/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/pages/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:pages/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ title: 'test', name: 'test', content: [], variables: [], script: 'test' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/pages/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/pages/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/pages/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:pages/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/pages/featured.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/pages/featured.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/pages/featured.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:pages/featured', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/pages/like.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/pages/like.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/pages/like.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:pages/like', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/pages/show.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/pages/show.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/pages/show.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:pages/show', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ pageId: 'aaaaaaaaaaa' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/pages/unlike.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/pages/unlike.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/pages/unlike.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:pages/unlike', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/pages/update.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/pages/update.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/pages/update.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:pages/update', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/ping.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/ping.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/ping.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:ping', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/pinned-users.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/pinned-users.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/pinned-users.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:pinned-users', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/promo/read.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/promo/read.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/promo/read.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:promo/read', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/renote-mute/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/renote-mute/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/renote-mute/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:renote-mute/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ userId: 'aaaaaaaaaaa' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/renote-mute/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/renote-mute/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/renote-mute/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:renote-mute/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/renote-mute/list.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/renote-mute/list.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/renote-mute/list.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:renote-mute/list', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/request-reset-password.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/request-reset-password.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/request-reset-password.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:request-reset-password', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/reset-db.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/reset-db.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/reset-db.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:reset-db', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/reset-password.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/reset-password.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/reset-password.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:reset-password', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/retention.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/retention.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/retention.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:retention', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/reversi/cancel-match.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/reversi/cancel-match.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/reversi/cancel-match.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:reversi/cancel-match', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/reversi/games.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/reversi/games.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/reversi/games.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:reversi/games', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/reversi/invitations.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/reversi/invitations.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/reversi/invitations.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:reversi/invitations', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/reversi/match.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/reversi/match.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/reversi/match.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:reversi/match', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/reversi/show-game.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/reversi/show-game.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/reversi/show-game.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:reversi/show-game', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/reversi/surrender.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/reversi/surrender.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/reversi/surrender.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:reversi/surrender', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/reversi/verify.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/reversi/verify.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/reversi/verify.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:reversi/verify', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/roles/list.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/roles/list.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/roles/list.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:roles/list', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/roles/notes.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/roles/notes.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/roles/notes.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:roles/notes', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/roles/show.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/roles/show.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/roles/show.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:roles/show', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ roleId: 'aaaaaaaaaaa' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/roles/users.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/roles/users.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/roles/users.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:roles/users', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/server-info.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/server-info.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/server-info.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:server-info', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/stats.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/stats.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/stats.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:stats', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/sw/register.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/sw/register.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/sw/register.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:sw/register', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/sw/show-registration.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/sw/show-registration.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/sw/show-registration.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:sw/show-registration', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/sw/unregister.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/sw/unregister.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/sw/unregister.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:sw/unregister', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/sw/update-registration.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/sw/update-registration.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/sw/update-registration.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:sw/update-registration', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/test.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/test.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/test.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:test', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/username/available.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/username/available.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/username/available.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:username/available', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/achievements.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/achievements.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/achievements.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/achievements', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/clips.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/clips.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/clips.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/clips', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/featured-notes.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/featured-notes.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/featured-notes.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/featured-notes', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/flashs.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/flashs.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/flashs.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/flashs', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/followers.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/followers.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/followers.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/followers', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/following.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/following.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/following.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/following', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/gallery/posts.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/gallery/posts.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/gallery/posts.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/gallery/posts', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/get-frequently-replied-users.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/get-frequently-replied-users.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/get-frequently-replied-users.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/get-frequently-replied-users', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/groups/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/groups/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/groups/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/groups/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ name: 'test' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/groups/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/groups/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/groups/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/groups/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/groups/invitations/accept.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/groups/invitations/accept.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/groups/invitations/accept.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/groups/invitations/accept', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/groups/invitations/reject.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/groups/invitations/reject.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/groups/invitations/reject.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/groups/invitations/reject', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/groups/invite.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/groups/invite.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/groups/invite.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/groups/invite', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/groups/joined.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/groups/joined.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/groups/joined.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/groups/joined', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/groups/leave.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/groups/leave.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/groups/leave.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/groups/leave', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/groups/owned.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/groups/owned.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/groups/owned.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/groups/owned', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/groups/pull.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/groups/pull.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/groups/pull.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/groups/pull', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/groups/show.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/groups/show.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/groups/show.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/groups/show', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ groupId: 'aaaaaaaaaaa' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/groups/transfer.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/groups/transfer.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/groups/transfer.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/groups/transfer', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/groups/update.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/groups/update.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/groups/update.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/groups/update', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/lists/create-from-public.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/lists/create-from-public.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/lists/create-from-public.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/lists/create-from-public', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/lists/create.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/lists/create.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/lists/create.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/lists/create', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ name: 'test' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/lists/delete.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/lists/delete.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/lists/delete.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/lists/delete', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/lists/favorite.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/lists/favorite.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/lists/favorite.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/lists/favorite', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/lists/get-memberships.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/lists/get-memberships.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/lists/get-memberships.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/lists/get-memberships', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/lists/list.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/lists/list.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/lists/list.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/lists/list', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/lists/show.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/lists/show.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/lists/show.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/lists/show', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('accept with required fields', () => expect(v({ listId: 'aaaaaaaaaaa' })).toBe(VALID));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/lists/unfavorite.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/lists/unfavorite.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/lists/unfavorite.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/lists/unfavorite', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/lists/update.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/lists/update.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/lists/update.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/lists/update', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/notes.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/notes.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/notes.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/notes', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/pages.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/pages.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/pages.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/pages', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/reactions.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/reactions.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/reactions.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/reactions', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/recommendation.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/recommendation.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/recommendation.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/recommendation', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/relation.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/relation.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/relation.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/relation', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/report-abuse.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/report-abuse.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/report-abuse.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/report-abuse', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/search-by-username-and-host.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/search-by-username-and-host.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/search-by-username-and-host.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/search-by-username-and-host', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/search.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/search.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/search.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/search', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/stats.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/stats.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/stats.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/stats', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/translate.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/translate.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/translate.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/translate', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/users/update-memo.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/users/update-memo.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/users/update-memo.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:users/update-memo', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/v2/admin/emoji/list.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/v2/admin/emoji/list.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/v2/admin/emoji/list.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:v2/admin/emoji/list', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('accept empty', () => expect(v({})).toBe(VALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});

--- a/packages/backend/test/unit/server/api/endpoints/verify-email.test.ts
+++ b/packages/backend/test/unit/server/api/endpoints/verify-email.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { getValidator } from '../../../../prelude/get-api-validator.js';
+import { paramDef } from '@/server/api/endpoints/verify-email.js';
+
+const VALID = true;
+const INVALID = false;
+
+describe('api:verify-email', () => {
+	describe('validation', () => {
+		const v = getValidator(paramDef);
+
+		test('reject empty', () => expect(v({})).toBe(INVALID));
+		test('validator is a function', () => expect(typeof v).toBe('function'));
+	});
+});


### PR DESCRIPTION
## Summary
全454エンドポイントのparamDef JSONスキーマバリデーションテストを自動生成

## Key Changes
- 456ファイル、+9,813行
- `scripts/generate-endpoint-tests.cjs`: テスト自動生成スクリプト
- `scripts/move-endpoint-tests.cjs`: src/からtest/への移動スクリプト
- `test/unit/server/api/endpoints/`: 454テストファイル
- 各テストはparamDefが有効なJSONスキーマであること、requiredフィールドの有無に基づく空オブジェクトの受理/拒否を検証

## Testing
```bash
pnpm --filter backend jest -- --testPathPattern='test/unit/server/api/endpoints/'
```

## Note
- PR1(Jest基盤)がマージされていることが前提

## Related
テストカバレッジ向上PRシリーズ [3/5]

🤖 Generated with [Claude Code](https://claude.com/claude-code)