### PR TITLE
test(backend): core/entities/activitypub/chartのDIインスタンス化テスト追加 [4/5]

### DIFF
--- a/packages/backend/scripts/generate-service-tests.cjs
+++ b/packages/backend/scripts/generate-service-tests.cjs
@@ -1,0 +1,95 @@
+/**
+ * Generates service instantiation tests for core/entities, core/activitypub, core/chart, queue/processors.
+ * These tests verify that services can be properly instantiated through NestJS DI.
+ * Run: node scripts/generate-service-tests.cjs
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const dirs = [
+	{ dir: 'src/core', testDir: 'test/unit/core', importBase: '@/core' },
+	{ dir: 'src/core/entities', testDir: 'test/unit/entities', importBase: '@/core/entities' },
+	{ dir: 'src/core/activitypub', testDir: 'test/unit/activitypub', importBase: '@/core/activitypub' },
+	{ dir: 'src/core/activitypub/models', testDir: 'test/unit/activitypub/models', importBase: '@/core/activitypub/models' },
+	{ dir: 'src/core/chart/charts', testDir: 'test/unit/chart/charts', importBase: '@/core/chart/charts' },
+];
+
+let generated = 0;
+let skipped = 0;
+
+for (const { dir, testDir, importBase } of dirs) {
+	if (!fs.existsSync(dir)) continue;
+
+	const files = fs.readdirSync(dir).filter(f =>
+		f.endsWith('.ts') &&
+		!f.endsWith('.test.ts') &&
+		!f.endsWith('.d.ts') &&
+		!f.startsWith('index') &&
+		fs.statSync(path.join(dir, f)).isFile()
+	);
+
+	for (const file of files) {
+		const content = fs.readFileSync(path.join(dir, file), 'utf-8');
+
+		// Extract class name - look for "export class" or "export default class"
+		const classMatch = content.match(/export\s+(?:default\s+)?class\s+(\w+)/);
+		if (!classMatch) continue;
+
+		const className = classMatch[1];
+		const baseName = file.replace('.ts', '');
+		const testFile = path.join(testDir, `${baseName}.ts`);
+
+		// Check if test already exists (in any known location)
+		const existingTestPaths = [
+			testFile,
+			`test/unit/${baseName}.ts`,
+			`test/unit/core/${baseName}.ts`,
+		];
+		if (existingTestPaths.some(p => fs.existsSync(p))) {
+			skipped++;
+			continue;
+		}
+
+		// Check if it's a default export (chart classes use default export)
+		const isDefault = content.includes('export default class');
+
+		fs.mkdirSync(testDir, { recursive: true });
+
+		const importStatement = isDefault
+			? `import ${className} from '${importBase}/${baseName}.js';`
+			: `import { ${className} } from '${importBase}/${baseName}.js';`;
+
+		const testContent = `/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+${importStatement}
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('${className}', () => {
+	let service: ${className};
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<${className}>(${className});
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});
+`;
+
+		fs.writeFileSync(testFile, testContent);
+		generated++;
+	}
+}
+
+console.log(`Generated: ${generated}, Skipped: ${skipped}`);

--- a/packages/backend/test/unit/activitypub/ApAudienceService.ts
+++ b/packages/backend/test/unit/activitypub/ApAudienceService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ApAudienceService } from '@/core/activitypub/ApAudienceService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ApAudienceService', () => {
+	let service: ApAudienceService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ApAudienceService>(ApAudienceService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/activitypub/ApDbResolverService.ts
+++ b/packages/backend/test/unit/activitypub/ApDbResolverService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ApDbResolverService } from '@/core/activitypub/ApDbResolverService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ApDbResolverService', () => {
+	let service: ApDbResolverService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ApDbResolverService>(ApDbResolverService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/activitypub/ApDeliverManagerService.ts
+++ b/packages/backend/test/unit/activitypub/ApDeliverManagerService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ApDeliverManagerService } from '@/core/activitypub/ApDeliverManagerService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ApDeliverManagerService', () => {
+	let service: ApDeliverManagerService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ApDeliverManagerService>(ApDeliverManagerService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/activitypub/ApInboxService.ts
+++ b/packages/backend/test/unit/activitypub/ApInboxService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ApInboxService } from '@/core/activitypub/ApInboxService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ApInboxService', () => {
+	let service: ApInboxService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ApInboxService>(ApInboxService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/activitypub/ApLoggerService.ts
+++ b/packages/backend/test/unit/activitypub/ApLoggerService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ApLoggerService } from '@/core/activitypub/ApLoggerService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ApLoggerService', () => {
+	let service: ApLoggerService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ApLoggerService>(ApLoggerService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/activitypub/ApRendererService.ts
+++ b/packages/backend/test/unit/activitypub/ApRendererService.ts
@@ -1,0 +1,200 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ApRendererService } from '@/core/activitypub/ApRendererService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ApRendererService', () => {
+	let service: ApRendererService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ApRendererService>(ApRendererService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+
+	describe('renderAccept', () => {
+		test('renders Accept activity', () => {
+			const result = service.renderAccept('https://example.com/follow/1', { id: 'user1', host: null });
+			expect(result.type).toBe('Accept');
+			expect(result.object).toBe('https://example.com/follow/1');
+		});
+	});
+
+	describe('renderBlock', () => {
+		test('renders Block activity', () => {
+			const blocking = {
+				id: 'block1',
+				blockerId: 'user1',
+				blockeeId: 'user2',
+				blocker: { id: 'user1', host: null, uri: null } as any,
+				blockee: { id: 'user2', host: 'remote.example.com', uri: 'https://remote.example.com/users/user2' } as any,
+			} as any;
+			const result = service.renderBlock(blocking);
+			expect(result.type).toBe('Block');
+		});
+	});
+
+	describe('renderDelete', () => {
+		test('renders Delete activity', () => {
+			const result = service.renderDelete({ type: 'Tombstone', id: 'https://example.com/notes/1' } as any, { id: 'user1', host: null });
+			expect(result.type).toBe('Delete');
+		});
+	});
+
+	describe('renderHashtag', () => {
+		test('renders hashtag', () => {
+			const result = service.renderHashtag('test');
+			expect(result.type).toBe('Hashtag');
+			expect(result.name).toBe('#test');
+		});
+	});
+
+	describe('renderTombstone', () => {
+		test('renders Tombstone', () => {
+			const result = service.renderTombstone('https://example.com/notes/1');
+			expect(result.type).toBe('Tombstone');
+			expect(result.id).toBe('https://example.com/notes/1');
+		});
+	});
+
+	describe('renderUndo', () => {
+		test('renders Undo activity', () => {
+			const result = service.renderUndo({ type: 'Follow' } as any, { id: 'user1' });
+			expect(result.type).toBe('Undo');
+			expect(result.object).toEqual({ type: 'Follow' });
+		});
+	});
+
+	describe('renderUpdate', () => {
+		test('renders Update activity', () => {
+			const result = service.renderUpdate({ type: 'Person' } as any, { id: 'user1' });
+			expect(result.type).toBe('Update');
+		});
+	});
+
+	describe('renderReject', () => {
+		test('renders Reject activity', () => {
+			const result = service.renderReject('https://example.com/follow/1', { id: 'user1' });
+			expect(result.type).toBe('Reject');
+			expect(result.object).toBe('https://example.com/follow/1');
+		});
+	});
+
+	describe('addContext', () => {
+		test('adds @context to activity', () => {
+			const activity = { type: 'Create', id: 'test' } as any;
+			const result = service.addContext(activity);
+			expect(result['@context']).toBeDefined();
+		});
+	});
+
+	describe('renderAdd', () => {
+		test('renders Add activity', () => {
+			const user = { id: 'user1', host: null, uri: null } as any;
+			const result = service.renderAdd(user, 'https://example.com/collection', 'https://example.com/notes/1');
+			expect(result.type).toBe('Add');
+		});
+	});
+
+	describe('renderRemove', () => {
+		test('renders Remove activity', () => {
+			const result = service.renderRemove({ id: 'user1' }, 'https://example.com/collection', 'https://example.com/notes/1');
+			expect(result.type).toBe('Remove');
+		});
+	});
+
+	describe('renderFlag', () => {
+		test('renders Flag activity', () => {
+			const user = { id: 'user1', host: null, uri: null } as any;
+			const result = service.renderFlag(user, 'https://remote.example.com/users/bad', 'spam report');
+			expect(result.type).toBe('Flag');
+			expect(result.content).toBe('spam report');
+		});
+	});
+
+	describe('renderOrderedCollection', () => {
+		test('renders OrderedCollection', () => {
+			const result = service.renderOrderedCollection('https://example.com/collection', 5);
+			expect(result.type).toBe('OrderedCollection');
+			expect(result.totalItems).toBe(5);
+		});
+
+		test('with ordered items', () => {
+			const items = [{ type: 'Note', id: 'n1' }] as any[];
+			const result = service.renderOrderedCollection(null, 1, undefined, undefined, items);
+			expect(result.orderedItems).toEqual(items);
+		});
+	});
+
+	describe('renderOrderedCollectionPage', () => {
+		test('renders OrderedCollectionPage', () => {
+			const result = service.renderOrderedCollectionPage(
+				'https://example.com/collection?page=1',
+				10,
+				[{ type: 'Note' }],
+				'https://example.com/collection',
+			);
+			expect(result.type).toBe('OrderedCollectionPage');
+			expect(result.partOf).toBe('https://example.com/collection');
+		});
+	});
+
+	describe('renderDocument', () => {
+		test('renders Document for drive file', () => {
+			const file = {
+				id: 'file1',
+				type: 'image/png',
+				uri: null,
+				url: 'https://example.com/files/file1.png',
+				name: 'test.png',
+				isSensitive: false,
+				comment: 'A test image',
+			} as any;
+			const result = service.renderDocument(file);
+			expect(result.type).toBe('Document');
+			expect(result.mediaType).toBe('image/png');
+		});
+	});
+
+	describe('renderMention', () => {
+		test('renders mention for local user', () => {
+			const user = { id: 'user1', host: null, username: 'alice', uri: null } as any;
+			const result = service.renderMention(user);
+			expect(result.type).toBe('Mention');
+		});
+
+		test('renders mention for remote user', () => {
+			const user = { id: 'user2', host: 'remote.example.com', username: 'bob', uri: 'https://remote.example.com/users/bob' } as any;
+			const result = service.renderMention(user);
+			expect(result.type).toBe('Mention');
+			expect(result.href).toBe('https://remote.example.com/users/bob');
+		});
+	});
+
+	describe('renderEmoji', () => {
+		test('renders Emoji', () => {
+			const emoji = {
+				name: 'test_emoji',
+				host: null,
+				publicUrl: 'https://example.com/emoji/test.png',
+				originalUrl: 'https://example.com/emoji/test.png',
+				type: 'image/png',
+				updatedAt: new Date(),
+			} as any;
+			const result = service.renderEmoji(emoji);
+			expect(result.type).toBe('Emoji');
+			expect(result.name).toBe(':test_emoji:');
+		});
+	});
+});

--- a/packages/backend/test/unit/activitypub/JsonLdService.ts
+++ b/packages/backend/test/unit/activitypub/JsonLdService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { JsonLdService } from '@/core/activitypub/JsonLdService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('JsonLdService', () => {
+	let service: JsonLdService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<JsonLdService>(JsonLdService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/activitypub/models/ApClipService.ts
+++ b/packages/backend/test/unit/activitypub/models/ApClipService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ApClipService } from '@/core/activitypub/models/ApClipService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ApClipService', () => {
+	let service: ApClipService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ApClipService>(ApClipService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/activitypub/models/ApEventService.ts
+++ b/packages/backend/test/unit/activitypub/models/ApEventService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ApEventService } from '@/core/activitypub/models/ApEventService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ApEventService', () => {
+	let service: ApEventService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ApEventService>(ApEventService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/activitypub/models/ApGameService.ts
+++ b/packages/backend/test/unit/activitypub/models/ApGameService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ApGameService } from '@/core/activitypub/models/ApGameService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ApGameService', () => {
+	let service: ApGameService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ApGameService>(ApGameService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/activitypub/models/ApImageService.ts
+++ b/packages/backend/test/unit/activitypub/models/ApImageService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ApImageService } from '@/core/activitypub/models/ApImageService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ApImageService', () => {
+	let service: ApImageService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ApImageService>(ApImageService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/activitypub/models/ApMentionService.ts
+++ b/packages/backend/test/unit/activitypub/models/ApMentionService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ApMentionService } from '@/core/activitypub/models/ApMentionService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ApMentionService', () => {
+	let service: ApMentionService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ApMentionService>(ApMentionService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/activitypub/models/ApNoteService.ts
+++ b/packages/backend/test/unit/activitypub/models/ApNoteService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ApNoteService } from '@/core/activitypub/models/ApNoteService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ApNoteService', () => {
+	let service: ApNoteService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ApNoteService>(ApNoteService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/activitypub/models/ApOutboxFetchService.ts
+++ b/packages/backend/test/unit/activitypub/models/ApOutboxFetchService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ApOutboxFetchService } from '@/core/activitypub/models/ApOutboxFetchService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ApOutboxFetchService', () => {
+	let service: ApOutboxFetchService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ApOutboxFetchService>(ApOutboxFetchService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/activitypub/models/ApPersonService.ts
+++ b/packages/backend/test/unit/activitypub/models/ApPersonService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ApPersonService } from '@/core/activitypub/models/ApPersonService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ApPersonService', () => {
+	let service: ApPersonService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ApPersonService>(ApPersonService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/activitypub/models/ApQuestionService.ts
+++ b/packages/backend/test/unit/activitypub/models/ApQuestionService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ApQuestionService } from '@/core/activitypub/models/ApQuestionService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ApQuestionService', () => {
+	let service: ApQuestionService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ApQuestionService>(ApQuestionService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/chart/charts/active-users.ts
+++ b/packages/backend/test/unit/chart/charts/active-users.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import ActiveUsersChart from '@/core/chart/charts/active-users.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ActiveUsersChart', () => {
+	let service: ActiveUsersChart;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ActiveUsersChart>(ActiveUsersChart);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/chart/charts/drive.ts
+++ b/packages/backend/test/unit/chart/charts/drive.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import DriveChart from '@/core/chart/charts/drive.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('DriveChart', () => {
+	let service: DriveChart;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<DriveChart>(DriveChart);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/chart/charts/federation.ts
+++ b/packages/backend/test/unit/chart/charts/federation.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import FederationChart from '@/core/chart/charts/federation.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('FederationChart', () => {
+	let service: FederationChart;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<FederationChart>(FederationChart);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/chart/charts/instance.ts
+++ b/packages/backend/test/unit/chart/charts/instance.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import InstanceChart from '@/core/chart/charts/instance.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('InstanceChart', () => {
+	let service: InstanceChart;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<InstanceChart>(InstanceChart);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/chart/charts/notes.ts
+++ b/packages/backend/test/unit/chart/charts/notes.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import NotesChart from '@/core/chart/charts/notes.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('NotesChart', () => {
+	let service: NotesChart;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<NotesChart>(NotesChart);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/chart/charts/per-user-drive.ts
+++ b/packages/backend/test/unit/chart/charts/per-user-drive.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import PerUserDriveChart from '@/core/chart/charts/per-user-drive.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('PerUserDriveChart', () => {
+	let service: PerUserDriveChart;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<PerUserDriveChart>(PerUserDriveChart);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/chart/charts/per-user-following.ts
+++ b/packages/backend/test/unit/chart/charts/per-user-following.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import PerUserFollowingChart from '@/core/chart/charts/per-user-following.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('PerUserFollowingChart', () => {
+	let service: PerUserFollowingChart;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<PerUserFollowingChart>(PerUserFollowingChart);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/chart/charts/per-user-notes.ts
+++ b/packages/backend/test/unit/chart/charts/per-user-notes.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import PerUserNotesChart from '@/core/chart/charts/per-user-notes.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('PerUserNotesChart', () => {
+	let service: PerUserNotesChart;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<PerUserNotesChart>(PerUserNotesChart);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/chart/charts/per-user-pv.ts
+++ b/packages/backend/test/unit/chart/charts/per-user-pv.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import PerUserPvChart from '@/core/chart/charts/per-user-pv.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('PerUserPvChart', () => {
+	let service: PerUserPvChart;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<PerUserPvChart>(PerUserPvChart);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/chart/charts/per-user-reactions.ts
+++ b/packages/backend/test/unit/chart/charts/per-user-reactions.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import PerUserReactionsChart from '@/core/chart/charts/per-user-reactions.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('PerUserReactionsChart', () => {
+	let service: PerUserReactionsChart;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<PerUserReactionsChart>(PerUserReactionsChart);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/chart/charts/users.ts
+++ b/packages/backend/test/unit/chart/charts/users.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import UsersChart from '@/core/chart/charts/users.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('UsersChart', () => {
+	let service: UsersChart;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<UsersChart>(UsersChart);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/AbuseReportService.ts
+++ b/packages/backend/test/unit/core/AbuseReportService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { AbuseReportService } from '@/core/AbuseReportService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('AbuseReportService', () => {
+	let service: AbuseReportService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<AbuseReportService>(AbuseReportService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/AccountMoveService.ts
+++ b/packages/backend/test/unit/core/AccountMoveService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { AccountMoveService } from '@/core/AccountMoveService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('AccountMoveService', () => {
+	let service: AccountMoveService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<AccountMoveService>(AccountMoveService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/AccountUpdateService.ts
+++ b/packages/backend/test/unit/core/AccountUpdateService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { AccountUpdateService } from '@/core/AccountUpdateService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('AccountUpdateService', () => {
+	let service: AccountUpdateService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<AccountUpdateService>(AccountUpdateService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/AchievementService.ts
+++ b/packages/backend/test/unit/core/AchievementService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { AchievementService } from '@/core/AchievementService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('AchievementService', () => {
+	let service: AchievementService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<AchievementService>(AchievementService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/AdvancedSearchService.ts
+++ b/packages/backend/test/unit/core/AdvancedSearchService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { AdvancedSearchService } from '@/core/AdvancedSearchService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('AdvancedSearchService', () => {
+	let service: AdvancedSearchService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<AdvancedSearchService>(AdvancedSearchService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/AiService.ts
+++ b/packages/backend/test/unit/core/AiService.ts
@@ -21,9 +21,6 @@ describe('AiService', () => {
 
 	test('should be defined', () => {
 
-	test('methods are accessible', () => {
-		expect(typeof service).toBe('object');
-	});
 		expect(service).toBeDefined();
 	});
 });

--- a/packages/backend/test/unit/core/AiService.ts
+++ b/packages/backend/test/unit/core/AiService.ts
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { AiService } from '@/core/AiService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('AiService', () => {
+	let service: AiService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<AiService>(AiService);
+	});
+
+	test('should be defined', () => {
+
+	test('methods are accessible', () => {
+		expect(typeof service).toBe('object');
+	});
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/AntennaService.ts
+++ b/packages/backend/test/unit/core/AntennaService.ts
@@ -21,9 +21,6 @@ describe('AntennaService', () => {
 
 	test('should be defined', () => {
 
-	test('methods are accessible', () => {
-		expect(typeof service).toBe('object');
-	});
 		expect(service).toBeDefined();
 	});
 });

--- a/packages/backend/test/unit/core/AntennaService.ts
+++ b/packages/backend/test/unit/core/AntennaService.ts
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { AntennaService } from '@/core/AntennaService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('AntennaService', () => {
+	let service: AntennaService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<AntennaService>(AntennaService);
+	});
+
+	test('should be defined', () => {
+
+	test('methods are accessible', () => {
+		expect(typeof service).toBe('object');
+	});
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/AppLockService.ts
+++ b/packages/backend/test/unit/core/AppLockService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { AppLockService } from '@/core/AppLockService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('AppLockService', () => {
+	let service: AppLockService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<AppLockService>(AppLockService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/AvatarDecorationService.ts
+++ b/packages/backend/test/unit/core/AvatarDecorationService.ts
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { AvatarDecorationService } from '@/core/AvatarDecorationService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('AvatarDecorationService', () => {
+	let service: AvatarDecorationService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<AvatarDecorationService>(AvatarDecorationService);
+	});
+
+	test('should be defined', () => {
+
+	test('methods are accessible', () => {
+		expect(typeof service).toBe('object');
+	});
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/AvatarDecorationService.ts
+++ b/packages/backend/test/unit/core/AvatarDecorationService.ts
@@ -21,9 +21,6 @@ describe('AvatarDecorationService', () => {
 
 	test('should be defined', () => {
 
-	test('methods are accessible', () => {
-		expect(typeof service).toBe('object');
-	});
 		expect(service).toBeDefined();
 	});
 });

--- a/packages/backend/test/unit/core/CacheService.ts
+++ b/packages/backend/test/unit/core/CacheService.ts
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { CacheService } from '@/core/CacheService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('CacheService', () => {
+	let service: CacheService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<CacheService>(CacheService);
+	});
+
+	test('should be defined', () => {
+
+	test('methods are accessible', () => {
+		expect(typeof service).toBe('object');
+	});
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/CacheService.ts
+++ b/packages/backend/test/unit/core/CacheService.ts
@@ -21,9 +21,6 @@ describe('CacheService', () => {
 
 	test('should be defined', () => {
 
-	test('methods are accessible', () => {
-		expect(typeof service).toBe('object');
-	});
 		expect(service).toBeDefined();
 	});
 });

--- a/packages/backend/test/unit/core/ChannelFollowingService.ts
+++ b/packages/backend/test/unit/core/ChannelFollowingService.ts
@@ -21,9 +21,6 @@ describe('ChannelFollowingService', () => {
 
 	test('should be defined', () => {
 
-	test('methods are accessible', () => {
-		expect(typeof service).toBe('object');
-	});
 		expect(service).toBeDefined();
 	});
 });

--- a/packages/backend/test/unit/core/ChannelFollowingService.ts
+++ b/packages/backend/test/unit/core/ChannelFollowingService.ts
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ChannelFollowingService } from '@/core/ChannelFollowingService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ChannelFollowingService', () => {
+	let service: ChannelFollowingService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ChannelFollowingService>(ChannelFollowingService);
+	});
+
+	test('should be defined', () => {
+
+	test('methods are accessible', () => {
+		expect(typeof service).toBe('object');
+	});
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/ChatService.ts
+++ b/packages/backend/test/unit/core/ChatService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ChatService } from '@/core/ChatService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ChatService', () => {
+	let service: ChatService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ChatService>(ChatService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/ClipService.ts
+++ b/packages/backend/test/unit/core/ClipService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ClipService } from '@/core/ClipService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ClipService', () => {
+	let service: ClipService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ClipService>(ClipService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/DeleteAccountService.ts
+++ b/packages/backend/test/unit/core/DeleteAccountService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { DeleteAccountService } from '@/core/DeleteAccountService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('DeleteAccountService', () => {
+	let service: DeleteAccountService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<DeleteAccountService>(DeleteAccountService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/DownloadService.ts
+++ b/packages/backend/test/unit/core/DownloadService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { DownloadService } from '@/core/DownloadService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('DownloadService', () => {
+	let service: DownloadService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<DownloadService>(DownloadService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/EmailService.ts
+++ b/packages/backend/test/unit/core/EmailService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { EmailService } from '@/core/EmailService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('EmailService', () => {
+	let service: EmailService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<EmailService>(EmailService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/FanoutTimelineEndpointService.ts
+++ b/packages/backend/test/unit/core/FanoutTimelineEndpointService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { FanoutTimelineEndpointService } from '@/core/FanoutTimelineEndpointService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('FanoutTimelineEndpointService', () => {
+	let service: FanoutTimelineEndpointService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<FanoutTimelineEndpointService>(FanoutTimelineEndpointService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/FederatedInstanceService.ts
+++ b/packages/backend/test/unit/core/FederatedInstanceService.ts
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { FederatedInstanceService } from '@/core/FederatedInstanceService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('FederatedInstanceService', () => {
+	let service: FederatedInstanceService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<FederatedInstanceService>(FederatedInstanceService);
+	});
+
+	test('should be defined', () => {
+
+	test('methods are accessible', () => {
+		expect(typeof service).toBe('object');
+	});
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/FederatedInstanceService.ts
+++ b/packages/backend/test/unit/core/FederatedInstanceService.ts
@@ -21,9 +21,6 @@ describe('FederatedInstanceService', () => {
 
 	test('should be defined', () => {
 
-	test('methods are accessible', () => {
-		expect(typeof service).toBe('object');
-	});
 		expect(service).toBeDefined();
 	});
 });

--- a/packages/backend/test/unit/core/HashtagService.ts
+++ b/packages/backend/test/unit/core/HashtagService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { HashtagService } from '@/core/HashtagService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('HashtagService', () => {
+	let service: HashtagService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<HashtagService>(HashtagService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/HttpRequestService.ts
+++ b/packages/backend/test/unit/core/HttpRequestService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { HttpRequestService } from '@/core/HttpRequestService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('HttpRequestService', () => {
+	let service: HttpRequestService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<HttpRequestService>(HttpRequestService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/InternalStorageService.ts
+++ b/packages/backend/test/unit/core/InternalStorageService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { InternalStorageService } from '@/core/InternalStorageService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('InternalStorageService', () => {
+	let service: InternalStorageService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<InternalStorageService>(InternalStorageService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/LoggerService.ts
+++ b/packages/backend/test/unit/core/LoggerService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { LoggerService } from '@/core/LoggerService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('LoggerService', () => {
+	let service: LoggerService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<LoggerService>(LoggerService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/NoteDeleteService.ts
+++ b/packages/backend/test/unit/core/NoteDeleteService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { NoteDeleteService } from '@/core/NoteDeleteService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('NoteDeleteService', () => {
+	let service: NoteDeleteService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<NoteDeleteService>(NoteDeleteService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/NoteDraftService.ts
+++ b/packages/backend/test/unit/core/NoteDraftService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { NoteDraftService } from '@/core/NoteDraftService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('NoteDraftService', () => {
+	let service: NoteDraftService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<NoteDraftService>(NoteDraftService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/NoteHistoryService.ts
+++ b/packages/backend/test/unit/core/NoteHistoryService.ts
@@ -21,9 +21,6 @@ describe('NoteHistorySerivce', () => {
 
 	test('should be defined', () => {
 
-	test('methods are accessible', () => {
-		expect(typeof service).toBe('object');
-	});
 		expect(service).toBeDefined();
 	});
 });

--- a/packages/backend/test/unit/core/NoteHistoryService.ts
+++ b/packages/backend/test/unit/core/NoteHistoryService.ts
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { NoteHistorySerivce } from '@/core/NoteHistoryService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('NoteHistorySerivce', () => {
+	let service: NoteHistorySerivce;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<NoteHistorySerivce>(NoteHistorySerivce);
+	});
+
+	test('should be defined', () => {
+
+	test('methods are accessible', () => {
+		expect(typeof service).toBe('object');
+	});
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/NotePiningService.ts
+++ b/packages/backend/test/unit/core/NotePiningService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { NotePiningService } from '@/core/NotePiningService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('NotePiningService', () => {
+	let service: NotePiningService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<NotePiningService>(NotePiningService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/NoteUpdateService.ts
+++ b/packages/backend/test/unit/core/NoteUpdateService.ts
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { NoteUpdateService } from '@/core/NoteUpdateService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('NoteUpdateService', () => {
+	let service: NoteUpdateService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<NoteUpdateService>(NoteUpdateService);
+	});
+
+	test('should be defined', () => {
+
+	test('methods are accessible', () => {
+		expect(typeof service).toBe('object');
+	});
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/NoteUpdateService.ts
+++ b/packages/backend/test/unit/core/NoteUpdateService.ts
@@ -21,9 +21,6 @@ describe('NoteUpdateService', () => {
 
 	test('should be defined', () => {
 
-	test('methods are accessible', () => {
-		expect(typeof service).toBe('object');
-	});
 		expect(service).toBeDefined();
 	});
 });

--- a/packages/backend/test/unit/core/NotificationService.ts
+++ b/packages/backend/test/unit/core/NotificationService.ts
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { NotificationService } from '@/core/NotificationService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('NotificationService', () => {
+	let service: NotificationService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<NotificationService>(NotificationService);
+	});
+
+	test('should be defined', () => {
+
+	test('methods are accessible', () => {
+		expect(typeof service).toBe('object');
+	});
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/NotificationService.ts
+++ b/packages/backend/test/unit/core/NotificationService.ts
@@ -21,9 +21,6 @@ describe('NotificationService', () => {
 
 	test('should be defined', () => {
 
-	test('methods are accessible', () => {
-		expect(typeof service).toBe('object');
-	});
 		expect(service).toBeDefined();
 	});
 });

--- a/packages/backend/test/unit/core/PageService.ts
+++ b/packages/backend/test/unit/core/PageService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { PageService } from '@/core/PageService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('PageService', () => {
+	let service: PageService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<PageService>(PageService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/PollService.ts
+++ b/packages/backend/test/unit/core/PollService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { PollService } from '@/core/PollService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('PollService', () => {
+	let service: PollService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<PollService>(PollService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/PushNotificationService.ts
+++ b/packages/backend/test/unit/core/PushNotificationService.ts
@@ -21,9 +21,6 @@ describe('PushNotificationService', () => {
 
 	test('should be defined', () => {
 
-	test('methods are accessible', () => {
-		expect(typeof service).toBe('object');
-	});
 		expect(service).toBeDefined();
 	});
 });

--- a/packages/backend/test/unit/core/PushNotificationService.ts
+++ b/packages/backend/test/unit/core/PushNotificationService.ts
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { PushNotificationService } from '@/core/PushNotificationService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('PushNotificationService', () => {
+	let service: PushNotificationService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<PushNotificationService>(PushNotificationService);
+	});
+
+	test('should be defined', () => {
+
+	test('methods are accessible', () => {
+		expect(typeof service).toBe('object');
+	});
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/QueryService.ts
+++ b/packages/backend/test/unit/core/QueryService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { QueryService } from '@/core/QueryService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('QueryService', () => {
+	let service: QueryService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<QueryService>(QueryService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/QueueModule.ts
+++ b/packages/backend/test/unit/core/QueueModule.ts
@@ -21,9 +21,6 @@ describe('QueueModule', () => {
 
 	test('should be defined', () => {
 
-	test('methods are accessible', () => {
-		expect(typeof service).toBe('object');
-	});
 		expect(service).toBeDefined();
 	});
 });

--- a/packages/backend/test/unit/core/QueueModule.ts
+++ b/packages/backend/test/unit/core/QueueModule.ts
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { QueueModule } from '@/core/QueueModule.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('QueueModule', () => {
+	let service: QueueModule;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<QueueModule>(QueueModule);
+	});
+
+	test('should be defined', () => {
+
+	test('methods are accessible', () => {
+		expect(typeof service).toBe('object');
+	});
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/QueueService.ts
+++ b/packages/backend/test/unit/core/QueueService.ts
@@ -1,0 +1,169 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { QueueService } from '@/core/QueueService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('QueueService', () => {
+	let service: QueueService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<QueueService>(QueueService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+
+	describe('createDeleteDriveFilesJob', () => {
+		test('does not throw', async () => {
+			await expect(service.createDeleteDriveFilesJob({ id: 'test-user' } as any)).resolves.not.toThrow();
+		});
+	});
+
+	describe('createExportNotesJob', () => {
+		test('does not throw', async () => {
+			await expect(service.createExportNotesJob({ id: 'test-user' } as any)).resolves.not.toThrow();
+		});
+	});
+
+	describe('createExportFollowingJob', () => {
+		test('does not throw', async () => {
+			await expect(service.createExportFollowingJob({ id: 'test-user' } as any)).resolves.not.toThrow();
+		});
+
+		test('with options', async () => {
+			await expect(service.createExportFollowingJob({ id: 'test-user' } as any, true, true)).resolves.not.toThrow();
+		});
+	});
+
+	describe('createExportMuteJob', () => {
+		test('does not throw', async () => {
+			await expect(service.createExportMuteJob({ id: 'test-user' } as any)).resolves.not.toThrow();
+		});
+	});
+
+	describe('createExportBlockingJob', () => {
+		test('does not throw', async () => {
+			await expect(service.createExportBlockingJob({ id: 'test-user' } as any)).resolves.not.toThrow();
+		});
+	});
+
+	describe('createExportUserListsJob', () => {
+		test('does not throw', async () => {
+			await expect(service.createExportUserListsJob({ id: 'test-user' } as any)).resolves.not.toThrow();
+		});
+	});
+
+	describe('createExportAntennasJob', () => {
+		test('does not throw', async () => {
+			await expect(service.createExportAntennasJob({ id: 'test-user' } as any)).resolves.not.toThrow();
+		});
+	});
+
+	describe('createExportFavoritesJob', () => {
+		test('does not throw', async () => {
+			await expect(service.createExportFavoritesJob({ id: 'test-user' } as any)).resolves.not.toThrow();
+		});
+	});
+
+	describe('createExportClipsJob', () => {
+		test('does not throw', async () => {
+			await expect(service.createExportClipsJob({ id: 'test-user' } as any)).resolves.not.toThrow();
+		});
+	});
+
+	describe('createExportCustomEmojisJob', () => {
+		test('does not throw', async () => {
+			await expect(service.createExportCustomEmojisJob({ id: 'test-user' } as any)).resolves.not.toThrow();
+		});
+	});
+
+	describe('createImportFollowingJob', () => {
+		test('does not throw', async () => {
+			await expect(service.createImportFollowingJob({ id: 'test-user' } as any, 'file-id')).resolves.not.toThrow();
+		});
+	});
+
+	describe('createImportMutingJob', () => {
+		test('does not throw', async () => {
+			await expect(service.createImportMutingJob({ id: 'test-user' } as any, 'file-id')).resolves.not.toThrow();
+		});
+	});
+
+	describe('createImportBlockingJob', () => {
+		test('does not throw', async () => {
+			await expect(service.createImportBlockingJob({ id: 'test-user' } as any, 'file-id')).resolves.not.toThrow();
+		});
+	});
+
+	describe('createImportUserListsJob', () => {
+		test('does not throw', async () => {
+			await expect(service.createImportUserListsJob({ id: 'test-user' } as any, 'file-id')).resolves.not.toThrow();
+		});
+	});
+
+	describe('createImportCustomEmojisJob', () => {
+		test('does not throw', async () => {
+			await expect(service.createImportCustomEmojisJob({ id: 'test-user' } as any, 'file-id')).resolves.not.toThrow();
+		});
+	});
+
+	describe('createDeleteAccountJob', () => {
+		test('does not throw', async () => {
+			await expect(service.createDeleteAccountJob({ id: 'test-user' } as any)).resolves.not.toThrow();
+		});
+	});
+
+	describe('createDeleteObjectStorageFileJob', () => {
+		test('does not throw', async () => {
+			await expect(service.createDeleteObjectStorageFileJob('test-key')).resolves.not.toThrow();
+		});
+	});
+
+	describe('createCleanRemoteFilesJob', () => {
+		test('does not throw', async () => {
+			await expect(service.createCleanRemoteFilesJob()).resolves.not.toThrow();
+		});
+	});
+
+	describe('createFollowJob', () => {
+		test('does not throw with empty array', async () => {
+			await expect(service.createFollowJob([])).resolves.not.toThrow();
+		});
+	});
+
+	describe('createUnfollowJob', () => {
+		test('does not throw with empty array', async () => {
+			await expect(service.createUnfollowJob([])).resolves.not.toThrow();
+		});
+	});
+
+	describe('createBlockJob', () => {
+		test('does not throw with empty array', async () => {
+			await expect(service.createBlockJob([])).resolves.not.toThrow();
+		});
+	});
+
+	describe('createUnblockJob', () => {
+		test('does not throw with empty array', async () => {
+			await expect(service.createUnblockJob([])).resolves.not.toThrow();
+		});
+	});
+
+	describe('queueGetQueues', () => {
+		test('returns queue stats', async () => {
+			const result = await service.queueGetQueues();
+			expect(Array.isArray(result)).toBe(true);
+			expect(result.length).toBeGreaterThan(0);
+		});
+	});
+});

--- a/packages/backend/test/unit/core/ReactionsBufferingService.ts
+++ b/packages/backend/test/unit/core/ReactionsBufferingService.ts
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ReactionsBufferingService } from '@/core/ReactionsBufferingService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ReactionsBufferingService', () => {
+	let service: ReactionsBufferingService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ReactionsBufferingService>(ReactionsBufferingService);
+	});
+
+	test('should be defined', () => {
+
+	test('methods are accessible', () => {
+		expect(typeof service).toBe('object');
+	});
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/ReactionsBufferingService.ts
+++ b/packages/backend/test/unit/core/ReactionsBufferingService.ts
@@ -21,9 +21,6 @@ describe('ReactionsBufferingService', () => {
 
 	test('should be defined', () => {
 
-	test('methods are accessible', () => {
-		expect(typeof service).toBe('object');
-	});
 		expect(service).toBeDefined();
 	});
 });

--- a/packages/backend/test/unit/core/RegistryApiService.ts
+++ b/packages/backend/test/unit/core/RegistryApiService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { RegistryApiService } from '@/core/RegistryApiService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('RegistryApiService', () => {
+	let service: RegistryApiService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<RegistryApiService>(RegistryApiService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/RemoteLoggerService.ts
+++ b/packages/backend/test/unit/core/RemoteLoggerService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { RemoteLoggerService } from '@/core/RemoteLoggerService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('RemoteLoggerService', () => {
+	let service: RemoteLoggerService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<RemoteLoggerService>(RemoteLoggerService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/RemoteUserResolveService.ts
+++ b/packages/backend/test/unit/core/RemoteUserResolveService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { RemoteUserResolveService } from '@/core/RemoteUserResolveService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('RemoteUserResolveService', () => {
+	let service: RemoteUserResolveService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<RemoteUserResolveService>(RemoteUserResolveService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/ReversiService.ts
+++ b/packages/backend/test/unit/core/ReversiService.ts
@@ -21,9 +21,6 @@ describe('ReversiService', () => {
 
 	test('should be defined', () => {
 
-	test('methods are accessible', () => {
-		expect(typeof service).toBe('object');
-	});
 		expect(service).toBeDefined();
 	});
 });

--- a/packages/backend/test/unit/core/ReversiService.ts
+++ b/packages/backend/test/unit/core/ReversiService.ts
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ReversiService } from '@/core/ReversiService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ReversiService', () => {
+	let service: ReversiService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ReversiService>(ReversiService);
+	});
+
+	test('should be defined', () => {
+
+	test('methods are accessible', () => {
+		expect(typeof service).toBe('object');
+	});
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/SearchService.ts
+++ b/packages/backend/test/unit/core/SearchService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { SearchService } from '@/core/SearchService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('SearchService', () => {
+	let service: SearchService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<SearchService>(SearchService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/SignupService.ts
+++ b/packages/backend/test/unit/core/SignupService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { SignupService } from '@/core/SignupService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('SignupService', () => {
+	let service: SignupService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<SignupService>(SignupService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/SystemAccountService.ts
+++ b/packages/backend/test/unit/core/SystemAccountService.ts
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { SystemAccountService } from '@/core/SystemAccountService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('SystemAccountService', () => {
+	let service: SystemAccountService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<SystemAccountService>(SystemAccountService);
+	});
+
+	test('should be defined', () => {
+
+	test('methods are accessible', () => {
+		expect(typeof service).toBe('object');
+	});
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/SystemAccountService.ts
+++ b/packages/backend/test/unit/core/SystemAccountService.ts
@@ -21,9 +21,6 @@ describe('SystemAccountService', () => {
 
 	test('should be defined', () => {
 
-	test('methods are accessible', () => {
-		expect(typeof service).toBe('object');
-	});
 		expect(service).toBeDefined();
 	});
 });

--- a/packages/backend/test/unit/core/TruncateAccountService.ts
+++ b/packages/backend/test/unit/core/TruncateAccountService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { TruncateAccountService } from '@/core/TruncateAccountService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('TruncateAccountService', () => {
+	let service: TruncateAccountService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<TruncateAccountService>(TruncateAccountService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/UserAuthService.ts
+++ b/packages/backend/test/unit/core/UserAuthService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { UserAuthService } from '@/core/UserAuthService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('UserAuthService', () => {
+	let service: UserAuthService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<UserAuthService>(UserAuthService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/UserBlockingService.ts
+++ b/packages/backend/test/unit/core/UserBlockingService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { UserBlockingService } from '@/core/UserBlockingService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('UserBlockingService', () => {
+	let service: UserBlockingService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<UserBlockingService>(UserBlockingService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/UserFollowingService.ts
+++ b/packages/backend/test/unit/core/UserFollowingService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { UserFollowingService } from '@/core/UserFollowingService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('UserFollowingService', () => {
+	let service: UserFollowingService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<UserFollowingService>(UserFollowingService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/UserKeypairService.ts
+++ b/packages/backend/test/unit/core/UserKeypairService.ts
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { UserKeypairService } from '@/core/UserKeypairService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('UserKeypairService', () => {
+	let service: UserKeypairService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<UserKeypairService>(UserKeypairService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+
+	test('dispose does not throw', () => {
+		expect(() => service.dispose()).not.toThrow();
+	});
+
+	test('onApplicationShutdown does not throw', () => {
+		expect(() => service.onApplicationShutdown()).not.toThrow();
+	});
+});

--- a/packages/backend/test/unit/core/UserListService.ts
+++ b/packages/backend/test/unit/core/UserListService.ts
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { UserListService } from '@/core/UserListService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('UserListService', () => {
+	let service: UserListService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<UserListService>(UserListService);
+	});
+
+	test('should be defined', () => {
+
+	test('methods are accessible', () => {
+		expect(typeof service).toBe('object');
+	});
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/UserListService.ts
+++ b/packages/backend/test/unit/core/UserListService.ts
@@ -21,9 +21,6 @@ describe('UserListService', () => {
 
 	test('should be defined', () => {
 
-	test('methods are accessible', () => {
-		expect(typeof service).toBe('object');
-	});
 		expect(service).toBeDefined();
 	});
 });

--- a/packages/backend/test/unit/core/UserMutingService.ts
+++ b/packages/backend/test/unit/core/UserMutingService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { UserMutingService } from '@/core/UserMutingService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('UserMutingService', () => {
+	let service: UserMutingService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<UserMutingService>(UserMutingService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/UserRenoteMutingService.ts
+++ b/packages/backend/test/unit/core/UserRenoteMutingService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { UserRenoteMutingService } from '@/core/UserRenoteMutingService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('UserRenoteMutingService', () => {
+	let service: UserRenoteMutingService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<UserRenoteMutingService>(UserRenoteMutingService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/UserService.ts
+++ b/packages/backend/test/unit/core/UserService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { UserService } from '@/core/UserService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('UserService', () => {
+	let service: UserService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<UserService>(UserService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/UserSuspendService.ts
+++ b/packages/backend/test/unit/core/UserSuspendService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { UserSuspendService } from '@/core/UserSuspendService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('UserSuspendService', () => {
+	let service: UserSuspendService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<UserSuspendService>(UserSuspendService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/VideoProcessingService.ts
+++ b/packages/backend/test/unit/core/VideoProcessingService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { VideoProcessingService } from '@/core/VideoProcessingService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('VideoProcessingService', () => {
+	let service: VideoProcessingService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<VideoProcessingService>(VideoProcessingService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/WebAuthnService.ts
+++ b/packages/backend/test/unit/core/WebAuthnService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { WebAuthnService } from '@/core/WebAuthnService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('WebAuthnService', () => {
+	let service: WebAuthnService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<WebAuthnService>(WebAuthnService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/core/WebfingerService.ts
+++ b/packages/backend/test/unit/core/WebfingerService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { WebfingerService } from '@/core/WebfingerService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('WebfingerService', () => {
+	let service: WebfingerService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<WebfingerService>(WebfingerService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/daemons/QueueStatsService.ts
+++ b/packages/backend/test/unit/daemons/QueueStatsService.ts
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { QueueStatsService } from '@/daemons/QueueStatsService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('QueueStatsService', () => {
+	let service: QueueStatsService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [QueueStatsService],
+		}).compile();
+		service = app.get<QueueStatsService>(QueueStatsService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/daemons/ServerStatsService.ts
+++ b/packages/backend/test/unit/daemons/ServerStatsService.ts
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ServerStatsService } from '@/daemons/ServerStatsService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ServerStatsService', () => {
+	let service: ServerStatsService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [ServerStatsService],
+		}).compile();
+		service = app.get<ServerStatsService>(ServerStatsService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+
+	test('start does not throw when stats disabled', async () => {
+		// enableServerMachineStatsがfalseなら早期return
+		await expect(service.start()).resolves.not.toThrow();
+	});
+});

--- a/packages/backend/test/unit/entities/AbuseReportNotificationRecipientEntityService.ts
+++ b/packages/backend/test/unit/entities/AbuseReportNotificationRecipientEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { AbuseReportNotificationRecipientEntityService } from '@/core/entities/AbuseReportNotificationRecipientEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('AbuseReportNotificationRecipientEntityService', () => {
+	let service: AbuseReportNotificationRecipientEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<AbuseReportNotificationRecipientEntityService>(AbuseReportNotificationRecipientEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/AbuseUserReportEntityService.ts
+++ b/packages/backend/test/unit/entities/AbuseUserReportEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { AbuseUserReportEntityService } from '@/core/entities/AbuseUserReportEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('AbuseUserReportEntityService', () => {
+	let service: AbuseUserReportEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<AbuseUserReportEntityService>(AbuseUserReportEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/AnnouncementEntityService.ts
+++ b/packages/backend/test/unit/entities/AnnouncementEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { AnnouncementEntityService } from '@/core/entities/AnnouncementEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('AnnouncementEntityService', () => {
+	let service: AnnouncementEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<AnnouncementEntityService>(AnnouncementEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/AntennaEntityService.ts
+++ b/packages/backend/test/unit/entities/AntennaEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { AntennaEntityService } from '@/core/entities/AntennaEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('AntennaEntityService', () => {
+	let service: AntennaEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<AntennaEntityService>(AntennaEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/AppEntityService.ts
+++ b/packages/backend/test/unit/entities/AppEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { AppEntityService } from '@/core/entities/AppEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('AppEntityService', () => {
+	let service: AppEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<AppEntityService>(AppEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/AuthSessionEntityService.ts
+++ b/packages/backend/test/unit/entities/AuthSessionEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { AuthSessionEntityService } from '@/core/entities/AuthSessionEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('AuthSessionEntityService', () => {
+	let service: AuthSessionEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<AuthSessionEntityService>(AuthSessionEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/BlockingEntityService.ts
+++ b/packages/backend/test/unit/entities/BlockingEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { BlockingEntityService } from '@/core/entities/BlockingEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('BlockingEntityService', () => {
+	let service: BlockingEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<BlockingEntityService>(BlockingEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/ChannelEntityService.ts
+++ b/packages/backend/test/unit/entities/ChannelEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ChannelEntityService } from '@/core/entities/ChannelEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ChannelEntityService', () => {
+	let service: ChannelEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ChannelEntityService>(ChannelEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/ChatEntityService.ts
+++ b/packages/backend/test/unit/entities/ChatEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ChatEntityService } from '@/core/entities/ChatEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ChatEntityService', () => {
+	let service: ChatEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ChatEntityService>(ChatEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/ClipEntityService.ts
+++ b/packages/backend/test/unit/entities/ClipEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ClipEntityService } from '@/core/entities/ClipEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ClipEntityService', () => {
+	let service: ClipEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ClipEntityService>(ClipEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/DriveFileEntityService.ts
+++ b/packages/backend/test/unit/entities/DriveFileEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { DriveFileEntityService } from '@/core/entities/DriveFileEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('DriveFileEntityService', () => {
+	let service: DriveFileEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<DriveFileEntityService>(DriveFileEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/DriveFileEntityService.ts
+++ b/packages/backend/test/unit/entities/DriveFileEntityService.ts
@@ -22,4 +22,38 @@ describe('DriveFileEntityService', () => {
 	test('should be defined', () => {
 		expect(service).toBeDefined();
 	});
+
+	describe('validateFileName', () => {
+		test('valid filename', () => {
+			expect(service.validateFileName('test.png')).toBe(true);
+		});
+
+		test('empty filename', () => {
+			expect(service.validateFileName('')).toBe(false);
+		});
+
+		test('whitespace-only filename', () => {
+			expect(service.validateFileName('   ')).toBe(false);
+		});
+
+		test('filename exceeding 200 chars', () => {
+			expect(service.validateFileName('a'.repeat(201))).toBe(false);
+		});
+
+		test('filename with backslash', () => {
+			expect(service.validateFileName('path\\file.txt')).toBe(false);
+		});
+
+		test('filename with slash', () => {
+			expect(service.validateFileName('path/file.txt')).toBe(false);
+		});
+
+		test('filename with double dots', () => {
+			expect(service.validateFileName('../file.txt')).toBe(false);
+		});
+
+		test('filename at exactly 200 chars', () => {
+			expect(service.validateFileName('a'.repeat(200))).toBe(true);
+		});
+	});
 });

--- a/packages/backend/test/unit/entities/DriveFolderEntityService.ts
+++ b/packages/backend/test/unit/entities/DriveFolderEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { DriveFolderEntityService } from '@/core/entities/DriveFolderEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('DriveFolderEntityService', () => {
+	let service: DriveFolderEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<DriveFolderEntityService>(DriveFolderEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/EmojiEntityService.ts
+++ b/packages/backend/test/unit/entities/EmojiEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { EmojiEntityService } from '@/core/entities/EmojiEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('EmojiEntityService', () => {
+	let service: EmojiEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<EmojiEntityService>(EmojiEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/FlashEntityService.ts
+++ b/packages/backend/test/unit/entities/FlashEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { FlashEntityService } from '@/core/entities/FlashEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('FlashEntityService', () => {
+	let service: FlashEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<FlashEntityService>(FlashEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/FlashLikeEntityService.ts
+++ b/packages/backend/test/unit/entities/FlashLikeEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { FlashLikeEntityService } from '@/core/entities/FlashLikeEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('FlashLikeEntityService', () => {
+	let service: FlashLikeEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<FlashLikeEntityService>(FlashLikeEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/FollowRequestEntityService.ts
+++ b/packages/backend/test/unit/entities/FollowRequestEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { FollowRequestEntityService } from '@/core/entities/FollowRequestEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('FollowRequestEntityService', () => {
+	let service: FollowRequestEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<FollowRequestEntityService>(FollowRequestEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/FollowingEntityService.ts
+++ b/packages/backend/test/unit/entities/FollowingEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { FollowingEntityService } from '@/core/entities/FollowingEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('FollowingEntityService', () => {
+	let service: FollowingEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<FollowingEntityService>(FollowingEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/GalleryLikeEntityService.ts
+++ b/packages/backend/test/unit/entities/GalleryLikeEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { GalleryLikeEntityService } from '@/core/entities/GalleryLikeEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('GalleryLikeEntityService', () => {
+	let service: GalleryLikeEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<GalleryLikeEntityService>(GalleryLikeEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/GalleryPostEntityService.ts
+++ b/packages/backend/test/unit/entities/GalleryPostEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { GalleryPostEntityService } from '@/core/entities/GalleryPostEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('GalleryPostEntityService', () => {
+	let service: GalleryPostEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<GalleryPostEntityService>(GalleryPostEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/HashtagEntityService.ts
+++ b/packages/backend/test/unit/entities/HashtagEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { HashtagEntityService } from '@/core/entities/HashtagEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('HashtagEntityService', () => {
+	let service: HashtagEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<HashtagEntityService>(HashtagEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/InstanceEntityService.ts
+++ b/packages/backend/test/unit/entities/InstanceEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { InstanceEntityService } from '@/core/entities/InstanceEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('InstanceEntityService', () => {
+	let service: InstanceEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<InstanceEntityService>(InstanceEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/InviteCodeEntityService.ts
+++ b/packages/backend/test/unit/entities/InviteCodeEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { InviteCodeEntityService } from '@/core/entities/InviteCodeEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('InviteCodeEntityService', () => {
+	let service: InviteCodeEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<InviteCodeEntityService>(InviteCodeEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/MetaEntityService.ts
+++ b/packages/backend/test/unit/entities/MetaEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { MetaEntityService } from '@/core/entities/MetaEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('MetaEntityService', () => {
+	let service: MetaEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<MetaEntityService>(MetaEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/ModerationLogEntityService.ts
+++ b/packages/backend/test/unit/entities/ModerationLogEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ModerationLogEntityService } from '@/core/entities/ModerationLogEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ModerationLogEntityService', () => {
+	let service: ModerationLogEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ModerationLogEntityService>(ModerationLogEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/MutingEntityService.ts
+++ b/packages/backend/test/unit/entities/MutingEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { MutingEntityService } from '@/core/entities/MutingEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('MutingEntityService', () => {
+	let service: MutingEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<MutingEntityService>(MutingEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/NoteDraftEntityService.ts
+++ b/packages/backend/test/unit/entities/NoteDraftEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { NoteDraftEntityService } from '@/core/entities/NoteDraftEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('NoteDraftEntityService', () => {
+	let service: NoteDraftEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<NoteDraftEntityService>(NoteDraftEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/NoteEntityService.ts
+++ b/packages/backend/test/unit/entities/NoteEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { NoteEntityService } from '@/core/entities/NoteEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('NoteEntityService', () => {
+	let service: NoteEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<NoteEntityService>(NoteEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/NoteFavoriteEntityService.ts
+++ b/packages/backend/test/unit/entities/NoteFavoriteEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { NoteFavoriteEntityService } from '@/core/entities/NoteFavoriteEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('NoteFavoriteEntityService', () => {
+	let service: NoteFavoriteEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<NoteFavoriteEntityService>(NoteFavoriteEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/NoteHistoryEntityService.ts
+++ b/packages/backend/test/unit/entities/NoteHistoryEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { NoteHistoryEntityService } from '@/core/entities/NoteHistoryEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('NoteHistoryEntityService', () => {
+	let service: NoteHistoryEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<NoteHistoryEntityService>(NoteHistoryEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/NoteReactionEntityService.ts
+++ b/packages/backend/test/unit/entities/NoteReactionEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { NoteReactionEntityService } from '@/core/entities/NoteReactionEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('NoteReactionEntityService', () => {
+	let service: NoteReactionEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<NoteReactionEntityService>(NoteReactionEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/NotificationEntityService.ts
+++ b/packages/backend/test/unit/entities/NotificationEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { NotificationEntityService } from '@/core/entities/NotificationEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('NotificationEntityService', () => {
+	let service: NotificationEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<NotificationEntityService>(NotificationEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/PageEntityService.ts
+++ b/packages/backend/test/unit/entities/PageEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { PageEntityService } from '@/core/entities/PageEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('PageEntityService', () => {
+	let service: PageEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<PageEntityService>(PageEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/PageLikeEntityService.ts
+++ b/packages/backend/test/unit/entities/PageLikeEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { PageLikeEntityService } from '@/core/entities/PageLikeEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('PageLikeEntityService', () => {
+	let service: PageLikeEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<PageLikeEntityService>(PageLikeEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/RenoteMutingEntityService.ts
+++ b/packages/backend/test/unit/entities/RenoteMutingEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { RenoteMutingEntityService } from '@/core/entities/RenoteMutingEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('RenoteMutingEntityService', () => {
+	let service: RenoteMutingEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<RenoteMutingEntityService>(RenoteMutingEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/ReversiGameEntityService.ts
+++ b/packages/backend/test/unit/entities/ReversiGameEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ReversiGameEntityService } from '@/core/entities/ReversiGameEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('ReversiGameEntityService', () => {
+	let service: ReversiGameEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<ReversiGameEntityService>(ReversiGameEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/RoleEntityService.ts
+++ b/packages/backend/test/unit/entities/RoleEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { RoleEntityService } from '@/core/entities/RoleEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('RoleEntityService', () => {
+	let service: RoleEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<RoleEntityService>(RoleEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/SigninEntityService.ts
+++ b/packages/backend/test/unit/entities/SigninEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { SigninEntityService } from '@/core/entities/SigninEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('SigninEntityService', () => {
+	let service: SigninEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<SigninEntityService>(SigninEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/SystemWebhookEntityService.ts
+++ b/packages/backend/test/unit/entities/SystemWebhookEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { SystemWebhookEntityService } from '@/core/entities/SystemWebhookEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('SystemWebhookEntityService', () => {
+	let service: SystemWebhookEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<SystemWebhookEntityService>(SystemWebhookEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/UserGroupEntityService.ts
+++ b/packages/backend/test/unit/entities/UserGroupEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { UserGroupEntityService } from '@/core/entities/UserGroupEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('UserGroupEntityService', () => {
+	let service: UserGroupEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<UserGroupEntityService>(UserGroupEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/UserGroupInvitationEntityService.ts
+++ b/packages/backend/test/unit/entities/UserGroupInvitationEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { UserGroupInvitationEntityService } from '@/core/entities/UserGroupInvitationEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('UserGroupInvitationEntityService', () => {
+	let service: UserGroupInvitationEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<UserGroupInvitationEntityService>(UserGroupInvitationEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/entities/UserListEntityService.ts
+++ b/packages/backend/test/unit/entities/UserListEntityService.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { UserListEntityService } from '@/core/entities/UserListEntityService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+
+describe('UserListEntityService', () => {
+	let service: UserListEntityService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		service = app.get<UserListEntityService>(UserListEntityService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/models/Notification.ts
+++ b/packages/backend/test/unit/models/Notification.ts
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test } from '@jest/globals';
+import type { MiNotification } from '@/models/Notification.js';
+
+describe('models:Notification', () => {
+	test('MiNotification type is defined', () => {
+		// Type-level test: verify the type is importable and usable
+		const notification: MiNotification = {
+			type: 'follow',
+			id: 'test-id',
+			createdAt: new Date().toISOString(),
+			notifierId: 'notifier-id',
+		};
+		expect(notification.type).toBe('follow');
+	});
+});

--- a/packages/backend/test/unit/queue/processors/AggregateRetentionProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/AggregateRetentionProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { AggregateRetentionProcessorService } from '@/queue/processors/AggregateRetentionProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('AggregateRetentionProcessorService', () => {
+	let service: AggregateRetentionProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [AggregateRetentionProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<AggregateRetentionProcessorService>(AggregateRetentionProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/AutoDeleteNotesProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/AutoDeleteNotesProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { AutoDeleteNotesProcessorService } from '@/queue/processors/AutoDeleteNotesProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('AutoDeleteNotesProcessorService', () => {
+	let service: AutoDeleteNotesProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [AutoDeleteNotesProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<AutoDeleteNotesProcessorService>(AutoDeleteNotesProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/BakeBufferedReactionsProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/BakeBufferedReactionsProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { BakeBufferedReactionsProcessorService } from '@/queue/processors/BakeBufferedReactionsProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('BakeBufferedReactionsProcessorService', () => {
+	let service: BakeBufferedReactionsProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [BakeBufferedReactionsProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<BakeBufferedReactionsProcessorService>(BakeBufferedReactionsProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/CheckExpiredMutingsProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/CheckExpiredMutingsProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { CheckExpiredMutingsProcessorService } from '@/queue/processors/CheckExpiredMutingsProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('CheckExpiredMutingsProcessorService', () => {
+	let service: CheckExpiredMutingsProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [CheckExpiredMutingsProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<CheckExpiredMutingsProcessorService>(CheckExpiredMutingsProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/CleanChartsProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/CleanChartsProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { CleanChartsProcessorService } from '@/queue/processors/CleanChartsProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('CleanChartsProcessorService', () => {
+	let service: CleanChartsProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [CleanChartsProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<CleanChartsProcessorService>(CleanChartsProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/CleanProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/CleanProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { CleanProcessorService } from '@/queue/processors/CleanProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('CleanProcessorService', () => {
+	let service: CleanProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [CleanProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<CleanProcessorService>(CleanProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/CleanRemoteFilesProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/CleanRemoteFilesProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { CleanRemoteFilesProcessorService } from '@/queue/processors/CleanRemoteFilesProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('CleanRemoteFilesProcessorService', () => {
+	let service: CleanRemoteFilesProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [CleanRemoteFilesProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<CleanRemoteFilesProcessorService>(CleanRemoteFilesProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/DeleteAccountProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/DeleteAccountProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { DeleteAccountProcessorService } from '@/queue/processors/DeleteAccountProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('DeleteAccountProcessorService', () => {
+	let service: DeleteAccountProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [DeleteAccountProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<DeleteAccountProcessorService>(DeleteAccountProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/DeleteDriveFilesProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/DeleteDriveFilesProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { DeleteDriveFilesProcessorService } from '@/queue/processors/DeleteDriveFilesProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('DeleteDriveFilesProcessorService', () => {
+	let service: DeleteDriveFilesProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [DeleteDriveFilesProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<DeleteDriveFilesProcessorService>(DeleteDriveFilesProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/DeleteFileProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/DeleteFileProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { DeleteFileProcessorService } from '@/queue/processors/DeleteFileProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('DeleteFileProcessorService', () => {
+	let service: DeleteFileProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [DeleteFileProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<DeleteFileProcessorService>(DeleteFileProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/DeliverProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/DeliverProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { DeliverProcessorService } from '@/queue/processors/DeliverProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('DeliverProcessorService', () => {
+	let service: DeliverProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [DeliverProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<DeliverProcessorService>(DeliverProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/EndedPollNotificationProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/EndedPollNotificationProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { EndedPollNotificationProcessorService } from '@/queue/processors/EndedPollNotificationProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('EndedPollNotificationProcessorService', () => {
+	let service: EndedPollNotificationProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [EndedPollNotificationProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<EndedPollNotificationProcessorService>(EndedPollNotificationProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/ExportAntennasProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/ExportAntennasProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ExportAntennasProcessorService } from '@/queue/processors/ExportAntennasProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('ExportAntennasProcessorService', () => {
+	let service: ExportAntennasProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [ExportAntennasProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<ExportAntennasProcessorService>(ExportAntennasProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/ExportBlockingProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/ExportBlockingProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ExportBlockingProcessorService } from '@/queue/processors/ExportBlockingProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('ExportBlockingProcessorService', () => {
+	let service: ExportBlockingProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [ExportBlockingProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<ExportBlockingProcessorService>(ExportBlockingProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/ExportClipsProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/ExportClipsProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ExportClipsProcessorService } from '@/queue/processors/ExportClipsProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('ExportClipsProcessorService', () => {
+	let service: ExportClipsProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [ExportClipsProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<ExportClipsProcessorService>(ExportClipsProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/ExportCustomEmojisProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/ExportCustomEmojisProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ExportCustomEmojisProcessorService } from '@/queue/processors/ExportCustomEmojisProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('ExportCustomEmojisProcessorService', () => {
+	let service: ExportCustomEmojisProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [ExportCustomEmojisProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<ExportCustomEmojisProcessorService>(ExportCustomEmojisProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/ExportFavoritesProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/ExportFavoritesProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ExportFavoritesProcessorService } from '@/queue/processors/ExportFavoritesProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('ExportFavoritesProcessorService', () => {
+	let service: ExportFavoritesProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [ExportFavoritesProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<ExportFavoritesProcessorService>(ExportFavoritesProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/ExportFollowingProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/ExportFollowingProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ExportFollowingProcessorService } from '@/queue/processors/ExportFollowingProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('ExportFollowingProcessorService', () => {
+	let service: ExportFollowingProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [ExportFollowingProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<ExportFollowingProcessorService>(ExportFollowingProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/ExportMutingProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/ExportMutingProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ExportMutingProcessorService } from '@/queue/processors/ExportMutingProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('ExportMutingProcessorService', () => {
+	let service: ExportMutingProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [ExportMutingProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<ExportMutingProcessorService>(ExportMutingProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/ExportNotesProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/ExportNotesProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ExportNotesProcessorService } from '@/queue/processors/ExportNotesProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('ExportNotesProcessorService', () => {
+	let service: ExportNotesProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [ExportNotesProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<ExportNotesProcessorService>(ExportNotesProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/ExportUserListsProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/ExportUserListsProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ExportUserListsProcessorService } from '@/queue/processors/ExportUserListsProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('ExportUserListsProcessorService', () => {
+	let service: ExportUserListsProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [ExportUserListsProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<ExportUserListsProcessorService>(ExportUserListsProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/ImportAntennasProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/ImportAntennasProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ImportAntennasProcessorService } from '@/queue/processors/ImportAntennasProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('ImportAntennasProcessorService', () => {
+	let service: ImportAntennasProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [ImportAntennasProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<ImportAntennasProcessorService>(ImportAntennasProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/ImportBlockingProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/ImportBlockingProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ImportBlockingProcessorService } from '@/queue/processors/ImportBlockingProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('ImportBlockingProcessorService', () => {
+	let service: ImportBlockingProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [ImportBlockingProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<ImportBlockingProcessorService>(ImportBlockingProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/ImportCustomEmojisProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/ImportCustomEmojisProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ImportCustomEmojisProcessorService } from '@/queue/processors/ImportCustomEmojisProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('ImportCustomEmojisProcessorService', () => {
+	let service: ImportCustomEmojisProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [ImportCustomEmojisProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<ImportCustomEmojisProcessorService>(ImportCustomEmojisProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/ImportFollowingProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/ImportFollowingProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ImportFollowingProcessorService } from '@/queue/processors/ImportFollowingProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('ImportFollowingProcessorService', () => {
+	let service: ImportFollowingProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [ImportFollowingProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<ImportFollowingProcessorService>(ImportFollowingProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/ImportMutingProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/ImportMutingProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ImportMutingProcessorService } from '@/queue/processors/ImportMutingProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('ImportMutingProcessorService', () => {
+	let service: ImportMutingProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [ImportMutingProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<ImportMutingProcessorService>(ImportMutingProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/ImportUserListsProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/ImportUserListsProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ImportUserListsProcessorService } from '@/queue/processors/ImportUserListsProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('ImportUserListsProcessorService', () => {
+	let service: ImportUserListsProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [ImportUserListsProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<ImportUserListsProcessorService>(ImportUserListsProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/InboxProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/InboxProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { InboxProcessorService } from '@/queue/processors/InboxProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('InboxProcessorService', () => {
+	let service: InboxProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [InboxProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<InboxProcessorService>(InboxProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/PostScheduledNoteProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/PostScheduledNoteProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { PostScheduledNoteProcessorService } from '@/queue/processors/PostScheduledNoteProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('PostScheduledNoteProcessorService', () => {
+	let service: PostScheduledNoteProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [PostScheduledNoteProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<PostScheduledNoteProcessorService>(PostScheduledNoteProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/RelationshipProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/RelationshipProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { RelationshipProcessorService } from '@/queue/processors/RelationshipProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('RelationshipProcessorService', () => {
+	let service: RelationshipProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [RelationshipProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<RelationshipProcessorService>(RelationshipProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/ReportAbuseProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/ReportAbuseProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ReportAbuseProcessorService } from '@/queue/processors/ReportAbuseProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('ReportAbuseProcessorService', () => {
+	let service: ReportAbuseProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [ReportAbuseProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<ReportAbuseProcessorService>(ReportAbuseProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/ResyncChartsProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/ResyncChartsProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ResyncChartsProcessorService } from '@/queue/processors/ResyncChartsProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('ResyncChartsProcessorService', () => {
+	let service: ResyncChartsProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [ResyncChartsProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<ResyncChartsProcessorService>(ResyncChartsProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/ScheduledNoteDeleteProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/ScheduledNoteDeleteProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { ScheduledNoteDeleteProcessorService } from '@/queue/processors/ScheduledNoteDeleteProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('ScheduledNoteDeleteProcessorService', () => {
+	let service: ScheduledNoteDeleteProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [ScheduledNoteDeleteProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<ScheduledNoteDeleteProcessorService>(ScheduledNoteDeleteProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/SystemWebhookDeliverProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/SystemWebhookDeliverProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { SystemWebhookDeliverProcessorService } from '@/queue/processors/SystemWebhookDeliverProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('SystemWebhookDeliverProcessorService', () => {
+	let service: SystemWebhookDeliverProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [SystemWebhookDeliverProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<SystemWebhookDeliverProcessorService>(SystemWebhookDeliverProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/TickChartsProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/TickChartsProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { TickChartsProcessorService } from '@/queue/processors/TickChartsProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('TickChartsProcessorService', () => {
+	let service: TickChartsProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [TickChartsProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<TickChartsProcessorService>(TickChartsProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/TruncateAccountProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/TruncateAccountProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { TruncateAccountProcessorService } from '@/queue/processors/TruncateAccountProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('TruncateAccountProcessorService', () => {
+	let service: TruncateAccountProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [TruncateAccountProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<TruncateAccountProcessorService>(TruncateAccountProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/processors/UserWebhookDeliverProcessorService.ts
+++ b/packages/backend/test/unit/queue/processors/UserWebhookDeliverProcessorService.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CoreModule } from '@/core/CoreModule.js';
+import { UserWebhookDeliverProcessorService } from '@/queue/processors/UserWebhookDeliverProcessorService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+describe('UserWebhookDeliverProcessorService', () => {
+	let service: UserWebhookDeliverProcessorService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [UserWebhookDeliverProcessorService, QueueLoggerService],
+		}).compile();
+		service = app.get<UserWebhookDeliverProcessorService>(UserWebhookDeliverProcessorService);
+	});
+
+	test('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/packages/backend/test/unit/queue/types.ts
+++ b/packages/backend/test/unit/queue/types.ts
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test } from '@jest/globals';
+import type { DeliverJobData, InboxJobData, RelationshipJobData, DbJobData, ThinUser } from '@/queue/types.js';
+
+describe('queue/types', () => {
+	test('ThinUser type is usable', () => {
+		const user: ThinUser = { id: 'test-id' };
+		expect(user.id).toBe('test-id');
+	});
+
+	test('DeliverJobData type is defined', () => {
+		const job: Partial<DeliverJobData> = { to: 'https://example.com/inbox' };
+		expect(job.to).toBeDefined();
+	});
+});


### PR DESCRIPTION
## Summary
NestJS DIコンテナによるサービスインスタンス化を検証するテスト125ファイルを自動生成

## Key Changes
125ファイル、+3,577行:
- `test/unit/core/`: 55サービス
- `test/unit/entities/`: 42エンティティサービス
- `test/unit/activitypub/`: 16 ActivityPubサービス
- `test/unit/chart/`: 11チャートサービス
- `test/unit/models/`: Notification型テスト
- `scripts/generate-service-tests.cjs`: 自動生成スクリプト

各テストは`Test.createTestingModule({ imports: [GlobalModule, CoreModule] })`で
サービスが正常にDI解決されることを確認する。

## Testing
```bash
pnpm --filter backend jest -- --testPathPattern='test/unit/(core|entities|activitypub|chart|models)/'
```

## Note
- PR1(Jest基盤)がマージされていることが前提
- テスト実行にはPostgreSQL(ポート54312)とRedis(ポート56312)が必要

## Related
テストカバレッジ向上PRシリーズ [4/5]

🤖 Generated with [Claude Code](https://claude.com/claude-code)