### PR TITLE
fix(frontend): remote-softwareが2度呼ばれているのを修正

### DIFF
--- a/packages/frontend/src/components/MkInstanceStats.vue
+++ b/packages/frontend/src/components/MkInstanceStats.vue
@@ -253,6 +253,7 @@ onMounted(() => {
 		});
 		createDoughnut(softwareDoughnutEl.value, externalTooltipHandler, sortedData);
 	});
+
 	misskeyApiGet('federation/stats', { limit: 30 }).then(fedStats => {
 		type ChartData = {
 			name: string,
@@ -304,26 +305,6 @@ onMounted(() => {
 		});
 
 		createDoughnut(pubDoughnutEl.value, externalTooltipHandler2, pubs);
-	});
-
-	misskeyApiGet('federation/remote-software', {}).then(fedStats => {
-		type ChartData = {
-			name: string,
-			color: string | null,
-			value: number,
-			onClick?: () => void,
-		}[];
-
-		const softwareData: ChartData = fedStats.map(x => ({
-			name: x.softwareName,
-			color: x.color,
-			value: x.count,
-			onClick: () => {},
-		}));
-
-		const sortedSoftwareData = softwareData.sort((a, b) => a.value > b.value ? -1 : 1);
-
-		createDoughnut(softwareDoughnutEl.value, externalTooltipHandler3, sortedSoftwareData);
 	});
 });
 </script>


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
タイトルの通り

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
/aboutのチャートで/api/federation/remote-softwareが2度呼ばれているため

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
