### PR TITLE
feat: 画像のアップロード時の圧縮にWebP圧縮のみの追加

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -1592,6 +1592,7 @@ _compression:
     high: "High quality"
     medium: "Medium quality"
     low: "Low quality"
+    webpcompress: "WebP Compress"
   _size:
     large: "Large size"
     medium: "Medium size"

--- a/locales/index.d.ts
+++ b/locales/index.d.ts
@@ -6521,6 +6521,10 @@ export interface Locale extends ILocale {
              * 低品質
              */
             "low": string;
+            /**
+             * WebP圧縮のみ
+             */
+            "webpcompress": string;
         };
         "_size": {
             /**

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -1628,6 +1628,7 @@ _compression:
     high: "高品質"
     medium: "中品質"
     low: "低品質"
+    webpcompress: "WebP圧縮のみ"
   _size:
     large: "サイズ大"
     medium: "サイズ中"

--- a/packages/frontend/src/composables/use-uploader.ts
+++ b/packages/frontend/src/composables/use-uploader.ts
@@ -79,7 +79,7 @@ export type UploaderItem = {
 	uploaded: Misskey.entities.DriveFile | null;
 	uploadFailed: boolean;
 	aborted: boolean;
-	compressionLevel: 0 | 1 | 2 | 3;
+	compressionLevel: 0 | 1 | 2 | 3 | 10;
 	compressedSize?: number | null;
 	preprocessedFile?: Blob | null;
 	file: File;
@@ -90,7 +90,7 @@ export type UploaderItem = {
 	abortPreprocess?: (() => void) | null;
 };
 
-function getCompressionSettings(level: 0 | 1 | 2 | 3) {
+function getCompressionSettings(level: 0 | 1 | 2 | 3 | 10, imageWidth: number, imageHeight: number) {
 	if (level === 1) {
 		return {
 			maxWidth: 2000,
@@ -105,6 +105,11 @@ function getCompressionSettings(level: 0 | 1 | 2 | 3) {
 		return {
 			maxWidth: 2000 * 0.75 * 0.75, // =1125
 			maxHeight: 2000 * 0.75 * 0.75, // =1125
+		};
+	} else if (level === 10) {
+		return {
+			maxWidth: imageWidth,
+			maxHeight: imageHeight,
 		};
 	} else {
 		return null;
@@ -336,7 +341,7 @@ export function useUploader(options: {
 			!item.uploading &&
 			!item.uploaded
 		) {
-			function changeCompressionLevel(level: 0 | 1 | 2 | 3) {
+			function changeCompressionLevel(level: 0 | 1 | 2 | 3 | 10) {
 				item.compressionLevel = level;
 				preprocess(item).then(() => {
 					triggerRef(items);
@@ -356,6 +361,8 @@ export function useUploader(options: {
 						text += `: ${i18n.ts.medium}`;
 					} else if (item.compressionLevel === 3) {
 						text += `: ${i18n.ts.high}`;
+					} else if (item.compressionLevel === 10) {
+						text += `: ${i18n.ts._compression._quality.webpcompress}`;
 					}
 
 					return text;
@@ -366,6 +373,11 @@ export function useUploader(options: {
 					text: i18n.ts.none,
 					active: computed(() => item.compressionLevel === 0 || item.compressionLevel == null),
 					action: () => changeCompressionLevel(0),
+				}, {
+					type: 'radioOption',
+					text: i18n.ts._compression._quality.webpcompress,
+					active: computed(() => item.compressionLevel === 10),
+					action: () => changeCompressionLevel(10),
 				}, {
 					type: 'divider',
 				}, {
@@ -571,7 +583,7 @@ export function useUploader(options: {
 			});
 		}
 
-		const compressionSettings = getCompressionSettings(item.compressionLevel);
+		const compressionSettings = getCompressionSettings(item.compressionLevel, imageBitmap.width, imageBitmap.height);
 		const needsCompress = item.compressionLevel !== 0 && compressionSettings && IMAGE_COMPRESSION_SUPPORTED_TYPES.includes(preprocessedFile.type) && !(await isAnimated(preprocessedFile));
 
 		if (needsCompress) {

--- a/packages/frontend/src/pages/settings/drive.vue
+++ b/packages/frontend/src/pages/settings/drive.vue
@@ -129,6 +129,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 							<MkSelect
 								v-model="defaultImageCompressionLevel" :items="[
 									{ label: i18n.ts.none, value: 0 },
+									{ label: i18n.ts._compression._quality.webpcompress, value: 10 },
 									{ label: `${i18n.ts.low} (${i18n.ts._compression._quality.high}; ${i18n.ts._compression._size.large})`, value: 1 },
 									{ label: `${i18n.ts.medium} (${i18n.ts._compression._quality.medium}; ${i18n.ts._compression._size.medium})`, value: 2 },
 									{ label: `${i18n.ts.high} (${i18n.ts._compression._quality.low}; ${i18n.ts._compression._size.small})`, value: 3 },
@@ -153,6 +154,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 							<MkSelect
 								v-model="defaultVideoCompressionLevel" :items="[
 									{ label: i18n.ts.none, value: 0 },
+									{ label: i18n.ts._compression._quality.webpcompress, value: 10 },
 									{ label: `${i18n.ts.low} (${i18n.ts._compression._quality.high}; ${i18n.ts._compression._size.large})`, value: 1 },
 									{ label: `${i18n.ts.medium} (${i18n.ts._compression._quality.medium}; ${i18n.ts._compression._size.medium})`, value: 2 },
 									{ label: `${i18n.ts.high} (${i18n.ts._compression._quality.low}; ${i18n.ts._compression._size.small})`, value: 3 },


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Resolve: #943 
<img width="430" height="242" alt="image" src="https://github.com/user-attachments/assets/115f24e2-cce1-4c01-8306-c8204730dc49" />
とりあえず`WebP圧縮のみ`という説明にする


## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
