### PR TITLE
fix(frontend): renoteの確認ポップアップ表示されるように

### DIFF
--- a/packages/frontend/src/utility/check-last-renote.ts
+++ b/packages/frontend/src/utility/check-last-renote.ts
@@ -7,6 +7,14 @@ import * as os from '@/os.js';
 import { prefer } from '@/preferences.js';
 
 export async function confirmRenote(renoteId:string) : Promise<boolean> {
+	if (prefer.s.showRenoteConfirmPopup) {
+		const { canceled } = await os.confirm({
+			type: 'info',
+			text: i18n.ts.renoteConfirm,
+			caption: i18n.ts.renoteConfirmDescription,
+		});
+		if (canceled) return canceled;
+	}
 	if (prefer.s.checkMultipleRenote === false ) return false;
 	const lastRenoteId = localStorage.getItem('lastRenoteId');
 	if (lastRenoteId) {

--- a/packages/frontend/src/utility/get-note-menu.ts
+++ b/packages/frontend/src/utility/get-note-menu.ts
@@ -981,9 +981,6 @@ export async function getRenoteMenu(props: {
 					visibility = smallerVisibility(visibility, 'home');
 				}
 
-				const result = await confirmRenote(appearNote.id);
-				if (result) return;
-
 				if (!props.mock) {
 					const canceled = await confirmRenote(appearNote.id);
 					if (canceled) return;


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
fix: #829

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [ ] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
