### PR TITLE
fix(frontend): コントロールパネルのファイル表示が絵文字ラベルでずれる問題の修正

### DIFF
--- a/packages/frontend/src/components/MkFileListForAdmin.vue
+++ b/packages/frontend/src/components/MkFileListForAdmin.vue
@@ -6,7 +6,13 @@ SPDX-License-Identifier: AGPL-3.0-only
 <template>
 <div>
 	<MkPagination v-slot="{ items }" :paginator="paginator">
-		<div :class="[$style.fileList, { [$style.grid]: viewMode === 'grid', [$style.list]: viewMode === 'list', '_gaps_s': viewMode === 'list' }]">
+		<div
+			:class="{
+				[$style.grid]: viewMode === 'grid',
+				[$style.list]: viewMode === 'list',
+				'_gaps_s': viewMode === 'list',
+			}"
+		>
 			<MkA
 				v-for="file in items"
 				:key="file.id"
@@ -14,17 +20,17 @@ SPDX-License-Identifier: AGPL-3.0-only
 				:to="`/admin/file/${file.id}`"
 				:class="[$style.file, '_button']"
 			>
-				<!-- <div v-if="file.isSensitive" :class="$style.sensitiveLabel">{{ i18n.ts.sensitive }}</div> -->
+				<!--<div v-if="file.isSensitive" :class="$style.sensitiveLabel">{{ i18n.ts.sensitive }}</div>-->
 				<div :class="$style.indicators">
 					<div v-if="['image/gif'].includes(file.type)" :class="$style.indicator">GIF</div>
 					<div v-if="['image/apng'].includes(file.type)" :class="$style.indicator">APNG</div>
 					<div v-if="file.comment" :class="$style.indicator">ALT</div>
 					<div v-if="file.isSensitive" :class="$style.indicator" style="color: var(--MI_THEME-warn);" :title="i18n.ts.sensitive"><i class="ti ti-eye-exclamation"></i></div>
 				</div>
-			<div v-if="customEmojiUrls.includes(file.url)" class="label">
-				<img class="labelImg" src="/client-assets/label.svg"/>
-				<p class="labelText">{{ i18n.ts.emoji }}</p>
-			</div>
+				<div v-if="customEmojiUrls.includes(file.url)" :class="$style.label">
+					<img :class="$style.labelImg" src="/client-assets/label.svg"/>
+					<p :class="$style.labelText">{{ i18n.ts.emoji }}</p>
+				</div>
 				<MkDriveFileThumbnail :class="$style.thumbnail" :file="file" fit="contain" :highlightWhenSensitive="true"/>
 				<div v-if="viewMode === 'list'" :class="$style.body">
 					<div>
@@ -50,8 +56,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 <script lang="ts" setup>
 import * as Misskey from 'cherrypick-js';
-import type { Paginator } from '@/utility/paginator.js';
 import { ref, watch } from 'vue';
+import type { Paginator } from '@/utility/paginator.js';
 import MkPagination from '@/components/MkPagination.vue';
 import MkDriveFileThumbnail from '@/components/MkDriveFileThumbnail.vue';
 import bytes from '@/filters/bytes.js';
@@ -63,6 +69,7 @@ let customEmojiUrls = ref<string[]>([]);
 watch(customEmojis, emojis => {
 	customEmojiUrls.value = emojis.map(emoji => emoji.url);
 }, { immediate: true });
+
 defineProps<{
 	paginator: Paginator<'admin/drive/files'>;
 	viewMode: 'grid' | 'list';
@@ -155,55 +162,55 @@ defineProps<{
 	font-weight: bold;
 	font-size: 0.8em;
 	padding: 2px 5px;
+}
 
-	.label {
+.label {
+	position: absolute;
+	top: 0;
+	left: 0;
+	pointer-events: none;
+
+	&::before,
+	&::after {
+		content: "";
+		display: block;
 		position: absolute;
+		z-index: 1;
+		background: #0c7ac9;
+	}
+
+	&::before {
 		top: 0;
+		left: 57px;
+		width: 28px;
+		height: 8px;
+	}
+
+	&::after {
+		top: 57px;
 		left: 0;
-		pointer-events: none;
-
-		&::before,
-		&::after {
-			content: "";
-			display: block;
-			position: absolute;
-			z-index: 1;
-			background: #0c7ac9;
-		}
-
-		&::before {
-			top: 0;
-			left: 57px;
-			width: 28px;
-			height: 8px;
-		}
-
-		&::after {
-			top: 57px;
-			left: 0;
-			width: 8px;
-			height: 28px;
-		}
+		width: 8px;
+		height: 28px;
 	}
+}
 
-	.labelImg {
-		position: absolute;
-		z-index: 2;
-		top: 0;
-		left: 0;
-	}
+.labelImg {
+	position: absolute;
+	z-index: 2;
+	top: 0;
+	left: 0;
+}
 
-	.labelText {
-		position: absolute;
-		z-index: 3;
-		top: 19px;
-		left: -28px;
-		width: 120px;
-		margin: 0;
-		text-align: center;
-		line-height: 28px;
-		color: #fff;
-		transform: rotate(-45deg);
-	}
+.labelText {
+	position: absolute;
+	z-index: 3;
+	top: 19px;
+	left: -28px;
+	width: 120px;
+	margin: 0;
+	text-align: center;
+	line-height: 28px;
+	color: #fff;
+	transform: rotate(-45deg);
 }
 </style>


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
fix: #984

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
