### PR TITLE
fix(frontend): 動画のアップロードでも圧縮時に"WebP圧縮のみ"が選べてしまう問題の修正

### DIFF
--- a/packages/frontend/src/composables/use-uploader.ts
+++ b/packages/frontend/src/composables/use-uploader.ts
@@ -334,9 +334,11 @@ export function useUploader(options: {
 				}],
 			});
 		}
+		const isImageCompressible = IMAGE_COMPRESSION_SUPPORTED_TYPES.includes(item.file.type);
+		const isVideoCompressible = VIDEO_COMPRESSION_SUPPORTED_TYPES.includes(item.file.type);
 
 		if (
-			(IMAGE_COMPRESSION_SUPPORTED_TYPES.includes(item.file.type) || VIDEO_COMPRESSION_SUPPORTED_TYPES.includes(item.file.type)) &&
+			(isImageCompressible || isVideoCompressible) &&
 			!item.preprocessing &&
 			!item.uploading &&
 			!item.uploaded
@@ -361,7 +363,7 @@ export function useUploader(options: {
 						text += `: ${i18n.ts.medium}`;
 					} else if (item.compressionLevel === 3) {
 						text += `: ${i18n.ts.high}`;
-					} else if (item.compressionLevel === 10) {
+					} else if (isImageCompressible && item.compressionLevel === 10) {
 						text += `: ${i18n.ts._compression._quality.webpcompress}`;
 					}
 
@@ -373,12 +375,12 @@ export function useUploader(options: {
 					text: i18n.ts.none,
 					active: computed(() => item.compressionLevel === 0 || item.compressionLevel == null),
 					action: () => changeCompressionLevel(0),
-				}, {
+				}, ...(isImageCompressible ? [{
 					type: 'radioOption',
 					text: i18n.ts._compression._quality.webpcompress,
 					active: computed(() => item.compressionLevel === 10),
 					action: () => changeCompressionLevel(10),
-				}, {
+				}] as const : []), {
 					type: 'divider',
 				}, {
 					type: 'radioOption',


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
fix: #999

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
