### PR TITLE
fix: 投稿通知ユーザーリストのページネーション不備の修正

### DIFF
--- a/packages/backend/src/server/api/endpoints/users/notify/list.ts
+++ b/packages/backend/src/server/api/endpoints/users/notify/list.ts
@@ -5,7 +5,7 @@
 
 import { Inject, Injectable } from '@nestjs/common';
 import { UserEntityService } from '@/core/entities/UserEntityService.js';
-import type { FollowingsRepository, MiMeta } from '@/models/_.js';
+import type { FollowingsRepository } from '@/models/_.js';
 import { Endpoint } from '@/server/api/endpoint-base.js';
 import { QueryService } from '@/core/QueryService.js';
 import { DI } from '@/di-symbols.js';
@@ -34,26 +34,6 @@ export const meta = {
 				},
 			},
 			required: ['id', 'user'],
-		},
-	},
-
-	errors: {
-		noSuchUser: {
-			message: 'No such user.',
-			code: 'NO_SUCH_USER',
-			id: '63e4aba4-4156-4e53-be25-c9559e42d71b',
-		},
-
-		forbidden: {
-			message: 'Forbidden.',
-			code: 'FORBIDDEN',
-			id: 'f6cdb0df-c19f-ec5c-7dbb-0ba84a1f92ba',
-		},
-
-		signinRequired: {
-			message: 'Signin required.',
-			code: 'SIGNIN_REQUIRED',
-			id: '9748b741-4742-4a34-97d4-c5abcb537ca4',
 		},
 	},
 } as const;

--- a/packages/backend/src/server/api/endpoints/users/notify/list.ts
+++ b/packages/backend/src/server/api/endpoints/users/notify/list.ts
@@ -22,8 +22,18 @@ export const meta = {
 		optional: false, nullable: false,
 		items: {
 			type: 'object',
-			optional: false, nullable: false,
-			ref: 'UserDetailed',
+			nullable: false,
+			properties: {
+				id: {
+					type: 'string',
+					format: 'misskey:id',
+				},
+				user: {
+					type: 'object',
+					ref: 'UserDetailed',
+				},
+			},
+			required: ['id', 'user'],
 		},
 	},
 
@@ -80,7 +90,12 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 
 			const users = followings.map(f => f.followee!);
 
-			return await this.userEntityService.packMany(users, me, { schema: 'UserDetailed' });
+			const userMap = await this.userEntityService.packMany(users, me, { schema: 'UserDetailed' })
+				.then(packed => new Map(packed.map(u => [u.id, u])));
+			return followings.map(following => ({
+				id: following.id,
+				user: userMap.get(following.followeeId)!,
+			}));
 		});
 	}
 }

--- a/packages/backend/test/e2e/note-notify.ts
+++ b/packages/backend/test/e2e/note-notify.ts
@@ -33,14 +33,14 @@ describe('users/notify/list', () => {
 
 	test('通知設定ありのフォローがある場合、そのユーザーが返る', async () => {
 		// alice が carol をフォローして通知ON
-		await api('following/create', { userId: carol.id, withReplies: false }, alice);
+		await api('following/create', { userId: carol.id }, alice);
 		await api('following/update', { userId: carol.id, notify: 'normal' }, alice);
 
 		const res = await api('users/notify/list', {}, alice);
 
 		assert.strictEqual(res.status, 200);
 		assert.strictEqual(res.body.length, 1);
-		assert.strictEqual(res.body[0].id, carol.id);
+		assert.strictEqual(res.body[0].user.id, carol.id);
 	});
 
 	test('複数ユーザーで通知設定ありの場合、全員返る', async () => {
@@ -52,7 +52,7 @@ describe('users/notify/list', () => {
 		assert.strictEqual(res.status, 200);
 		assert.strictEqual(res.body.length, 2);
 
-		const ids = res.body.map((u: { id: string }) => u.id).sort();
+		const ids = res.body.map((u: { id: string, user: misskey.entities.UserDetailed }) => u.user.id).sort();
 		assert.deepStrictEqual(ids, [bob.id, carol.id].sort());
 	});
 
@@ -63,7 +63,7 @@ describe('users/notify/list', () => {
 
 		assert.strictEqual(res.status, 200);
 		assert.strictEqual(res.body.length, 1);
-		assert.strictEqual(res.body[0].id, carol.id);
+		assert.strictEqual(res.body[0].user.id, carol.id);
 	});
 
 	test('他のユーザーの通知対象は見えない', async () => {
@@ -79,7 +79,7 @@ describe('users/notify/list', () => {
 		// bob の一覧には carol だけが含まれる
 		const bobRes = await api('users/notify/list', {}, bob);
 		assert.strictEqual(bobRes.body.length, 1);
-		assert.strictEqual(bobRes.body[0].id, carol.id);
+		assert.strictEqual(bobRes.body[0].user.id, carol.id);
 
 		// 後片付け: bob → carol のフォローを解除
 		await api('following/delete', { userId: carol.id }, bob);
@@ -122,6 +122,34 @@ describe('users/notify/list', () => {
 		const res = await api('users/notify/list', { limit: 1 }, alice);
 		assert.strictEqual(res.status, 200);
 		assert.strictEqual(res.body.length, 1);
+	});
+
+	test('untilId パラメータが効く', async () => {
+		const allRes = await api('users/notify/list', {}, alice);
+		assert.strictEqual(allRes.status, 200);
+		assert.strictEqual(allRes.body.length, 2);
+
+		const newerId = allRes.body[0].id;
+		const olderId = allRes.body[1].id;
+
+		const res = await api('users/notify/list', { untilId: newerId }, alice);
+		assert.strictEqual(res.status, 200);
+		assert.strictEqual(res.body.length, 1);
+		assert.strictEqual(res.body[0].id, olderId);
+	});
+
+	test('sinceId パラメータが効く', async () => {
+		const allRes = await api('users/notify/list', {}, alice);
+		assert.strictEqual(allRes.status, 200);
+		assert.strictEqual(allRes.body.length, 2);
+
+		const newerId = allRes.body[0].id;
+		const olderId = allRes.body[1].id;
+
+		const res = await api('users/notify/list', { sinceId: olderId }, alice);
+		assert.strictEqual(res.status, 200);
+		assert.strictEqual(res.body.length, 1);
+		assert.strictEqual(res.body[0].id, newerId);
 	});
 
 	test('未認証の場合はエラー', async () => {

--- a/packages/frontend/src/pages/settings/notifications.vue
+++ b/packages/frontend/src/pages/settings/notifications.vue
@@ -45,12 +45,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<template #label><SearchLabel>{{ i18n.ts.notifyUsers }}</SearchLabel></template>
 					<MkPagination v-slot="{items}" :paginator="notifyUserPaginator" withControl>
 						<div class="_gaps_s">
-							<div v-for="item in items" :key="item.id" :class="[$style.userItem ]">
+							<div v-for="item in items" :key="item.id">
 								<div :class="$style.userItemMain">
-									<MkA :class="$style.userItemMainBody" :to="userPage(item)">
-										<MkUserCardMini :user="item"/>
+									<MkA :class="$style.userItemMainBody" :to="userPage(item.user)">
+										<MkUserCardMini :user="item.user"/>
 									</MkA>
-									<button class="_button" :class="$style.notifyMenu" @click="showNotifyMenu(item, $event)"><i class="ti ti-dots"></i></button>
+									<button class="_button" :class="$style.notifyMenu" @click="showNotifyMenu(item.user, $event)"><i class="ti ti-dots"></i></button>
 								</div>
 							</div>
 						</div>

--- a/packages/frontend/src/pages/settings/notifications.vue
+++ b/packages/frontend/src/pages/settings/notifications.vue
@@ -185,12 +185,6 @@ definePage(() => ({
 	display: flex;
 }
 
-.userItemSub {
-	padding: 6px 12px;
-	font-size: 85%;
-	color: color(from var(--MI_THEME-fg) srgb r g b / 0.75);
-}
-
 .userItemMainBody {
 	flex: 1;
 	min-width: 0;
@@ -205,16 +199,5 @@ definePage(() => ({
 	width: 32px;
 	height: 32px;
 	align-self: center;
-}
-
-.chevron {
-	display: block;
-	transition: transform 0.1s ease-out;
-}
-
-.userItem.userItemOpend {
-	.chevron {
-		transform: rotateX(180deg);
-	}
 }
 </style>

--- a/packages/misskey-js/src/autogen/types.ts
+++ b/packages/misskey-js/src/autogen/types.ts
@@ -39600,7 +39600,11 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    'application/json': components['schemas']['UserDetailed'][];
+                    'application/json': {
+                        /** Format: misskey:id */
+                        id: string;
+                        user: components['schemas']['UserDetailed'];
+                    }[];
                 };
             };
             /** @description Client error */


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
正しくページネーションできない問題の修正

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
#987 での実装不備

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->
untilId / sinceIdテストの追加

## Checklist
- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [x] (必要なら)テストの追加((If possible) Add tests)
