### PR TITLE
fix(test): application/activity+jsonをnginxでキャッシュしないように

### DIFF
--- a/packages/backend/test-federation/.config/example.conf
+++ b/packages/backend/test-federation/.config/example.conf
@@ -6,6 +6,13 @@ map $http_upgrade $connection_upgrade {
 	'' close;
 }
 
+# Do not cache ActivityPub responses
+map $http_accept $ap_no_cache {
+	default 0;
+	"~*application/activity\+json" 1;
+	"~*application/ld\+json" 1;
+}
+
 proxy_cache_path /tmp/nginx_cache levels=1:2 keys_zone=cache1:16m max_size=1g inactive=720m use_temp_path=off;
 
 server {
@@ -65,6 +72,11 @@ server {
 		proxy_cache_lock on;
 		proxy_cache_use_stale updating;
 		proxy_force_ranges on;
+
+		# Bypass cache for ActivityPub JSON requests
+		proxy_no_cache $ap_no_cache;
+		proxy_cache_bypass $ap_no_cache;
+
 		add_header X-Cache $upstream_cache_status;
 	}
 }

--- a/packages/backend/test-federation/test/user.test.ts
+++ b/packages/backend/test-federation/test/user.test.ts
@@ -557,5 +557,38 @@ describe('User', () => {
 				);
 			});
 		});
+
+		describe('Remote user', () => {
+			let alice: LoginUser, bob: LoginUser;
+			let aliceInB: Misskey.entities.UserDetailedNotMe;
+
+			beforeAll(async () => {
+				[alice, bob] = await Promise.all([
+					createAccount('a.test'),
+					createAccount('b.test'),
+				]);
+
+				aliceInB = await resolveRemoteUser('a.test', alice.id, bob);
+			});
+
+			test('Bob can retrieve Alice\'s username change even though Bob does not follow Alice.', async () => {
+				const aliceFollowers = await alice.client.request('users/followers', { userId: alice.id });
+				strictEqual(aliceFollowers.length, 0);
+
+				const bobFollowers = await bob.client.request('users/followers', { userId: bob.id });
+				strictEqual(bobFollowers.length, 0);
+
+				const renewedAlice = await alice.client.request('i/update', { name: 'alice-test' });
+				strictEqual(renewedAlice.name, 'alice-test');
+				await sleep();
+
+				await bob.client.request('federation/update-remote-user', { userId: aliceInB.id });
+				await sleep();
+
+				// キャッシュされている場合、nameがnullで返ってきてnameの変更が反映されていないように見える
+				const newAliceInB = await bob.client.request('users/show', { userId: aliceInB.id });
+				strictEqual(newAliceInB.name, 'alice-test');
+			});
+		});
 	});
 });


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
test-federationのnginxで`application/activity+json`、`application/ld+json`のキャッシュを行わないように変更しました

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
a.testでnameを変更後
b.testで`federation/update-remote-user` -> `users/snow`を行っても
nameがnullから変わらないことがある問題が改善されます

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [x] (必要なら)テストの追加((If possible) Add tests)
