### PR TITLE
fix(frontend): ローカル投稿者のノートでリアクション絵文字をインポートできない問題の修正

### DIFF
--- a/packages/frontend/src/components/MkReactionsViewer.reaction.vue
+++ b/packages/frontend/src/components/MkReactionsViewer.reaction.vue
@@ -92,7 +92,7 @@ const router = useRouter();
 
 const alternative: ComputedRef<string | null> = computed(() => prefer.s.reactableRemoteReactionEnabled ? (customEmojis.value.find(it => it.name === reactionName.value)?.name ?? null) : null);
 
-const canSteal = computed(() => props.note.user.host && $i && ($i.isAdmin || $i.policies.canManageCustomEmojis));
+const canSteal = computed(() => $i != null && ($i.isAdmin || $i.policies.canManageCustomEmojis));
 
 const longTouchEmoji = ref(false);
 
@@ -215,7 +215,7 @@ function stealReaction(ev: MouseEvent) {
 		});
 	}
 
-	if (canSteal.value && reactionHost.value !== '.') {
+	if (canSteal.value && reactionHost.value && reactionHost.value !== '.') {
 		menuItems.push({
 			text: i18n.ts.import,
 			icon: 'ti ti-plus',
@@ -311,7 +311,7 @@ async function menu(ev) {
 		});
 	}
 
-	if (canSteal.value && reactionHost.value !== '.') {
+	if (canSteal.value && reactionHost.value && reactionHost.value !== '.') {
 		menuItems.push({
 			text: i18n.ts.import,
 			icon: 'ti ti-plus',


### PR DESCRIPTION
## 概要

ローカルユーザーが投稿したノートに付いたリモート絵文字のリアクションから、絵文字のインポートメニュー(`stealReaction` / `menu`)が表示されない問題を修正します。

## 背景・原因

インポート項目の表示条件である `canSteal` が、ノート投稿者のホストを必須にしています。

```js
const canSteal = computed(() => props.note.user.host && $i && ($i.isAdmin || $i.policies.canManageCustomEmojis));
```

`props.note.user.host`(=ノート投稿者がリモートユーザー)が前提のため、**投稿者がローカルユーザーのノートでは、管理者・絵文字管理権限者であってもリモート絵文字リアクションのインポート項目が表示されません**。インポート可否はノート投稿者ではなく、リアクション絵文字自体のホストで判定すべきです。

## 主な変更点

- `canSteal` をノート投稿者ホスト依存から外し、権限のみで判定するよう変更
- `stealReaction` / `menu` の2箇所の表示ガードを `canSteal.value && reactionHost.value && reactionHost.value !== '.'` に変更
  - リモート絵文字(`:foo@example.com:`)なら投稿者を問わずインポート可
  - ローカル絵文字(`@.`)・Unicode絵文字・ホスト無し(`reactionHost`が空/undefined)は対象外。`admin/emoji/steal` へ host 未指定で投げる事故も防止します

## テスト

- ローカルユーザーのノートに付いたリモート絵文字リアクションを左クリック/右クリックし、インポート項目が表示されることを手動確認
- ローカル絵文字・Unicode絵文字のリアクションではインポート項目が表示されないことを確認