### PR TITLE
fix(frontend): リアクションメニューのインポート表示条件とラベル表示の修正

### DIFF
--- a/packages/frontend/src/components/MkReactionsViewer.reaction.vue
+++ b/packages/frontend/src/components/MkReactionsViewer.reaction.vue
@@ -75,7 +75,7 @@ const canToggle = computed(() => {
 	//return !props.reaction.match(/@\w/) && $i && emoji && checkReactionPermissions($i, props.note, emoji);
 	return props.reaction.match(/@\w/) == null && $i != null && emoji != null;
 });
-const canGetInfo = computed(() => props.reaction.includes(':'));
+const canGetInfo = computed(() => props.reaction.startsWith(':'));
 const isLocalCustomEmoji = props.reaction[0] === ':' && props.reaction.includes('@.');
 
 const reactionName = computed(() => {
@@ -93,6 +93,10 @@ const router = useRouter();
 const alternative: ComputedRef<string | null> = computed(() => prefer.s.reactableRemoteReactionEnabled ? (customEmojis.value.find(it => it.name === reactionName.value)?.name ?? null) : null);
 
 const canSteal = computed(() => $i != null && ($i.isAdmin || $i.policies.canManageCustomEmojis));
+
+const canImport = computed(() => canSteal.value && props.reaction.startsWith(':') && !!reactionHost.value && reactionHost.value !== '.' && !customEmojisMap.has(reactionName.value));
+
+const reactionLabel = computed(() => props.reaction.startsWith(':') ? `:${reactionName.value}:` : props.reaction);
 
 const longTouchEmoji = ref(false);
 
@@ -185,7 +189,7 @@ function stealReaction(ev: MouseEvent) {
 
 	menuItems.push({
 		type: 'label',
-		text: `:${reactionName.value}:`,
+		text: reactionLabel.value,
 	});
 
 	if (canGetInfo.value) {
@@ -215,7 +219,7 @@ function stealReaction(ev: MouseEvent) {
 		});
 	}
 
-	if (canSteal.value && reactionHost.value && reactionHost.value !== '.') {
+	if (canImport.value) {
 		menuItems.push({
 			text: i18n.ts.import,
 			icon: 'ti ti-plus',
@@ -281,7 +285,7 @@ async function menu(ev) {
 
 	menuItems.push({
 		type: 'label',
-		text: `:${reactionName.value}:`,
+		text: reactionLabel.value,
 	});
 
 	if (canGetInfo.value) {
@@ -311,7 +315,7 @@ async function menu(ev) {
 		});
 	}
 
-	if (canSteal.value && reactionHost.value && reactionHost.value !== '.') {
+	if (canImport.value) {
 		menuItems.push({
 			text: i18n.ts.import,
 			icon: 'ti ti-plus',


### PR DESCRIPTION
## 概要

リアクションのメニュー(`stealReaction` / `menu`)で見つかった3つの不具合を修正します。

## 修正内容

`MkReactionsViewer.reaction.vue` に computed を2つ追加し、`stealReaction` / `menu` の両関数で使用します。

```js
const canImport = computed(() => canSteal.value && props.reaction.startsWith(':') && !!reactionHost.value && reactionHost.value !== '.' && !customEmojisMap.has(reactionName.value));

const reactionLabel = computed(() => props.reaction.startsWith(':') ? `:${reactionName.value}:` : props.reaction);
```

| 不具合 | 原因 | 修正 |
|---|---|---|
| ① Unicode絵文字にインポートボタンが表示される | `:`を含まない/ホスト無しのリアクションでも表示されていた | `canImport` が `startsWith(':')` と `!!reactionHost.value` を要求し除外 |
| ② ローカルに同名ショートコードがあってもインポート/インポート+リアクションが表示される | 同名ローカル絵文字の有無を見ていなかった | `!customEmojisMap.has(reactionName.value)` により同名ローカルがあれば両ボタンを非表示 |
| ③ Unicode絵文字でラベルのショートコード表示が壊れる(`:?:`等) | `reactionName` が `slice(0, -1)` でUnicode絵文字を壊していた | `reactionLabel` で Unicode絵文字はそのまま絵文字を、カスタム絵文字は `:name:` を表示 |

あわせて、カスタム絵文字判定を `includes(':')` から `startsWith(':')` に統一しました(`MkReactionIcon.vue` の `reaction[0] === ':'` と整合)。

## テスト

- ESLint: 0エラー(該当ファイル。残存警告はすべて既存のもの)
- 各リアクション種別(Unicode / ローカルカスタム / リモートカスタム / 同名ローカルありのリモート)で `canImport` と `reactionLabel` の評価を確認