### PR TITLE
fix: nodeinfo 500エラーによってフェデレーションテストが落ちる問題の対策

### DIFF
--- a/packages/backend/src/core/SystemAccountService.ts
+++ b/packages/backend/src/core/SystemAccountService.ts
@@ -96,13 +96,31 @@ export class SystemAccountService implements OnApplicationShutdown {
 		if (systemAccount) {
 			this.cache.set(type, systemAccount.user as MiLocalUser);
 			return systemAccount.user as MiLocalUser;
-		} else {
+		}
+
+		// 複数の並行リクエストが同時にアカウント作成を試みる可能性がある。
+		// PostgreSQLではNULLを含む複合ユニークインデックスで重複検出が不完全なため
+		// (MiUserの(host)がnullableで、PGではNULL != NULL)、
+		// 並行INSERTが両方MiUserに成功し、後続テーブル(used_username)で初めて
+		// 衝突が発生するケースがある。その場合は既存レコードを返却する。
+		try {
 			const created = await this.createCorrespondingUser(type, {
 				username: `system.${type}`, // NOTE: (できれば避けたいが) . が含まれるかどうかでシステムアカウントかどうかを判定している処理もあるので変えないように
 				name: this.meta.name,
 			});
 			this.cache.set(type, created);
 			return created;
+		} catch (err: any) {
+			// 競合が発生した可能性。DBから再度検索してみる。
+			const retried = await this.systemAccountsRepository.findOne({
+				where: { type: type },
+				relations: ['user'],
+			});
+			if (retried) {
+				this.cache.set(type, retried.user as MiLocalUser);
+				return retried.user as MiLocalUser;
+			}
+			throw err;
 		}
 	}
 
@@ -160,10 +178,15 @@ export class SystemAccountService implements OnApplicationShutdown {
 				password: hash,
 			});
 
-			await transactionalEntityManager.insert(MiUsedUsername, {
-				createdAt: new Date(),
+			const usedUsernameExists = await transactionalEntityManager.findOneBy(MiUsedUsername, {
 				username: extra.username.toLowerCase(),
 			});
+			if (!usedUsernameExists) {
+				await transactionalEntityManager.insert(MiUsedUsername, {
+					createdAt: new Date(),
+					username: extra.username.toLowerCase(),
+				});
+			}
 
 			await transactionalEntityManager.insert(MiSystemAccount, {
 				id: this.idService.gen(),

--- a/packages/backend/src/core/SystemAccountService.ts
+++ b/packages/backend/src/core/SystemAccountService.ts
@@ -21,7 +21,7 @@ import { IdService } from '@/core/IdService.js';
 import { genRsaKeyPair } from '@/misc/gen-key-pair.js';
 import type { OnApplicationShutdown } from '@nestjs/common';
 import { LoggerService } from '@/core/LoggerService.js';
-import Logger from '@/logger.js';
+import type Logger from '@/logger.js';
 
 export const SYSTEM_ACCOUNT_TYPES = ['actor', 'relay', 'proxy'] as const;
 

--- a/packages/backend/src/core/SystemAccountService.ts
+++ b/packages/backend/src/core/SystemAccountService.ts
@@ -19,9 +19,9 @@ import { bindThis } from '@/decorators.js';
 import { generateNativeUserToken } from '@/misc/token.js';
 import { IdService } from '@/core/IdService.js';
 import { genRsaKeyPair } from '@/misc/gen-key-pair.js';
-import type { OnApplicationShutdown } from '@nestjs/common';
 import { LoggerService } from '@/core/LoggerService.js';
 import type Logger from '@/logger.js';
+import type { OnApplicationShutdown } from '@nestjs/common';
 
 export const SYSTEM_ACCOUNT_TYPES = ['actor', 'relay', 'proxy'] as const;
 
@@ -137,18 +137,18 @@ export class SystemAccountService implements OnApplicationShutdown {
 		let account!: MiUser;
 
 		// Start transaction
-		await this.db.transaction(async transactionalEntityManager => {
-			const exist = await transactionalEntityManager.findOneBy(MiUser, {
-				usernameLower: extra.username.toLowerCase(),
-				host: IsNull(),
-			});
+		try {
+			await this.db.transaction(async transactionalEntityManager => {
+				const exist = await transactionalEntityManager.findOneBy(MiUser, {
+					usernameLower: extra.username.toLowerCase(),
+					host: IsNull(),
+				});
 
-			if (exist) {
-				account = exist;
-				this.logger.info(`System account '${type}' create: existing user found, reusing`);
-				return;
-			}
-			try {
+				if (exist) {
+					account = exist;
+					this.logger.info(`System account '${type}' create: existing user found, reusing`);
+					return;
+				}
 				account = await transactionalEntityManager.insert(MiUser, {
 					id: this.idService.gen(),
 					username: extra.username,
@@ -160,39 +160,38 @@ export class SystemAccountService implements OnApplicationShutdown {
 					isBot: true,
 					name: extra.name,
 				}).then(x => transactionalEntityManager.findOneByOrFail(MiUser, x.identifiers[0]));
-			} catch (e) {
-				// insertでこけたなら、別で作成された可能性があるのでそっちを使ってみる
-				this.logger.info(`System account '${type}' already created by another worker, reusing existing one`);
-				account = await transactionalEntityManager.findOneByOrFail(MiUser, {
-					usernameLower: extra.username.toLowerCase(),
-					host: IsNull(),
+
+				await transactionalEntityManager.insert(MiUserKeypair, {
+					publicKey: keyPair.publicKey,
+					privateKey: keyPair.privateKey,
+					userId: account.id,
 				});
-				return;
-			}
 
-			await transactionalEntityManager.insert(MiUserKeypair, {
-				publicKey: keyPair.publicKey,
-				privateKey: keyPair.privateKey,
-				userId: account.id,
-			});
+				await transactionalEntityManager.insert(MiUserProfile, {
+					userId: account.id,
+					autoAcceptFollowed: false,
+					password: hash,
+				});
 
-			await transactionalEntityManager.insert(MiUserProfile, {
-				userId: account.id,
-				autoAcceptFollowed: false,
-				password: hash,
-			});
+				await transactionalEntityManager.insert(MiUsedUsername, {
+					createdAt: new Date(),
+					username: extra.username.toLowerCase(),
+				});
 
-			await transactionalEntityManager.insert(MiUsedUsername, {
-				createdAt: new Date(),
-				username: extra.username.toLowerCase(),
+				await transactionalEntityManager.insert(MiSystemAccount, {
+					id: this.idService.gen(),
+					userId: account.id,
+					type: type,
+				});
 			});
-
-			await transactionalEntityManager.insert(MiSystemAccount, {
-				id: this.idService.gen(),
-				userId: account.id,
-				type: type,
+		} catch (e) {
+			// transactionでこけたなら、別で作成された可能性がある？
+			this.logger.info(`System account '${type}' already created by another worker, reusing existing one`);
+			account = await this.usersRepository.findOneByOrFail({
+				usernameLower: extra.username.toLowerCase(),
+				host: IsNull(),
 			});
-		});
+		}
 
 		return account as MiLocalUser;
 	}

--- a/packages/backend/src/core/SystemAccountService.ts
+++ b/packages/backend/src/core/SystemAccountService.ts
@@ -148,18 +148,27 @@ export class SystemAccountService implements OnApplicationShutdown {
 				this.logger.info(`System account '${type}' create: existing user found, reusing`);
 				return;
 			}
-
-			account = await transactionalEntityManager.insert(MiUser, {
-				id: this.idService.gen(),
-				username: extra.username,
-				usernameLower: extra.username.toLowerCase(),
-				host: null,
-				token: secret,
-				isLocked: true,
-				isExplorable: false,
-				isBot: true,
-				name: extra.name,
-			}).then(x => transactionalEntityManager.findOneByOrFail(MiUser, x.identifiers[0]));
+			try {
+				account = await transactionalEntityManager.insert(MiUser, {
+					id: this.idService.gen(),
+					username: extra.username,
+					usernameLower: extra.username.toLowerCase(),
+					host: null,
+					token: secret,
+					isLocked: true,
+					isExplorable: false,
+					isBot: true,
+					name: extra.name,
+				}).then(x => transactionalEntityManager.findOneByOrFail(MiUser, x.identifiers[0]));
+			} catch (e) {
+				// insertでこけたなら、別で作成された可能性があるのでそっちを使ってみる
+				this.logger.info(`System account '${type}' already created by another worker, reusing existing one`);
+				account = await transactionalEntityManager.findOneByOrFail(MiUser, {
+					usernameLower: extra.username.toLowerCase(),
+					host: IsNull(),
+				});
+				return;
+			}
 
 			await transactionalEntityManager.insert(MiUserKeypair, {
 				publicKey: keyPair.publicKey,

--- a/packages/backend/src/core/SystemAccountService.ts
+++ b/packages/backend/src/core/SystemAccountService.ts
@@ -26,6 +26,7 @@ export const SYSTEM_ACCOUNT_TYPES = ['actor', 'relay', 'proxy'] as const;
 @Injectable()
 export class SystemAccountService implements OnApplicationShutdown {
 	private cache: MemoryKVCache<MiLocalUser>;
+	/** 同時に fetch されたとき、進行中の作成処理を共有する（二重作成防止） */
 	private pendingFetches = new Map<typeof SYSTEM_ACCOUNT_TYPES[number], Promise<MiLocalUser>>();
 
 	constructor(

--- a/packages/backend/src/core/SystemAccountService.ts
+++ b/packages/backend/src/core/SystemAccountService.ts
@@ -20,14 +20,15 @@ import { generateNativeUserToken } from '@/misc/token.js';
 import { IdService } from '@/core/IdService.js';
 import { genRsaKeyPair } from '@/misc/gen-key-pair.js';
 import type { OnApplicationShutdown } from '@nestjs/common';
+import { LoggerService } from '@/core/LoggerService.js';
+import Logger from '@/logger.js';
 
 export const SYSTEM_ACCOUNT_TYPES = ['actor', 'relay', 'proxy'] as const;
 
 @Injectable()
 export class SystemAccountService implements OnApplicationShutdown {
 	private cache: MemoryKVCache<MiLocalUser>;
-	/** 同時に fetch されたとき、進行中の作成処理を共有する（二重作成防止） */
-	private pendingFetches = new Map<typeof SYSTEM_ACCOUNT_TYPES[number], Promise<MiLocalUser>>();
+	private logger: Logger;
 
 	constructor(
 		@Inject(DI.redisForSub)
@@ -49,8 +50,11 @@ export class SystemAccountService implements OnApplicationShutdown {
 		private userProfilesRepository: UserProfilesRepository,
 
 		private idService: IdService,
+
+		private loggerService: LoggerService,
 	) {
 		this.cache = new MemoryKVCache<MiLocalUser>(1000 * 60 * 10); // 10m
+		this.logger = this.loggerService.getLogger('SystemAccount', 'blue');
 
 		this.redisForSub.on('message', this.onMessage);
 	}
@@ -88,36 +92,30 @@ export class SystemAccountService implements OnApplicationShutdown {
 	@bindThis
 	public async fetch(type: typeof SYSTEM_ACCOUNT_TYPES[number]): Promise<MiLocalUser> {
 		const cached = this.cache.get(type);
-		if (cached) return cached;
+		if (cached) {
+			this.logger.info(`System account '${type}' fetch: cache hit`);
+			return cached;
+		}
 
-		const pending = this.pendingFetches.get(type);
-		if (pending) return pending;
-
-		const promise = this.fetchInternal(type).finally(() => {
-			this.pendingFetches.delete(type);
-		});
-		this.pendingFetches.set(type, promise);
-		return promise;
-	}
-
-	@bindThis
-	private async fetchInternal(type: typeof SYSTEM_ACCOUNT_TYPES[number]): Promise<MiLocalUser> {
 		const systemAccount = await this.systemAccountsRepository.findOne({
 			where: { type: type },
 			relations: ['user'],
 		});
 
 		if (systemAccount) {
+			this.logger.info(`System account '${type}' fetch: db hit`);
 			this.cache.set(type, systemAccount.user as MiLocalUser);
 			return systemAccount.user as MiLocalUser;
+		} else {
+			this.logger.info(`System account '${type}' fetch: creating new account...`);
+			const created = await this.createCorrespondingUser(type, {
+				username: `system.${type}`, // NOTE: (できれば避けたいが) . が含まれるかどうかでシステムアカウントかどうかを判定している処理もあるので変えないように
+				name: this.meta.name,
+			});
+			this.cache.set(type, created);
+			this.logger.succ(`System account '${type}' created successfully`);
+			return created;
 		}
-
-		const created = await this.createCorrespondingUser(type, {
-			username: `system.${type}`, // NOTE: (できれば避けたいが) . が含まれるかどうかでシステムアカウントかどうかを判定している処理もあるので変えないように
-			name: this.meta.name,
-		});
-		this.cache.set(type, created);
-		return created;
 	}
 
 	@bindThis
@@ -147,15 +145,7 @@ export class SystemAccountService implements OnApplicationShutdown {
 
 			if (exist) {
 				account = exist;
-
-				const systemAccountExists = await transactionalEntityManager.findOneBy(MiSystemAccount, { type: type });
-				if (!systemAccountExists) {
-					await transactionalEntityManager.insert(MiSystemAccount, {
-						id: this.idService.gen(),
-						userId: account.id,
-						type: type,
-					});
-				}
+				this.logger.info(`System account '${type}' create: existing user found, reusing`);
 				return;
 			}
 

--- a/packages/backend/src/core/SystemAccountService.ts
+++ b/packages/backend/src/core/SystemAccountService.ts
@@ -26,6 +26,7 @@ export const SYSTEM_ACCOUNT_TYPES = ['actor', 'relay', 'proxy'] as const;
 @Injectable()
 export class SystemAccountService implements OnApplicationShutdown {
 	private cache: MemoryKVCache<MiLocalUser>;
+	private pendingFetches = new Map<typeof SYSTEM_ACCOUNT_TYPES[number], Promise<MiLocalUser>>();
 
 	constructor(
 		@Inject(DI.redisForSub)
@@ -88,6 +89,18 @@ export class SystemAccountService implements OnApplicationShutdown {
 		const cached = this.cache.get(type);
 		if (cached) return cached;
 
+		const pending = this.pendingFetches.get(type);
+		if (pending) return pending;
+
+		const promise = this.fetchInternal(type).finally(() => {
+			this.pendingFetches.delete(type);
+		});
+		this.pendingFetches.set(type, promise);
+		return promise;
+	}
+
+	@bindThis
+	private async fetchInternal(type: typeof SYSTEM_ACCOUNT_TYPES[number]): Promise<MiLocalUser> {
 		const systemAccount = await this.systemAccountsRepository.findOne({
 			where: { type: type },
 			relations: ['user'],
@@ -98,30 +111,12 @@ export class SystemAccountService implements OnApplicationShutdown {
 			return systemAccount.user as MiLocalUser;
 		}
 
-		// 複数の並行リクエストが同時にアカウント作成を試みる可能性がある。
-		// PostgreSQLではNULLを含む複合ユニークインデックスで重複検出が不完全なため
-		// (MiUserの(host)がnullableで、PGではNULL != NULL)、
-		// 並行INSERTが両方MiUserに成功し、後続テーブル(used_username)で初めて
-		// 衝突が発生するケースがある。その場合は既存レコードを返却する。
-		try {
-			const created = await this.createCorrespondingUser(type, {
-				username: `system.${type}`, // NOTE: (できれば避けたいが) . が含まれるかどうかでシステムアカウントかどうかを判定している処理もあるので変えないように
-				name: this.meta.name,
-			});
-			this.cache.set(type, created);
-			return created;
-		} catch (err: any) {
-			// 競合が発生した可能性。DBから再度検索してみる。
-			const retried = await this.systemAccountsRepository.findOne({
-				where: { type: type },
-				relations: ['user'],
-			});
-			if (retried) {
-				this.cache.set(type, retried.user as MiLocalUser);
-				return retried.user as MiLocalUser;
-			}
-			throw err;
-		}
+		const created = await this.createCorrespondingUser(type, {
+			username: `system.${type}`, // NOTE: (できれば避けたいが) . が含まれるかどうかでシステムアカウントかどうかを判定している処理もあるので変えないように
+			name: this.meta.name,
+		});
+		this.cache.set(type, created);
+		return created;
 	}
 
 	@bindThis
@@ -151,6 +146,15 @@ export class SystemAccountService implements OnApplicationShutdown {
 
 			if (exist) {
 				account = exist;
+
+				const systemAccountExists = await transactionalEntityManager.findOneBy(MiSystemAccount, { type: type });
+				if (!systemAccountExists) {
+					await transactionalEntityManager.insert(MiSystemAccount, {
+						id: this.idService.gen(),
+						userId: account.id,
+						type: type,
+					});
+				}
 				return;
 			}
 
@@ -178,15 +182,10 @@ export class SystemAccountService implements OnApplicationShutdown {
 				password: hash,
 			});
 
-			const usedUsernameExists = await transactionalEntityManager.findOneBy(MiUsedUsername, {
+			await transactionalEntityManager.insert(MiUsedUsername, {
+				createdAt: new Date(),
 				username: extra.username.toLowerCase(),
 			});
-			if (!usedUsernameExists) {
-				await transactionalEntityManager.insert(MiUsedUsername, {
-					createdAt: new Date(),
-					username: extra.username.toLowerCase(),
-				});
-			}
 
 			await transactionalEntityManager.insert(MiSystemAccount, {
 				id: this.idService.gen(),

--- a/packages/backend/src/core/SystemAccountService.ts
+++ b/packages/backend/src/core/SystemAccountService.ts
@@ -157,6 +157,7 @@ export class SystemAccountService implements OnApplicationShutdown {
 				this.logger.info(`System account '${type}' create: existing user found, reusing`);
 				return;
 			}
+
 			account = await transactionalEntityManager.insert(MiUser, {
 				id: this.idService.gen(),
 				username: extra.username,

--- a/packages/backend/src/core/SystemAccountService.ts
+++ b/packages/backend/src/core/SystemAccountService.ts
@@ -92,10 +92,7 @@ export class SystemAccountService implements OnApplicationShutdown {
 	@bindThis
 	public async fetch(type: typeof SYSTEM_ACCOUNT_TYPES[number]): Promise<MiLocalUser> {
 		const cached = this.cache.get(type);
-		if (cached) {
-			this.logger.info(`System account '${type}' fetch: cache hit`);
-			return cached;
-		}
+		if (cached) return cached;
 
 		const systemAccount = await this.systemAccountsRepository.findOne({
 			where: { type: type },
@@ -108,13 +105,25 @@ export class SystemAccountService implements OnApplicationShutdown {
 			return systemAccount.user as MiLocalUser;
 		} else {
 			this.logger.info(`System account '${type}' fetch: creating new account...`);
-			const created = await this.createCorrespondingUser(type, {
-				username: `system.${type}`, // NOTE: (できれば避けたいが) . が含まれるかどうかでシステムアカウントかどうかを判定している処理もあるので変えないように
-				name: this.meta.name,
-			});
-			this.cache.set(type, created);
-			this.logger.succ(`System account '${type}' created successfully`);
-			return created;
+
+			try {
+				const created = await this.createCorrespondingUser(type, {
+					username: `system.${type}`, // NOTE: (できれば避けたいが) . が含まれるかどうかでシステムアカウントかどうかを判定している処理もあるので変えないように
+					name: this.meta.name,
+				});
+				this.cache.set(type, created);
+				this.logger.succ(`System account '${type}' created successfully`);
+				return created;
+			} catch (e) {
+				// transactionでこけたなら、別で作成された可能性がある
+				const account = await this.usersRepository.findOneByOrFail({
+					usernameLower: `system.${type}`.toLowerCase(),
+					host: IsNull(),
+				}) as MiLocalUser;
+				this.cache.set(type, account);
+				this.logger.info(`System account '${type}' already created by another worker, reusing existing one`);
+				return account;
+			}
 		}
 	}
 
@@ -137,61 +146,52 @@ export class SystemAccountService implements OnApplicationShutdown {
 		let account!: MiUser;
 
 		// Start transaction
-		try {
-			await this.db.transaction(async transactionalEntityManager => {
-				const exist = await transactionalEntityManager.findOneBy(MiUser, {
-					usernameLower: extra.username.toLowerCase(),
-					host: IsNull(),
-				});
-
-				if (exist) {
-					account = exist;
-					this.logger.info(`System account '${type}' create: existing user found, reusing`);
-					return;
-				}
-				account = await transactionalEntityManager.insert(MiUser, {
-					id: this.idService.gen(),
-					username: extra.username,
-					usernameLower: extra.username.toLowerCase(),
-					host: null,
-					token: secret,
-					isLocked: true,
-					isExplorable: false,
-					isBot: true,
-					name: extra.name,
-				}).then(x => transactionalEntityManager.findOneByOrFail(MiUser, x.identifiers[0]));
-
-				await transactionalEntityManager.insert(MiUserKeypair, {
-					publicKey: keyPair.publicKey,
-					privateKey: keyPair.privateKey,
-					userId: account.id,
-				});
-
-				await transactionalEntityManager.insert(MiUserProfile, {
-					userId: account.id,
-					autoAcceptFollowed: false,
-					password: hash,
-				});
-
-				await transactionalEntityManager.insert(MiUsedUsername, {
-					createdAt: new Date(),
-					username: extra.username.toLowerCase(),
-				});
-
-				await transactionalEntityManager.insert(MiSystemAccount, {
-					id: this.idService.gen(),
-					userId: account.id,
-					type: type,
-				});
-			});
-		} catch (e) {
-			// transactionでこけたなら、別で作成された可能性がある？
-			this.logger.info(`System account '${type}' already created by another worker, reusing existing one`);
-			account = await this.usersRepository.findOneByOrFail({
+		await this.db.transaction(async transactionalEntityManager => {
+			const exist = await transactionalEntityManager.findOneBy(MiUser, {
 				usernameLower: extra.username.toLowerCase(),
 				host: IsNull(),
 			});
-		}
+
+			if (exist) {
+				account = exist;
+				this.logger.info(`System account '${type}' create: existing user found, reusing`);
+				return;
+			}
+			account = await transactionalEntityManager.insert(MiUser, {
+				id: this.idService.gen(),
+				username: extra.username,
+				usernameLower: extra.username.toLowerCase(),
+				host: null,
+				token: secret,
+				isLocked: true,
+				isExplorable: false,
+				isBot: true,
+				name: extra.name,
+			}).then(x => transactionalEntityManager.findOneByOrFail(MiUser, x.identifiers[0]));
+
+			await transactionalEntityManager.insert(MiUserKeypair, {
+				publicKey: keyPair.publicKey,
+				privateKey: keyPair.privateKey,
+				userId: account.id,
+			});
+
+			await transactionalEntityManager.insert(MiUserProfile, {
+				userId: account.id,
+				autoAcceptFollowed: false,
+				password: hash,
+			});
+
+			await transactionalEntityManager.insert(MiUsedUsername, {
+				createdAt: new Date(),
+				username: extra.username.toLowerCase(),
+			});
+
+			await transactionalEntityManager.insert(MiSystemAccount, {
+				id: this.idService.gen(),
+				userId: account.id,
+				type: type,
+			});
+		});
 
 		return account as MiLocalUser;
 	}

--- a/packages/backend/test-server/entry.ts
+++ b/packages/backend/test-server/entry.ts
@@ -5,6 +5,7 @@ import { NestFactory } from '@nestjs/core';
 import { INestApplicationContext } from '@nestjs/common';
 import { MainModule } from '@/MainModule.js';
 import { ServerService } from '@/server/ServerService.js';
+import { SYSTEM_ACCOUNT_TYPES, SystemAccountService } from '@/core/SystemAccountService.js';
 import { loadConfig } from '@/config.js';
 import { NestLogger } from '@/NestLogger.js';
 
@@ -15,6 +16,13 @@ process.env.NODE_ENV = 'test';
 
 let app: INestApplicationContext;
 let serverService: ServerService;
+
+async function initializeSystemAccounts(): Promise<void> {
+	const systemAccountService = app.get(SystemAccountService);
+	for (const type of SYSTEM_ACCOUNT_TYPES) {
+		await systemAccountService.fetch(type);
+	}
+}
 
 /**
  * テスト用のサーバインスタンスを起動する
@@ -29,6 +37,7 @@ async function launch() {
 	});
 	serverService = app.get(ServerService);
 	await serverService.launch();
+	await initializeSystemAccounts();
 
 	await startControllerEndpoints();
 
@@ -88,6 +97,7 @@ async function startControllerEndpoints(port = config.port + 1000) {
 		});
 		serverService = app.get(ServerService);
 		await serverService.launch();
+		await initializeSystemAccounts();
 
 		res.code(200).send({ success: true });
 	});

--- a/packages/backend/test-server/entry.ts
+++ b/packages/backend/test-server/entry.ts
@@ -36,8 +36,8 @@ async function launch() {
 		logger: new NestLogger(),
 	});
 	serverService = app.get(ServerService);
-	await serverService.launch();
 	await initializeSystemAccounts();
+	await serverService.launch();
 
 	await startControllerEndpoints();
 
@@ -96,8 +96,8 @@ async function startControllerEndpoints(port = config.port + 1000) {
 			logger: new NestLogger(),
 		});
 		serverService = app.get(ServerService);
-		await serverService.launch();
 		await initializeSystemAccounts();
+		await serverService.launch();
 
 		res.code(200).send({ success: true });
 	});

--- a/packages/backend/test-server/entry.ts
+++ b/packages/backend/test-server/entry.ts
@@ -5,7 +5,6 @@ import { NestFactory } from '@nestjs/core';
 import { INestApplicationContext } from '@nestjs/common';
 import { MainModule } from '@/MainModule.js';
 import { ServerService } from '@/server/ServerService.js';
-import { SYSTEM_ACCOUNT_TYPES, SystemAccountService } from '@/core/SystemAccountService.js';
 import { loadConfig } from '@/config.js';
 import { NestLogger } from '@/NestLogger.js';
 
@@ -16,13 +15,6 @@ process.env.NODE_ENV = 'test';
 
 let app: INestApplicationContext;
 let serverService: ServerService;
-
-async function initializeSystemAccounts(): Promise<void> {
-	const systemAccountService = app.get(SystemAccountService);
-	for (const type of SYSTEM_ACCOUNT_TYPES) {
-		await systemAccountService.fetch(type);
-	}
-}
 
 /**
  * テスト用のサーバインスタンスを起動する
@@ -36,7 +28,6 @@ async function launch() {
 		logger: new NestLogger(),
 	});
 	serverService = app.get(ServerService);
-	await initializeSystemAccounts();
 	await serverService.launch();
 
 	await startControllerEndpoints();
@@ -96,7 +87,6 @@ async function startControllerEndpoints(port = config.port + 1000) {
 			logger: new NestLogger(),
 		});
 		serverService = app.get(ServerService);
-		await initializeSystemAccounts();
 		await serverService.launch();
 
 		res.code(200).send({ success: true });

--- a/packages/backend/test/unit/RelayService.ts
+++ b/packages/backend/test/unit/RelayService.ts
@@ -18,6 +18,7 @@ import { RelayService } from '@/core/RelayService.js';
 import { SystemAccountService } from '@/core/SystemAccountService.js';
 import { GlobalModule } from '@/GlobalModule.js';
 import { UtilityService } from '@/core/UtilityService.js';
+import { LoggerService } from '@/core/LoggerService.js';
 
 const moduleMocker = new ModuleMocker(global);
 
@@ -38,6 +39,7 @@ describe('RelayService', () => {
 				UserEntityService,
 				SystemAccountService,
 				UtilityService,
+				LoggerService,
 			],
 		})
 			.useMocker((token) => {


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
resolve: #1102
トランザクションでこけた場合に、findOneByOrFailでアカウントを探すように変更しました

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
nodeinfo やテストが、`system.proxy` アカウントを二重に作ろうとして 500 エラーになる

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [X] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [ ] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
