### PR TITLE
fix(test-federation): Profile deliveryテストでwaitForを使ってプロファイル連合を待機するように修正 (#1130)

### DIFF
--- a/packages/backend/test-federation/test/emoji.test.ts
+++ b/packages/backend/test-federation/test/emoji.test.ts
@@ -1,6 +1,6 @@
 import assert, { deepStrictEqual, strictEqual } from 'assert';
 import * as Misskey from 'misskey-js';
-import { addCustomEmoji, createAccount, type LoginUser, resolveRemoteUser, sleep, fetchAdmin, requestFederationTestNote, waitForRemoteEmoji } from './utils.js';
+import { addCustomEmoji, createAccount, type LoginUser, resolveRemoteUser, sleep, fetchAdmin, requestFederationTestNote, waitForRemoteEmoji, waitFor } from './utils.js';
 
 describe('Emoji', () => {
 	let alice: LoginUser, bob: LoginUser;
@@ -116,10 +116,15 @@ describe('Emoji', () => {
 		const renewedAlice = await alice.client.request('i/update', { name: `:${emoji.name}:` });
 		await sleep();
 
-		const renewedaliceInB = await bob.client.request('users/show', { userId: aliceInB.id });
-		strictEqual(renewedaliceInB.name, renewedAlice.name);
-		assert(emoji.name in renewedaliceInB.emojis);
-		strictEqual(renewedaliceInB.emojis[emoji.name], emoji.url);
+		let renewedaliceInB: Misskey.entities.UserDetailedNotMe;
+		await waitFor(async () => {
+			renewedaliceInB = await bob.client.request('users/show', { userId: aliceInB.id });
+			return renewedaliceInB.name === renewedAlice.name;
+		});
+
+		strictEqual(renewedaliceInB!.name, renewedAlice.name);
+		assert(emoji.name in renewedaliceInB!.emojis);
+		strictEqual(renewedaliceInB!.emojis[emoji.name], emoji.url);
 		const remoteEmoji = await bob.client.request('emoji', { name: emoji.name, host: 'a.test' });
 		deepStrictEqual(JSON.stringify({
 			id: remoteEmoji.id,
@@ -172,9 +177,14 @@ describe('Emoji', () => {
 		const renewedAlice = await alice.client.request('i/update', { name: `:${emoji.name}:` });
 		await sleep();
 
-		const renewedaliceInB = await bob.client.request('users/show', { userId: aliceInB.id });
-		strictEqual(renewedaliceInB.name, renewedAlice.name);
-		deepStrictEqual({ ...renewedaliceInB.emojis }, {});
+		let renewedaliceInB: Misskey.entities.UserDetailedNotMe;
+		await waitFor(async () => {
+			renewedaliceInB = await bob.client.request('users/show', { userId: aliceInB.id });
+			return renewedaliceInB.name === renewedAlice.name;
+		});
+
+		strictEqual(renewedaliceInB!.name, renewedAlice.name);
+		deepStrictEqual({ ...renewedaliceInB!.emojis }, {});
 	});
 
 	test('コピー拒否の絵文字をコピーできない(copy)', async () => {

--- a/packages/backend/test-federation/test/emoji.test.ts
+++ b/packages/backend/test-federation/test/emoji.test.ts
@@ -2,6 +2,32 @@ import assert, { deepStrictEqual, strictEqual } from 'assert';
 import * as Misskey from 'misskey-js';
 import { addCustomEmoji, createAccount, type LoginUser, resolveRemoteUser, sleep, fetchAdmin, requestFederationTestNote, waitForRemoteEmoji, waitFor } from './utils.js';
 
+/**
+ * リモートユーザーのプロフィール更新(users/show)がpredicateを満たすまでポーリングして待つ。
+ * predicateが真を返した時点の値を返す。
+ */
+export async function waitForRemoteUserUpdate(
+	viewer: LoginUser,
+	userId: string,
+	predicate: (user: Misskey.entities.UserDetailedNotMe) => boolean,
+	options?: { timeout?: number },
+): Promise<Misskey.entities.UserDetailedNotMe> {
+	let user: Misskey.entities.UserDetailedNotMe | undefined;
+	try {
+		await waitFor(async () => {
+			try {
+				user = await viewer.client.request('users/show', { userId });
+				return predicate(user);
+			} catch {
+				return false;
+			}
+		}, { timeout: options?.timeout ?? 30_000, interval: 1_000 });
+	} catch {
+		throw new Error(`remote user update not observed: userId=${userId}, lastObserved=${JSON.stringify(user)}`);
+	}
+	return user as Misskey.entities.UserDetailedNotMe;
+}
+
 describe('Emoji', () => {
 	let alice: LoginUser, bob: LoginUser;
 	let bobInA: Misskey.entities.UserDetailedNotMe, aliceInB: Misskey.entities.UserDetailedNotMe;
@@ -114,17 +140,14 @@ describe('Emoji', () => {
 			description: 'description',
 		});
 		const renewedAlice = await alice.client.request('i/update', { name: `:${emoji.name}:` });
-		await sleep();
 
-		let renewedaliceInB: Misskey.entities.UserDetailedNotMe;
-		await waitFor(async () => {
-			renewedaliceInB = await bob.client.request('users/show', { userId: aliceInB.id });
-			return renewedaliceInB.name === renewedAlice.name;
-		});
+		const renewedaliceInB = await waitForRemoteUserUpdate(bob, aliceInB.id, user =>
+			user.name === renewedAlice.name && emoji.name in user.emojis,
+		);
 
-		strictEqual(renewedaliceInB!.name, renewedAlice.name);
-		assert(emoji.name in renewedaliceInB!.emojis);
-		strictEqual(renewedaliceInB!.emojis[emoji.name], emoji.url);
+		strictEqual(renewedaliceInB.name, renewedAlice.name);
+		assert(emoji.name in renewedaliceInB.emojis);
+		strictEqual(renewedaliceInB.emojis[emoji.name], emoji.url);
 		const remoteEmoji = await bob.client.request('emoji', { name: emoji.name, host: 'a.test' });
 		deepStrictEqual(JSON.stringify({
 			id: remoteEmoji.id,
@@ -175,16 +198,11 @@ describe('Emoji', () => {
 	test('Local-only custom emoji aren\'t delivered with Profile delivery', async () => {
 		const emoji = await addCustomEmoji('a.test', { localOnly: true });
 		const renewedAlice = await alice.client.request('i/update', { name: `:${emoji.name}:` });
-		await sleep();
 
-		let renewedaliceInB: Misskey.entities.UserDetailedNotMe;
-		await waitFor(async () => {
-			renewedaliceInB = await bob.client.request('users/show', { userId: aliceInB.id });
-			return renewedaliceInB.name === renewedAlice.name;
-		});
+		const renewedaliceInB = await waitForRemoteUserUpdate(bob, aliceInB.id, user => user.name === renewedAlice.name);
 
-		strictEqual(renewedaliceInB!.name, renewedAlice.name);
-		deepStrictEqual({ ...renewedaliceInB!.emojis }, {});
+		strictEqual(renewedaliceInB.name, renewedAlice.name);
+		deepStrictEqual({ ...renewedaliceInB.emojis }, {});
 	});
 
 	test('コピー拒否の絵文字をコピーできない(copy)', async () => {


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [ ] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
