### PR TITLE
Enhance: 新しいノート件数が上限に達したとき「100個以上」と表示する

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -738,6 +738,7 @@ showFixedPostFormInChannel: "Display the posting form at the top of the timeline
 withRepliesByDefaultForNewlyFollowed: "Include replies by newly followed users in the timeline by default"
 newNoteRecived: "There are new notes"
 newNoteRecivedCount: "There are {n} new notes"
+newNoteRecivedCountCapped: "There are {n} or more new notes"
 newNote: "New Note"
 sounds: "Sounds"
 sound: "Sounds"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -747,6 +747,7 @@ showFixedPostFormInChannel: "タイムライン上部に投稿フォームを表
 withRepliesByDefaultForNewlyFollowed: "フォローする際、デフォルトで返信をTLに含むようにする"
 newNoteRecived: "新しいノートがあります"
 newNoteRecivedCount: "{n}個の新しいノートがあります"
+newNoteRecivedCountCapped: "{n}個以上の新しいノートがあります"
 newNote: "新しいノート"
 sounds: "サウンド"
 sound: "サウンド"

--- a/packages/frontend/src/components/MkStreamingNotesTimeline.vue
+++ b/packages/frontend/src/components/MkStreamingNotesTimeline.vue
@@ -24,7 +24,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 			>
 				<button class="_buttonPrimary" :class="$style.newButton2" @click="releaseQueue()">
 					<i class="ti ti-arrow-up"></i>
-					<I18n v-if="prefer.s.newNoteReceivedNotificationBehavior === 'count'" :src="i18n.ts.newNoteRecivedCount" textTag="span">
+					<I18n v-if="prefer.s.newNoteReceivedNotificationBehavior === 'count'" :src="paginator.queuedAheadItemsCount.value >= MAX_QUEUE_ITEMS ? i18n.ts.newNoteRecivedCountCapped : i18n.ts.newNoteRecivedCount" textTag="span">
 						<template #n>{{ paginator.queuedAheadItemsCount.value }}</template>
 					</I18n>
 					<span v-else-if="prefer.s.newNoteReceivedNotificationBehavior === 'default'">{{ i18n.ts.newNoteRecived }}</span>
@@ -101,7 +101,7 @@ import MkButton from '@/components/MkButton.vue';
 import { i18n } from '@/i18n.js';
 import { globalEvents, useGlobalEvent } from '@/events.js';
 import { isSeparatorNeeded, getSeparatorInfo } from '@/utility/timeline-date-separate.js';
-import { Paginator } from '@/utility/paginator.js';
+import { MAX_QUEUE_ITEMS, Paginator } from '@/utility/paginator.js';
 import { deviceKind } from '@/utility/device-kind.js';
 import { isFriendly } from '@/utility/is-friendly.js';
 import { scrollToVisibility } from '@/utility/scroll-to-visibility.js';

--- a/packages/frontend/src/utility/paginator.ts
+++ b/packages/frontend/src/utility/paginator.ts
@@ -9,7 +9,7 @@ import type { ComputedRef, Ref, ShallowRef, UnwrapRef } from 'vue';
 import { misskeyApi } from '@/utility/misskey-api.js';
 
 const MAX_ITEMS = 30;
-const MAX_QUEUE_ITEMS = 100;
+export const MAX_QUEUE_ITEMS = 100;
 const FIRST_FETCH_LIMIT = 15;
 const SECOND_FETCH_LIMIT = 30;
 

--- a/packages/i18n/src/autogen/locale.ts
+++ b/packages/i18n/src/autogen/locale.ts
@@ -3013,6 +3013,10 @@ export interface Locale extends ILocale {
      */
     "newNoteRecivedCount": ParameterizedString<"n">;
     /**
+     * {n}個以上の新しいノートがあります
+     */
+    "newNoteRecivedCountCapped": ParameterizedString<"n">;
+    /**
      * 新しいノート
      */
     "newNote": string;


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
resolve: #1128

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
キュー上限で件数が打ち切られてもちょうど100個に見える問題を解消する (#1128)
<img width="454" height="71" alt="image" src="https://github.com/user-attachments/assets/5f917d53-0238-4e44-ad7d-194aa4105f9b" />


## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [ ] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
