### PR TITLE
fix: チャンネル作成時にユーザーアカウントに名前が設定されない問題を修正

### DIFF
--- a/packages/backend/src/core/SignupService.ts
+++ b/packages/backend/src/core/SignupService.ts
@@ -263,6 +263,7 @@ export class SignupService {
 				username: username,
 				usernameLower: username.toLowerCase(),
 				host: null,
+				name: name ?? null,
 				emojis,
 				tags,
 				token: secret,

--- a/packages/backend/src/server/api/endpoints/channels/create.ts
+++ b/packages/backend/src/server/api/endpoints/channels/create.ts
@@ -108,6 +108,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				const { account, channel } = await this.signupService.signupChannel({
 					bannerId: banner?.id,
 					username: ps.username,
+					name: ps.name,
 					ownerId: me.id,
 					description: ps.description,
 					ignorePreservedUsernames: await this.roleService.isModerator(me),

--- a/packages/backend/test/e2e/channel.ts
+++ b/packages/backend/test/e2e/channel.ts
@@ -101,9 +101,9 @@ describe('channels/create with canCreateChannel policy', () => {
 	test('チャンネル作成時にユーザーの名前が設定される', async () => {
 		const username = randomString();
 		const name = randomString() + ' Channel';
-		const ch = await api('channels/create', { username: username, name: name }, alice);
+		const ch = await api('channels/create', { username: username, name: name }, root);
 		assert.strictEqual(ch.status, 200);
-		const channelActor = await api('users/show', { userId: ch.body.actorId! }, alice);
+		const channelActor = await api('users/show', { userId: ch.body.actorId! }, root);
 		assert.strictEqual(channelActor.body.name!, name, 'チャンネル作成時に指定した名前がユーザーとして正しく設定される');
 	});
 });

--- a/packages/backend/test/e2e/channel.ts
+++ b/packages/backend/test/e2e/channel.ts
@@ -97,4 +97,13 @@ describe('channels/create with canCreateChannel policy', () => {
 		const res2 = await api('channels/create', { name: 'channel-ng', username: randomString() }, alice);
 		assert.strictEqual(res2.status, 403, 'チャンネル作成が拒否されること');
 	});
+
+	test('チャンネル作成時にユーザーの名前が設定される', async () => {
+		const username = randomString();
+		const name = randomString() + ' Channel';
+		const ch = await api('channels/create', { username: username, name: name }, alice);
+		assert.strictEqual(ch.status, 200);
+		const channelActor = await api('users/show', { userId: ch.body.actorId! }, alice);
+		assert.strictEqual(channelActor.body.name!, name, 'チャンネル作成時に指定した名前がユーザーとして正しく設定される');
+	});
 });

--- a/packages/backend/test/e2e/channel.ts
+++ b/packages/backend/test/e2e/channel.ts
@@ -9,101 +9,108 @@ import * as assert from 'assert';
 import { api, randomString, signup } from '../utils.js';
 import type * as misskey from 'misskey-js';
 
-describe('channels/create with canCreateChannel policy', () => {
+describe('channels/create', () => {
 	let root: misskey.entities.SignupResponse;
 	let alice: misskey.entities.SignupResponse;
-	let roleId: string;
-	const defaultCanCreateChannel = true;
 
 	beforeAll(async () => {
 		root = await signup({ username: 'root' });
 		alice = await signup({ username: 'alice' });
-
-		const res = await api('admin/roles/create', {
-			name: 'New Role',
-			description: '',
-			color: null,
-			iconUrl: null,
-			target: 'manual',
-			condFormula: { },
-			displayOrder: 0,
-			canEditMembersByModerator: false,
-			asBadge: false,
-			isAdministrator: false,
-			isExplorable: false,
-			isModerator: false,
-			isPublic: false,
-			policies: {
-				canCreateChannel: false,
-			} as any,
-		}, root);
-		assert.strictEqual(res.status, 200, 'ロールが作成されること');
-		assert.strictEqual(res.body.name, 'New Role', 'ロール名が New Role に設定されること');
-		assert.strictEqual(res.body.policies.canCreateChannel, false, 'チャンネル作成ポリシーが false であること');
-		roleId = res.body.id;
 	});
 
-	afterAll(async () => {
-		await api('admin/roles/delete', { roleId }, root).catch(() => {});
+	describe('canCreateChannel policy', () => {
+		let roleId: string;
+		const defaultCanCreateChannel = true;
+
+		beforeAll(async () => {
+			const res = await api('admin/roles/create', {
+				name: 'New Role',
+				description: '',
+				color: null,
+				iconUrl: null,
+				target: 'manual',
+				condFormula: { },
+				displayOrder: 0,
+				canEditMembersByModerator: false,
+				asBadge: false,
+				isAdministrator: false,
+				isExplorable: false,
+				isModerator: false,
+				isPublic: false,
+				policies: {
+					canCreateChannel: false,
+				} as any,
+			}, root);
+			assert.strictEqual(res.status, 200, 'ロールが作成されること');
+			assert.strictEqual(res.body.name, 'New Role', 'ロール名が New Role に設定されること');
+			assert.strictEqual(res.body.policies.canCreateChannel, false, 'チャンネル作成ポリシーが false であること');
+			roleId = res.body.id;
+		});
+
+		afterAll(async () => {
+			await api('admin/roles/delete', { roleId }, root).catch(() => {});
+		});
+
+		beforeEach(async () => {
+			await api('admin/roles/update-default-policies', {
+				policies: {
+					canCreateChannel: defaultCanCreateChannel,
+				} as any,
+			}, root);
+		});
+
+		test('ベースロールで canCreateChannel が false ならチャンネルを作成できない', async () => {
+			await api('admin/roles/update-default-policies', {
+				policies: {
+					canCreateChannel: false,
+				} as any,
+			}, root);
+
+			// /api/i を叩いて policies.canCreateChannel が false であることを確認
+			const iRes = await api('i', {}, alice);
+			assert.strictEqual(iRes.status, 200);
+			assert.strictEqual(iRes.body.policies.canCreateChannel, false);
+
+			const res = await api('channels/create', { name: 'channel-ng', username: randomString() }, alice);
+			assert.strictEqual(res.status, 403, 'チャンネル作成が拒否されること');
+		});
+
+		test('ベースロールで canCreateChannel が true ならチャンネルを作成できる', async () => {
+			const iRes = await api('i', {}, alice);
+			assert.strictEqual(iRes.status, 200);
+			assert.strictEqual(iRes.body.policies.canCreateChannel, true, 'canCreateChannel が true であること');
+
+			const res = await api('channels/create', { name: 'channel-ok', username: randomString() }, alice);
+			assert.strictEqual(res.status, 200);
+			assert.strictEqual(res.body.name, 'channel-ok', 'チャンネル作成ができること');
+		});
+
+		test('付与したロールで canCreateChannel が false ならチャンネルを作成できない', async() => {
+			const iRes1 = await api('i', {}, alice);
+			assert.strictEqual(iRes1.status, 200);
+			assert.strictEqual(iRes1.body.policies.canCreateChannel, true, 'canCreateChannel が true であること');
+
+			const res = await api('admin/roles/assign', { expiresAt: null, roleId: roleId, userId: alice.id }, root);
+			assert.strictEqual(res.status, 204);
+
+			// ロール割り当て後、チャンネルが作成できないポリシーになっていることを確認する
+			const iRes2 = await api('i', {}, alice);
+			assert.strictEqual(iRes2.status, 200);
+			assert.strictEqual(iRes2.body.policies.canCreateChannel, false, 'canCreateChannel が false であること');
+
+			const res2 = await api('channels/create', { name: 'channel-ng', username: randomString() }, alice);
+			assert.strictEqual(res2.status, 403, 'チャンネル作成が拒否されること');
+		});
 	});
 
-	beforeEach(async () => {
-		await api('admin/roles/update-default-policies', {
-			policies: {
-				canCreateChannel: defaultCanCreateChannel,
-			} as any,
-		}, root);
-	});
-
-	test('ベースロールで canCreateChannel が false ならチャンネルを作成できない', async () => {
-		await api('admin/roles/update-default-policies', {
-			policies: {
-				canCreateChannel: false,
-			} as any,
-		}, root);
-
-		// /api/i を叩いて policies.canCreateChannel が false であることを確認
-		const iRes = await api('i', {}, alice);
-		assert.strictEqual(iRes.status, 200);
-		assert.strictEqual(iRes.body.policies.canCreateChannel, false);
-
-		const res = await api('channels/create', { name: 'channel-ng', username: randomString() }, alice);
-		assert.strictEqual(res.status, 403, 'チャンネル作成が拒否されること');
-	});
-
-	test('ベースロールで canCreateChannel が true ならチャンネルを作成できる', async () => {
-		const iRes = await api('i', {}, alice);
-		assert.strictEqual(iRes.status, 200);
-		assert.strictEqual(iRes.body.policies.canCreateChannel, true, 'canCreateChannel が true であること');
-
-		const res = await api('channels/create', { name: 'channel-ok', username: randomString() }, alice);
-		assert.strictEqual(res.status, 200);
-		assert.strictEqual(res.body.name, 'channel-ok', 'チャンネル作成ができること');
-	});
-
-	test('付与したロールで canCreateChannel が false ならチャンネルを作成できない', async() => {
-		const iRes1 = await api('i', {}, alice);
-		assert.strictEqual(iRes1.status, 200);
-		assert.strictEqual(iRes1.body.policies.canCreateChannel, true, 'canCreateChannel が true であること');
-
-		const res = await api('admin/roles/assign', { expiresAt: null, roleId: roleId, userId: alice.id }, root);
-		assert.strictEqual(res.status, 204);
-
-		// ロール割り当て後、チャンネルが作成できないポリシーになっていることを確認する
-		const iRes2 = await api('i', {}, alice);
-		assert.strictEqual(iRes2.status, 200);
-		assert.strictEqual(iRes2.body.policies.canCreateChannel, false, 'canCreateChannel が false であること');
-
-		const res2 = await api('channels/create', { name: 'channel-ng', username: randomString() }, alice);
-		assert.strictEqual(res2.status, 403, 'チャンネル作成が拒否されること');
-	});
-
-	test('チャンネル作成時にユーザーの名前が設定される', async () => {
-		const username = randomString();
-		const name = randomString() + ' Channel';
-		const ch = await api('channels/create', { username: username, name: name }, root);
-		assert.strictEqual(ch.status, 200);
-		const channelActor = await api('users/show', { userId: ch.body.actorId! }, root);
-		assert.strictEqual(channelActor.body.name!, name, 'チャンネル作成時に指定した名前がユーザーとして正しく設定される');
+	describe('チャンネル作成時の基本設定', () => {
+		test('チャンネル作成時にユーザーの名前が設定される', async () => {
+			const username = randomString();
+			const name = randomString() + ' Channel';
+			const ch = await api('channels/create', { username: username, name: name }, root);
+			assert.strictEqual(ch.status, 200);
+			const channelActor = await api('users/show', { userId: ch.body.actorId! }, root);
+			assert.strictEqual(channelActor.body.name!, name, 'チャンネル作成時に指定した名前がユーザーとして正しく設定される');
+		});
 	});
 });


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
fix: #1179

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->
Generated by Kimi-K2.6

## Checklist
- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [ ] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [x] (必要なら)テストの追加((If possible) Add tests)
