### PR TITLE
fix: チャンネル作成時にバナーが設定されない問題を修正

### DIFF
--- a/packages/backend/src/core/SignupService.ts
+++ b/packages/backend/src/core/SignupService.ts
@@ -294,6 +294,7 @@ export class SignupService {
 				actor: account,
 				actorId: account.id,
 				description,
+				bannerId: bannerId ?? null,
 			}));
 			await transactionalEntityManager.update(MiUser, {
 				id: account.id,

--- a/packages/backend/src/core/SignupService.ts
+++ b/packages/backend/src/core/SignupService.ts
@@ -11,7 +11,8 @@ import * as argon2 from 'argon2';
 import { DataSource, IsNull } from 'typeorm';
 import { DriveFile } from 'misskey-js/entities.js';
 import { DI } from '@/di-symbols.js';
-import type { ChannelsRepository, MiMeta, UsedUsernamesRepository, UsersRepository } from '@/models/_.js';
+import { DriveFileEntityService } from '@/core/entities/DriveFileEntityService.js';
+import type { ChannelsRepository, DriveFilesRepository, MiMeta, UsedUsernamesRepository, UsersRepository } from '@/models/_.js';
 import { MiUser } from '@/models/User.js';
 import { MiChannel } from '@/models/Channel.js';
 import { MiUserProfile } from '@/models/UserProfile.js';
@@ -44,6 +45,9 @@ export class SignupService {
 		@Inject(DI.channelsRepository)
 		private channelsRepository: ChannelsRepository,
 
+		@Inject(DI.driveFilesRepository)
+		private driveFilesRepository: DriveFilesRepository,
+
 		@Inject(DI.usedUsernamesRepository)
 		private usedUsernamesRepository: UsedUsernamesRepository,
 
@@ -54,6 +58,7 @@ export class SignupService {
 		private systemAccountService: SystemAccountService,
 		private metaService: MetaService,
 		private usersChart: UsersChart,
+		private driveFileEntityService: DriveFileEntityService,
 	) {
 	}
 
@@ -248,6 +253,10 @@ export class SignupService {
 		}
 		let account!: MiUser;
 		let channel!:MiChannel;
+		let bannerFile = null;
+		if (bannerId != null) {
+			bannerFile = await this.driveFilesRepository.findOneBy({ id: bannerId });
+		}
 
 		// Start transaction
 		await this.db.transaction(async transactionalEntityManager => {
@@ -268,6 +277,8 @@ export class SignupService {
 				tags,
 				token: secret,
 				bannerId: bannerId ?? null,
+				bannerUrl: bannerFile ? this.driveFileEntityService.getPublicUrl(bannerFile) : null,
+				bannerBlurhash: bannerFile ? bannerFile.blurhash : null,
 			}));
 
 			await transactionalEntityManager.save(new MiUserKeypair({

--- a/packages/backend/test/e2e/channel.ts
+++ b/packages/backend/test/e2e/channel.ts
@@ -12,12 +12,10 @@ import type * as misskey from 'misskey-js';
 describe('channels/create', () => {
 	let root: misskey.entities.SignupResponse;
 	let alice: misskey.entities.SignupResponse;
-	let bob: misskey.entities.SignupResponse;
 
 	beforeAll(async () => {
 		root = await signup({ username: 'root' });
 		alice = await signup({ username: 'alice' });
-		bob = await signup({ username: 'bob' });
 	});
 
 	describe('canCreateChannel policy', () => {
@@ -107,12 +105,15 @@ describe('channels/create', () => {
 
 	describe('チャンネル作成時の基本設定', () => {
 		test('チャンネル作成時にバナーが設定される', async () => {
-			const file = await uploadUrl(bob, 'https://raw.githubusercontent.com/yojo-art/cherrypick/develop/packages/backend/test/resources/192.jpg');
+			const file = await uploadUrl(root, 'https://raw.githubusercontent.com/yojo-art/cherrypick/develop/packages/backend/test/resources/192.jpg');
 			const username = randomString();
 			const name = randomString() + ' Channel';
-			const ch = await api('channels/create', { username: username, name: name, bannerId: file.id }, bob);
+			const ch = await api('channels/create', { username: username, name: name, bannerId: file.id }, root);
 			assert.strictEqual(ch.status, 200);
-			assert.strictEqual(ch.body.bannerId, file.id, 'チャンネル作成時に指定したバナーが正しく設定される');
+			assert.notStrictEqual(ch.body.bannerUrl, null, 'チャンネルのbannerUrlが設定される');
+			const channelActor = await api('users/show', { userId: ch.body.actorId! }, root);
+			assert.notStrictEqual(channelActor.body.bannerUrl, null, 'チャンネルアカウントのbannerUrlが設定される');
+			assert.notStrictEqual(channelActor.body.bannerBlurhash, null, 'チャンネルアカウントのbannerBlurhashが設定される');
 		});
 
 		test('チャンネル作成時にユーザーの名前が設定される', async () => {

--- a/packages/backend/test/e2e/channel.ts
+++ b/packages/backend/test/e2e/channel.ts
@@ -6,16 +6,18 @@
 process.env.NODE_ENV = 'test';
 
 import * as assert from 'assert';
-import { api, randomString, signup } from '../utils.js';
+import { api, randomString, signup, uploadUrl } from '../utils.js';
 import type * as misskey from 'misskey-js';
 
 describe('channels/create', () => {
 	let root: misskey.entities.SignupResponse;
 	let alice: misskey.entities.SignupResponse;
+	let bob: misskey.entities.SignupResponse;
 
 	beforeAll(async () => {
 		root = await signup({ username: 'root' });
 		alice = await signup({ username: 'alice' });
+		bob = await signup({ username: 'bob' });
 	});
 
 	describe('canCreateChannel policy', () => {
@@ -104,6 +106,15 @@ describe('channels/create', () => {
 	});
 
 	describe('チャンネル作成時の基本設定', () => {
+		test('チャンネル作成時にバナーが設定される', async () => {
+			const file = await uploadUrl(bob, 'https://raw.githubusercontent.com/yojo-art/cherrypick/develop/packages/backend/test/resources/192.jpg');
+			const username = randomString();
+			const name = randomString() + ' Channel';
+			const ch = await api('channels/create', { username: username, name: name, bannerId: file.id }, bob);
+			assert.strictEqual(ch.status, 200);
+			assert.strictEqual(ch.body.bannerId, file.id, 'チャンネル作成時に指定したバナーが正しく設定される');
+		});
+
 		test('チャンネル作成時にユーザーの名前が設定される', async () => {
 			const username = randomString();
 			const name = randomString() + ' Channel';


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
fix: #1196

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->
- [x] チャンネル作成時にチャンネルにバナーが設定される
- [x] チャンネルユーザーアカウントにバナーが設定される
- [x] チャンネル作成時に各情報にバナーが設定されていることを確認するテストの追加

Generated by kimi-K2.6

## Checklist
- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [x] (必要なら)テストの追加((If possible) Add tests)
