### PR TITLE
feat(frontend): セットアップウィザードでリモートコンテンツの自動クリーニングをデフォルトで無効化

### DIFF
--- a/packages/frontend/src/components/MkServerSetupWizard.vue
+++ b/packages/frontend/src/components/MkServerSetupWizard.vue
@@ -221,7 +221,7 @@ const q_name = ref('');
 const q_use = ref<'single' | 'group' | 'open'>('single');
 const q_scale = ref<'small' | 'medium' | 'large'>('small');
 const q_federation = ref<'yes' | 'no'>('no');
-const q_remoteContentsCleaning = ref(true);
+const q_remoteContentsCleaning = ref(false);
 const q_adminName = ref('');
 const q_adminEmail = ref('');
 


### PR DESCRIPTION
## 概要

Issue #1267 の対応です。
セットアップウィザード（`MkServerSetupWizard.vue`）で、リモートコンテンツの自動クリーニング（Remote Note Cleaning）が初期状態で有効になっていたのを、**デフォルトで無効**に変更しました。

## 変更内容

- `packages/frontend/src/components/MkServerSetupWizard.vue`
  - `q_remoteContentsCleaning` の初期値を `true` → `false` に変更
  - 新規インストール時、ウィザードが送信する `enableRemoteNotesCleaning` が無効になります

## 補足

- DB カラム `enableRemoteNotesCleaning` の既定値はすでに `false`（migration `1753863104203`）で、既存サーバーの手動設定には影響しません
- 実行時は `CleanRemoteNotesProcessorService` が設定値を参照して無効時はスキップするため、バックエンド側の変更は不要です
- 管理画面からは引き続き手動で有効化できます

## テスト

- `pnpm --filter frontend test`
- `pnpm lint`

## 関連

- Closes #1267