### PR TITLE
fix(frontend): 画像ビューアでファイル名（キャプション）が二重に表示される問題を修正

### DIFF
--- a/packages/frontend/src/components/MkMediaList.vue
+++ b/packages/frontend/src/components/MkMediaList.vue
@@ -108,10 +108,8 @@ onMounted(() => {
 					src: media.url,
 					w: media.properties.width,
 					h: media.properties.height,
-					// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-					alt: media.comment || media.name,
-					// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-					comment: media.comment || media.name,
+					alt: media.comment ?? undefined,
+					comment: media.comment ?? undefined,
 				};
 				if (media.properties.orientation != null && media.properties.orientation >= 5) {
 					[item.w, item.h] = [item.h, item.w];
@@ -158,10 +156,8 @@ onMounted(() => {
 			[itemData.w, itemData.h] = [itemData.h, itemData.w];
 		}
 		itemData.msrc = file.thumbnailUrl ?? undefined;
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-		itemData.alt = file.comment || file.name;
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-		itemData.comment = file.comment || file.name;
+		itemData.alt = file.comment ?? undefined;
+		itemData.comment = file.comment ?? undefined;
 		itemData.title = file.name;
 		itemData.thumbCropped = true;
 
@@ -187,13 +183,9 @@ onMounted(() => {
 				el.appendChild(textBox);
 
 				pswp.on('change', () => {
-					textBox.textContent = pswp.currSlide?.data.comment;
-
 					const altText = pswp.currSlide?.data.alt || null;
 					textBox.textContent = altText;
-					if (!altText) {
-						el.style.display = 'none';
-					}
+					el.style.display = altText ? '' : 'none';
 				});
 			},
 		});


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

画像ビューア（PhotoSwipe lightbox）で、キャプション未設定の画像を開いたときにファイル名が二重に表示される問題を修正します。

- **`dataSource` マップ / `itemData` フィルタのフォールバック除去**
  `alt` / `comment` を `media.comment || media.name` / `file.comment || file.name` から `media.comment ?? undefined` / `file.comment ?? undefined` に変更し、キャプション未設定時にファイル名へフォールバックしないようにした。
- **`altText` 要素の表示/非表示トグルを双方向に修正**
  従来は「キャプション無し → `display: none`」のみで、キャプション有りの画像に切り替えても非表示のまま復帰しない二次バグがあった。`altText` の有無で `display` を `''` / `'none'` に明示的に設定するようにした。

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

Issue #1278: ライトボックスには `altText` 要素（キャプション表示、下100px）と `fileName` 要素（ファイル名表示、下20px）の2つが登録されている。`alt` / `comment` がファイル名へフォールバックするため、**キャプション未設定の画像では2つの要素が同じファイル名を表示**し二重表示になっていた。`fileName` 要素がファイル名表示を担うため、`altText` はキャプションのみを表示し、無ければ非表示にするのが本来の意図。

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

- 修正後の表示:
  - キャプション有り → 上にキャプション、下にファイル名
  - キャプション無し → ファイル名のみ（`altText` 要素は非表示）
- キャプション無しの画像でライトボックス内 `<img alt>` は空になるが、`fileName` 要素が代替表示を担うため実用上問題なし
- 検証: `pnpm --filter frontend eslint` / `pnpm --filter frontend typecheck`（MkMediaList.vue のエラーなし。既存の typecheck エラー112件は変更前と同数で無関係）

## Checklist
- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md) 
- [ ] (必要なら)テストの追加((If possible) Add tests) 
