### PR TITLE
fix(test): フレーキーなテストを修正

### DIFF
--- a/packages/backend/test-federation/test/abuse-report.test.ts
+++ b/packages/backend/test-federation/test/abuse-report.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, beforeAll } from 'vitest';
 import { rejects, strictEqual } from 'node:assert';
 import * as Misskey from 'misskey-js';
-import { createAccount, createModerator, resolveRemoteUser, sleep, type LoginUser } from './utils.js';
+import { createAccount, createModerator, resolveRemoteUser, waitFor, type LoginUser } from './utils.js';
 
 describe('Abuse report', () => {
 	describe('Forwarding report', () => {
@@ -31,13 +31,16 @@ describe('Abuse report', () => {
 			const reports = await aModerator.client.request('admin/abuse-user-reports', {});
 			const report = reports.filter(report => report.comment === comment)[0];
 			await aModerator.client.request('admin/forward-abuse-user-report', { reportId: report.id });
-			await sleep();
 
-			const reportsInB = await bModerator.client.request('admin/abuse-user-reports', {});
-			const reportInB = reportsInB.filter(report => report.comment.includes(comment))[0];
-			// NOTE: reporter is not Alice, and is not moderator in A
-			strictEqual(reportInB.reporter.url, 'https://a.test/@system.actor');
-			strictEqual(reportInB.targetUserId, bob.id);
+			await waitFor(async () => {
+				const reportsInB = await bModerator.client.request('admin/abuse-user-reports', {});
+				const reportInB = reportsInB.find(report => report.comment.includes(comment));
+				if (reportInB == null) return false;
+				// NOTE: reporter is not Alice, and is not moderator in A
+				strictEqual(reportInB.reporter.url, 'https://a.test/@system.actor');
+				strictEqual(reportInB.targetUserId, bob.id);
+				return true;
+			});
 
 			// NOTE: cannot forward multiple times
 			await rejects(

--- a/packages/backend/test/e2e/endpoints.ts
+++ b/packages/backend/test/e2e/endpoints.ts
@@ -372,7 +372,7 @@ describe('Endpoints', () => {
 			const newAlice = await Users.findOneByOrFail({ id: alice.id });
 			assert.strictEqual(newAlice.followersCount, 1);
 			assert.strictEqual(newAlice.followingCount, 0);
-			connection.destroy();
+			await connection.destroy();
 		});
 
 		test('既にフォローしている場合は怒る', async () => {
@@ -435,7 +435,7 @@ describe('Endpoints', () => {
 			const newAlice = await Users.findOneByOrFail({ id: alice.id });
 			assert.strictEqual(newAlice.followersCount, 0);
 			assert.strictEqual(newAlice.followingCount, 0);
-			connection.destroy();
+			await connection.destroy();
 		});
 
 		test('フォローしていない場合は怒る', async () => {


### PR DESCRIPTION
## What

CI で間欠的に失敗していたバックエンドテスト 2 件を堅牢化しました。

- `test-federation/test/abuse-report.test.ts`: 通報フォワード後の B サーバーへの配送完了待ちを固定 `sleep()`(250ms) から、既存の `waitFor()`（条件ポーリング, timeout 10s）に変更
- `test/e2e/endpoints.ts`: `following/create` / `following/delete` テストが使う `initTestDb(true)` の借用コネクションを `await connection.destroy()` で確実に閉じるよう変更

## Why

- **abuse-report**: `AbuseReportService.forward` は `queueService.deliver()` による非同期の ActivityPub 配送のため、テスト側の固定 250ms 待ちでは配送が間に合わず、`reportInB` が `undefined` になり `TypeError: Cannot read properties of undefined (reading 'reporter')` で間欠失敗していた
- **endpoints**: `connection.destroy()` が await されていないため借用コネクションの後始末が確定せず、後続テストファイルの `setup.e2e.ts` → `initTestDb(false)`（`dropSchema: true`）によるスキーマ全削除後に残クエリが実行され、`UnhandledRejection: relation "user" does not exist` でジョブ全体が exit 1 になることがあった（テスト自体は全ファイル PASS）

## Additional info (optional)

- `test:fed`（abuse-report 単体・5回連続）と `test:e2e`（endpoints 92テスト）をローカル（Docker）で実行し、いずれも PASS を確認
- 型チェック（`tsgo -p test-federation` / `tsgo -p test`）と eslint はエラーなし（新規警告なし）

## Checklist

- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [ ] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md) 
- [ ] (必要なら)テストの追加((If possible) Add tests) 