### PR TITLE
fix(frontend): スプラッシュ画面のスピナーが背景リングと同色になりただの円に見える問題を修正

### DIFF
--- a/packages/frontend-embed/public/loader/style.css
+++ b/packages/frontend-embed/public/loader/style.css
@@ -77,12 +77,17 @@ html.embed.noborder #splash {
 	left: 0;
 	width: 28px;
 	height: 28px;
-	animation: splashSpinner 2s linear infinite;
-}
-#splashSpinner > .spinner > .path {
-	stroke: var(--MI_THEME-accent);
+	fill-rule: evenodd;
+	clip-rule: evenodd;
 	stroke-linecap: round;
-	animation: dash 1.2s ease-in-out infinite;
+	stroke-linejoin: round;
+	stroke-miterlimit: 1.5;
+}
+#splashSpinner > .spinner.bg {
+	opacity: 0.275;
+}
+#splashSpinner > .spinner.fg {
+	animation: splashSpinner 0.5s linear infinite;
 }
 
 @keyframes splashSpinner {
@@ -91,20 +96,5 @@ html.embed.noborder #splash {
 	}
 	100% {
 		transform: rotate(360deg);
-	}
-}
-
-@keyframes dash {
-	0% {
-		stroke-dasharray: 1, 150;
-		stroke-dashoffset: 0;
-	}
-	50% {
-		stroke-dasharray: 90, 150;
-		stroke-dashoffset: -35;
-	}
-	100% {
-		stroke-dasharray: 90, 150;
-		stroke-dashoffset: -124;
 	}
 }

--- a/packages/frontend/public/loader/style.css
+++ b/packages/frontend/public/loader/style.css
@@ -66,12 +66,17 @@ html {
 	left: 0;
 	width: 28px;
 	height: 28px;
-	animation: splashSpinner 2s linear infinite;
-}
-#splashSpinner > .spinner > .path {
-	stroke: var(--MI_THEME-accent);
+	fill-rule: evenodd;
+	clip-rule: evenodd;
 	stroke-linecap: round;
-	animation: dash 1.2s ease-in-out infinite;
+	stroke-linejoin: round;
+	stroke-miterlimit: 1.5;
+}
+#splashSpinner > .spinner.bg {
+	opacity: 0.275;
+}
+#splashSpinner > .spinner.fg {
+	animation: splashSpinner 0.5s linear infinite;
 }
 
 @keyframes splashSpinner {
@@ -80,20 +85,5 @@ html {
 	}
 	100% {
 		transform: rotate(360deg);
-	}
-}
-
-@keyframes dash {
-	0% {
-		stroke-dasharray: 1, 150;
-		stroke-dashoffset: 0;
-	}
-	50% {
-		stroke-dasharray: 90, 150;
-		stroke-dashoffset: -35;
-	}
-	100% {
-		stroke-dasharray: 90, 150;
-		stroke-dashoffset: -124;
 	}
 }


### PR DESCRIPTION
## What

スプラッシュ画面のローディングスピナーが、背景リングと同色のため回転する円弧が見えず「ただの円」に見える問題を修正しました。

- `packages/frontend/public/loader/style.css` / `packages/frontend-embed/public/loader/style.css`
- 背景リング `.spinner.bg` に `opacity: 0.275` を適用し、前景の円弧 `.spinner.fg` のみ回転させる方式に変更
- SVG 構造に一致しない死に CSS (`#splashSpinner > .spinner > .path` / `@keyframes dash`) を削除
- misskey/develop・cherrypick 上流と同じ実装に統一

## Why

スプラッシュのスピナーは背景の全円リング (`bg`) と前面の円弧 (`fg`) の2要素で構成されますが、yojo-art 側では旧 cherrypick 由来の「dash デザイン」の取り込み時に `.spinner.bg` の不透明度指定が失われ、両リングが同じアクセント色になっていました。加えて `.spinner > .path` セレクタが実際の SVG 構造 (`<circle>` / `<path>` + `stroke:currentColor`) と一致せず dash アニメーションも無効だったため、回転する円弧が視認できずただの円に見えていました。

## Additional info

- 新規アクセス (localStorage 未設定)・既存テーマ・メイン / 埋め込み (frontend-embed) の両方で確認
- 位置 (`translateY`) や `#splashText` など yojo-art 固有のスタイルは変更していません
- CHANGELOG_YOJO.md は今回のコミットに含めていません (必要なら追記します)

## Checklist

- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
