### PR TITLE
fix(frontend): エラーページの表示色とtheme-colorをダーク/ライトテーマに連動させる

### DIFF
--- a/packages/backend/assets/misc/error.css
+++ b/packages/backend/assets/misc/error.css
@@ -19,8 +19,8 @@
 
 body,
 html {
-	background-color: rgb(28, 28, 37);
-	color: #dfddcc;
+	background-color: var(--error-bg, rgb(28, 28, 37));
+	color: var(--error-fg, #dfddcc);
 	justify-content: center;
 	margin: auto;
 	padding: 10px;
@@ -49,12 +49,12 @@ button {
 }
 
 .button-small {
-	background: rgb(35, 35, 47);
+	background: var(--error-sub-bg, rgb(35, 35, 47));
 	line-height: 40px;
 }
 
 .button-small:hover {
-	background: rgba(255, 255, 255, 0.1);
+	background: var(--error-sub-bg-hover, rgba(255, 255, 255, 0.1));
 }
 
 .button-label-big {
@@ -65,13 +65,13 @@ button {
 }
 
 .button-label-small {
-	color: rgb(185, 216, 255);
+	color: var(--error-sub-fg, rgb(185, 216, 255));
 	font-size: 16px;
 	padding: 12px;
 }
 
 a {
-	color: rgb(134, 179, 0);
+	color: var(--error-accent, rgb(255, 188, 220));
 	text-decoration: none;
 }
 
@@ -94,7 +94,7 @@ h1 {
 code {
 	display: block;
 	font-family: "JetBrains Mono", "Pretendard JP", Pretendard, Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-	background: rgb(35, 35, 47);
+	background: var(--error-sub-bg, rgb(35, 35, 47));
 	padding: 0.5rem 1rem;
 	max-width: 40rem;
 	border-radius: 10px;

--- a/packages/backend/assets/misc/error.js
+++ b/packages/backend/assets/misc/error.js
@@ -5,6 +5,70 @@
 
 'use strict';
 
+// ダークテーマならピンク、ライトテーマならブルーの --error-* を設定する
+(() => {
+	try {
+		const PALETTE = {
+			dark: {
+				bg: 'rgb(28, 28, 37)',
+				fg: '#dfddcc',
+				subBg: 'rgb(35, 35, 47)',
+				subBgHover: 'rgba(255, 255, 255, 0.1)',
+				subFg: 'rgb(185, 216, 255)',
+				accent: 'rgb(255, 188, 220)',
+			},
+			light: {
+				bg: 'rgb(238, 241, 252)',
+				fg: 'rgb(87, 112, 150)',
+				subBg: 'rgb(255, 255, 255)',
+				subBgHover: 'rgba(0, 0, 0, 0.05)',
+				subFg: 'rgb(87, 112, 150)',
+				accent: 'rgb(107, 165, 227)',
+			},
+		};
+
+		let dark = null;
+
+		const theme = (() => {
+			try {
+				return JSON.parse(localStorage.getItem('theme') || '{}');
+			} catch (_) {
+				return {};
+			}
+		})();
+
+		if (typeof theme.bg === 'string') {
+			const m = theme.bg.match(/\d+/g);
+			if (m && m.length >= 3) {
+				dark = (0.299 * +m[0] + 0.587 * +m[1] + 0.114 * +m[2]) < 128;
+			}
+		}
+
+		if (dark == null) {
+			const themeId = localStorage.getItem('themeId');
+			if (themeId != null) {
+				if (themeId.startsWith('d-') || themeId === 'dark') dark = true;
+				else if (themeId.startsWith('l-') || themeId === 'light') dark = false;
+			}
+		}
+
+		if (dark == null) {
+			dark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+		}
+
+		const p = dark ? PALETTE.dark : PALETTE.light;
+		const root = document.documentElement.style;
+		root.setProperty('--error-bg', p.bg);
+		root.setProperty('--error-fg', p.fg);
+		root.setProperty('--error-sub-bg', p.subBg);
+		root.setProperty('--error-sub-bg-hover', p.subBgHover);
+		root.setProperty('--error-sub-fg', p.subFg);
+		root.setProperty('--error-accent', p.accent);
+	} catch (_) {
+		// localStorage等が使えない環境ではCSSのフォールバック色に任せる
+	}
+})();
+
 (() => {
 	document.addEventListener('DOMContentLoaded', () => {
 		const locale = JSON.parse(localStorage.getItem('locale') || '{}');

--- a/packages/backend/src/server/web/views/base-embed.tsx
+++ b/packages/backend/src/server/web/views/base-embed.tsx
@@ -37,8 +37,8 @@ export function BaseEmbed(props: PropsWithChildren<CommonProps<{
 					<meta charset="UTF-8" />
 					<meta name="application-name" content="Misskey" />
 					<meta name="referer" content="origin" />
-					<meta name="theme-color" content={props.themeColor ?? '#86b300'} />
-					<meta name="theme-color-orig" content={props.themeColor ?? '#86b300'} />
+					<meta name="theme-color" content={props.themeColor ?? '#ffbcdc'} />
+					<meta name="theme-color-orig" content={props.themeColor ?? '#ffbcdc'} />
 					<meta property="og:site_name" content={props.instanceName || 'Misskey'} />
 					<meta property="instance_url" content={props.instanceUrl} />
 					<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />

--- a/packages/backend/src/server/web/views/base.tsx
+++ b/packages/backend/src/server/web/views/base.tsx
@@ -39,8 +39,8 @@ export function Layout(props: PropsWithChildren<CommonProps<{
 					<meta charset="UTF-8" />
 					<meta name="application-name" content="Misskey" />
 					<meta name="referer" content="origin" />
-					<meta name="theme-color" content={props.themeColor ?? '#86b300'} />
-					<meta name="theme-color-orig" content={props.themeColor ?? '#86b300'} />
+					<meta name="theme-color" content={props.themeColor ?? '#ffbcdc'} />
+					<meta name="theme-color-orig" content={props.themeColor ?? '#ffbcdc'} />
 					<meta property="og:site_name" content={props.instanceName || 'Misskey'} />
 					<meta property="instance_url" content={props.instanceUrl} />
 					<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />

--- a/packages/backend/src/server/web/views/error.tsx
+++ b/packages/backend/src/server/web/views/error.tsx
@@ -64,7 +64,7 @@ export function ErrorPage(props: {
 					<p data-i18n="solution3">Clear your browser cache</p>
 					<p data-i18n="solution4">(Tor Browser) Set dom.webaudio.enabled to true</p>
 
-					<details style="color: #86b300;">
+					<details style="color: var(--error-accent, rgb(255, 188, 220));">
 						<summary data-i18n="otherOption">Other options</summary>
 						<a href="/flush">
 							<button class="button-small">

--- a/packages/frontend-embed/public/loader/boot.js
+++ b/packages/frontend-embed/public/loader/boot.js
@@ -7,6 +7,47 @@
 
 // ブロックの中に入れないと、定義した変数がブラウザのグローバルスコープに登録されてしまい邪魔なので
 (async () => {
+	// colorModeパラメータかOSの配色設定に応じて、ダークならピンク・ライトならブルーを設定する
+	(() => {
+		try {
+			const PALETTE = {
+				dark: {
+					bg: 'rgb(25, 35, 32)',
+					fg: '#dee7e4',
+					border: 'rgba(231, 255, 251, 0.14)',
+					accent: 'rgb(255, 188, 220)',
+					accentHover: 'rgb(255, 222, 241)',
+					onAccent: '#192320',
+				},
+				light: {
+					bg: 'rgb(238, 241, 252)',
+					fg: 'rgb(87, 112, 150)',
+					border: 'rgba(0, 0, 0, 0.1)',
+					accent: 'rgb(107, 165, 227)',
+					accentHover: 'rgb(150, 191, 235)',
+					onAccent: 'rgb(255, 255, 255)',
+				},
+			};
+
+			let dark = null;
+			const colorMode = new URLSearchParams(location.search).get('colorMode');
+			if (colorMode === 'dark') dark = true;
+			else if (colorMode === 'light') dark = false;
+			if (dark == null) dark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+			const p = dark ? PALETTE.dark : PALETTE.light;
+			const root = document.documentElement.style;
+			root.setProperty('--embed-error-bg', p.bg);
+			root.setProperty('--embed-error-fg', p.fg);
+			root.setProperty('--embed-error-border', p.border);
+			root.setProperty('--embed-error-accent', p.accent);
+			root.setProperty('--embed-error-accent-hover', p.accentHover);
+			root.setProperty('--embed-error-on-accent', p.onAccent);
+		} catch (_) {
+			// CSSのフォールバック色に任せる
+		}
+	})();
+
 	window.onerror = (e) => {
 		console.error(e);
 		renderError('SOMETHING_HAPPENED');
@@ -126,7 +167,7 @@
 
 		body {
 			position: relative;
-			color: #dee7e4;
+			color: var(--embed-error-fg, #dee7e4);
 			font-family: Hiragino Maru Gothic Pro, BIZ UDGothic, Roboto, HelveticaNeue, Arial, sans-serif;
 			line-height: 1.35;
 			display: flex;
@@ -140,7 +181,7 @@
 			overflow: hidden;
 
 			border-radius: var(--MI-radius, 12px);
-			border: 1px solid rgba(231, 255, 251, 0.14);
+			border: 1px solid var(--embed-error-border, rgba(231, 255, 251, 0.14));
 		}
 
 		body::before {
@@ -150,7 +191,7 @@
 			left: 0;
 			width: 100%;
 			height: 100%;
-			background: #192320;
+			background: var(--embed-error-bg, rgb(25, 35, 32));
 			border-radius: var(--MI-radius, 12px);
 			z-index: -1;
 		}
@@ -196,15 +237,15 @@
 			font-family: Hiragino Maru Gothic Pro, BIZ UDGothic, Roboto, HelveticaNeue, Arial, sans-serif;
 			line-height: 1.35;
 			border-radius: 99rem;
-			background-color: #b4e900;
-			color: #192320;
+			background-color: var(--embed-error-accent, rgb(255, 188, 220));
+			color: var(--embed-error-on-accent, #192320);
 			border: none;
 			cursor: pointer;
 			-webkit-tap-highlight-color: transparent;
 		}
 
 		button:hover {
-			background-color: #c6ff03;
+			background-color: var(--embed-error-accent-hover, rgb(255, 222, 241));
 		}`);
 	}
 })();

--- a/packages/frontend/public/loader/boot.js
+++ b/packages/frontend/public/loader/boot.js
@@ -7,6 +7,70 @@
 
 // ブロックの中に入れないと、定義した変数がブラウザのグローバルスコープに登録されてしまい邪魔なので
 (async () => {
+	// ダークテーマならピンク、ライトテーマならブルーの --error-* を設定する
+	(() => {
+		try {
+			const PALETTE = {
+				dark: {
+					bg: 'rgb(28, 28, 37)',
+					fg: '#dfddcc',
+					subBg: 'rgb(35, 35, 47)',
+					subBgHover: 'rgba(255, 255, 255, 0.1)',
+					subFg: 'rgb(185, 216, 255)',
+					accent: 'rgb(255, 188, 220)',
+				},
+				light: {
+					bg: 'rgb(238, 241, 252)',
+					fg: 'rgb(87, 112, 150)',
+					subBg: 'rgb(255, 255, 255)',
+					subBgHover: 'rgba(0, 0, 0, 0.05)',
+					subFg: 'rgb(87, 112, 150)',
+					accent: 'rgb(107, 165, 227)',
+				},
+			};
+
+			let dark = null;
+
+			const theme = (() => {
+				try {
+					return JSON.parse(localStorage.getItem('theme') || '{}');
+				} catch (_) {
+					return {};
+				}
+			})();
+
+			if (typeof theme.bg === 'string') {
+				const m = theme.bg.match(/\d+/g);
+				if (m && m.length >= 3) {
+					dark = (0.299 * +m[0] + 0.587 * +m[1] + 0.114 * +m[2]) < 128;
+				}
+			}
+
+			if (dark == null) {
+				const themeId = localStorage.getItem('themeId');
+				if (themeId != null) {
+					if (themeId.startsWith('d-') || themeId === 'dark') dark = true;
+					else if (themeId.startsWith('l-') || themeId === 'light') dark = false;
+				}
+			}
+
+			if (dark == null) {
+				dark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+			}
+
+			const p = dark ? PALETTE.dark : PALETTE.light;
+			const root = document.documentElement.style;
+			root.setProperty('--error-bg', p.bg);
+			root.setProperty('--error-fg', p.fg);
+			root.setProperty('--error-sub-bg', p.subBg);
+			root.setProperty('--error-sub-bg-hover', p.subBgHover);
+			root.setProperty('--error-sub-fg', p.subFg);
+			root.setProperty('--error-accent', p.accent);
+		} catch (_) {
+			// localStorage等が使えない環境ではCSSのフォールバック色に任せる
+		}
+	})();
+
 	window.onerror = (e) => {
 		console.error(e);
 		renderError('SOMETHING_HAPPENED', e);
@@ -192,7 +256,7 @@
 			<p>${messages.solution2}</p>
 			<p>${messages.solution3}</p>
 			<p>${messages.solution4}</p>
-			<details style="color: rgb(255, 188, 220);">
+			<details style="color: var(--error-accent, rgb(255, 188, 220));">
 				<summary>${messages.otherOption}</summary>
 				<a href="${safeModeUrl}">
 					<button class="button-small">
@@ -244,8 +308,8 @@
 
 		body,
 		html {
-			background-color: rgb(28, 28, 37);
-			color: #dfddcc;
+			background-color: var(--error-bg, rgb(28, 28, 37));
+			color: var(--error-fg, #dfddcc);
 			justify-content: center;
 			margin: auto;
 			padding: 10px;
@@ -274,12 +338,12 @@
 		}
 
 		.button-small {
-			background: rgb(35, 35, 47);
+			background: var(--error-sub-bg, rgb(35, 35, 47));
 			line-height: 40px;
 		}
 
 		.button-small:hover {
-			background: rgba(255, 255, 255, 0.1);
+			background: var(--error-sub-bg-hover, rgba(255, 255, 255, 0.1));
 		}
 
 		.button-label-big {
@@ -290,13 +354,13 @@
 		}
 
 		.button-label-small {
-			color: rgb(185, 216, 255);
+			color: var(--error-sub-fg, rgb(185, 216, 255));
 			font-size: 16px;
 			padding: 12px;
 		}
 
 		a {
-			color: rgb(134, 179, 0);
+			color: var(--error-accent, rgb(255, 188, 220));
 			text-decoration: none;
 		}
 
@@ -321,7 +385,7 @@
 		}
 
 		#errorInfo {
-			background: rgb(35, 35, 47);
+			background: var(--error-sub-bg, rgb(35, 35, 47));
 			margin-bottom: 2rem;
 			padding: 0.5rem 1rem;
 			width: 40rem;


### PR DESCRIPTION
## What

マイグレーション (2026.3.2 マージ) で Misskey のオリジナル色 (グリーン `#86b300` 系) のまま取り残された画面・色を、ダーク/ライトテーマに応じて cherrypick のアクセントカラーに切り替わるよう修正しました。

**エラーページ** (サーバー描画 / クライアント描画 / 埋め込み) は、**背景・リンク色・`details` 見出し色・ボタン色** をテーマ連動に:

- ダークテーマ → 暗背景 (`rgb(28, 28, 37)`) + ピンク `rgb(255, 188, 220)`
- ライトテーマ → 明るい背景 (`rgb(238, 241, 252)`) + ブルー `rgb(107, 165, 227)`

さらに、モバイルブラウザ / PWA の**アドレスバー色 (`theme-color` meta)** のフォールバック色を、マイグレーション時に失われていた **1.8.0 のピンク (`#ffbcdc`)** に戻しました (Misskey グリーンの `#86b300` のまま残っていた)。

対象ファイル:

- `packages/backend/assets/misc/error.css` / `error.js` — サーバー描画エラーページ (背景・リンク・小ボタン・コードブロック)
- `packages/backend/src/server/web/views/error.tsx` — `<details>` 見出し色 (`#86b300` → テーマ連動)
- `packages/frontend/public/loader/boot.js` — クライアント描画エラーページ (埋め込み CSS)
- `packages/frontend-embed/public/loader/boot.js` — 埋め込みエラーページ (背景・枠線・リロードボタン)
- `packages/backend/src/server/web/views/base.tsx` / `base-embed.tsx` — `theme-color` フォールバック色 (`#86b300` → `#ffbcdc`)

## Why

マイグレーション時に cherrypick のアクセントカラーが Misskey オリジナルの色に上書き・取り残されていました。

- エラーページは Misskey オリジナルのグリーン (`rgb(134, 179, 0)`) のリンクと固定の暗背景のまま取り残されていました (yojo-art 1.8.0 も同じ状態)。エラーページもダーク/ライトテーマに合わせて cherrypick のアクセントカラーと背景で統一するためです。
- `theme-color` meta は 1.8.0 ではピンク (`#ffbcdc`) でしたが、2026.3.2 のマージで上流の Misskey グリーン (`#86b300`) に上書きされていました。同じく「マイグレーション時に失われた」残骸のため復元します。

## Additional info

- 判定ロジック: ① キャッシュ済みテーマの `bg` 輝度 ② `themeId` の `d-`/`l-` 接頭辞 ③ `prefers-color-scheme` (フォールバック)
- 埋め込みは `colorMode` パラメータ → `prefers-color-scheme` で判定 (boot.ts のテーマ適用ロジックと一致)
- CSS 変数 `--error-bg` / `--error-fg` / `--error-sub-bg` / `--error-sub-fg` / `--error-accent` 等を導入し、JS がページ描画前にセット (フラッシュなし)
- ライトテーマのリンク色は、明るい背景での視認性のため `rgb(107, 165, 227)` (#6ba5e3 = ライトテーマの実アクセント) を使用
- Playwright で検証済み (server / client / embed / offline × dark / light の 8 ケース、アクセント色・背景色の computed style を比較)
- `--CP-misskey` (about-misskey.vue の Misskey ロゴ表示) は意図的な継承色のため変更していません
- CHANGELOG_YOJO.md は含めていません

## Checklist

- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [ ] ローカル環境で動作しました(Test working in a local environment) ※Playwright でスクリーンショット撮影・検証済み
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
