### PR TITLE
fix(test-federation): 投票連合テストのフレーキー修正

### DIFF
--- a/packages/backend/test-federation/test/note.test.ts
+++ b/packages/backend/test-federation/test/note.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, beforeAll, afterAll } from 'vitest';
+import { describe, test, beforeAll, afterAll, vi } from 'vitest';
 import assert, { rejects, strictEqual } from 'node:assert';
 import * as Misskey from 'misskey-js';
 import { addCustomEmoji, createAccount, createModerator, deepStrictEqualWithExcludedFields, type LoginUser, resolveRemoteNote, resolveRemoteUser, sleep, uploadFile } from './utils.js';
@@ -332,7 +332,13 @@ describe('Note', () => {
 				const note = (await bob.client.request('notes/create', { poll: { choices: ['inu', 'neko'] } })).createdNote;
 				const noteInA = await resolveRemoteNote('b.test', note.id, carol);
 				await carol.client.request('notes/polls/vote', { noteId: noteInA.id, choice: 0 });
-				await sleep();
+
+				await vi.waitFor(async () => {
+					const n = await bob.client.request('notes/show', { noteId: note.id });
+					assert(n.poll != null);
+					strictEqual(n.poll.choices[0].votes, 1);
+					strictEqual(n.poll.choices[1].votes, 0);
+				}, { timeout: 10_000, interval: 500 });
 
 				const noteAfterVote = await bob.client.request('notes/show', { noteId: note.id });
 				assert(noteAfterVote.poll != null);
@@ -362,7 +368,13 @@ describe('Note', () => {
 				// NOTE: resolve before voting
 				const noteInA = await resolveRemoteNote('b.test', note.id, bobRemoteFollower);
 				await localVoter.client.request('notes/polls/vote', { noteId: note.id, choice: 0 });
-				await sleep();
+
+				await vi.waitFor(async () => {
+					const n = await bobRemoteFollower.client.request('notes/show', { noteId: noteInA.id });
+					assert(n.poll != null);
+					strictEqual(n.poll.choices[0].votes, 1);
+					strictEqual(n.poll.choices[1].votes, 0);
+				}, { timeout: 10_000, interval: 500 });
 
 				const noteAfterVote = await bobRemoteFollower.client.request('notes/show', { noteId: noteInA.id });
 				assert(noteAfterVote.poll != null);

--- a/packages/backend/test-federation/test/note.test.ts
+++ b/packages/backend/test-federation/test/note.test.ts
@@ -338,7 +338,7 @@ describe('Note', () => {
 					assert(n.poll != null);
 					strictEqual(n.poll.choices[0].votes, 1);
 					strictEqual(n.poll.choices[1].votes, 0);
-				}, { timeout: 10_000, interval: 500 });
+				}, { timeout: 10_000, interval: 250 });
 
 				const noteAfterVote = await bob.client.request('notes/show', { noteId: note.id });
 				assert(noteAfterVote.poll != null);
@@ -374,7 +374,7 @@ describe('Note', () => {
 					assert(n.poll != null);
 					strictEqual(n.poll.choices[0].votes, 1);
 					strictEqual(n.poll.choices[1].votes, 0);
-				}, { timeout: 10_000, interval: 500 });
+				}, { timeout: 10_000, interval: 250 });
 
 				const noteAfterVote = await bobRemoteFollower.client.request('notes/show', { noteId: noteInA.id });
 				assert(noteAfterVote.poll != null);


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What

`packages/backend/test-federation/test/note.test.ts` の Poll 連合テスト2件で、固定 `sleep(250)` を `vi.waitFor` ポーリング（`timeout: 10_000`, `interval: 500`）に置換。

- `Bob creates poll and receives a vote from Carol`（`a.test` Carol → `b.test` Bob、`Create(Note)` 経由）
- `A vote in Bob's server is delivered to Bob's remote followers`（`b.test` localVoter → `a.test` bobRemoteFollower、`Update` 経由）

## Why

いずれのテストも `deliver` → `inbox` → BullMQ パイプラインに依存。15ファイル/200テスト同時実行の高負荷時（実行時間203秒）では 250ms を超過し、`notes/show` の `poll.choices[0].votes` が 0 のまま `strictEqual(1)` で flaky に失敗していた。

## Additional info (optional)

- 検証: `pnpm --filter backend exec eslint test-federation/test/note.test.ts` → 0 errors, `tsc` 新規エラーなし。`test:fed` は要 Docker のためローカルでは未実行だが、既存の `channel.test.ts:834` の `waitFor` パターンと同等のポーリング挙動。
- `beforeAll` の `following/create` 後の `sleep(250)` は本PRのスコープ外として残置

## Checklist
- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [ ] ローカル環境で動作しました(Test working in a local environment) 
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md) 
- [ ] (必要なら)テストの追加((If possible) Add tests) 