### PR TITLE
fix(backend): QueueServiceの起動時デバッグログを削除

### DIFF
--- a/packages/backend/src/core/QueueService.ts
+++ b/packages/backend/src/core/QueueService.ts
@@ -124,40 +124,30 @@ export class QueueService implements OnModuleInit {
 	) { }
 
 	async onModuleInit() {
-		console.log('[QueueService] onModuleInit: Setting up', REPEATABLE_SYSTEM_JOB_DEF.length, 'repeatable jobs');
-		try {
-			for (const def of REPEATABLE_SYSTEM_JOB_DEF) {
-				console.log('[QueueService] Setting up repeatable job:', def.name, 'pattern:', def.pattern);
-				const result = await this.systemQueue.upsertJobScheduler(def.name, {
-					pattern: def.pattern,
-					immediately: false,
-				}, {
-					name: def.name,
-					opts: {
-						// 期限ではなくcountで設定したいが、ジョブごとではなくキュー全体でカウントされるため、高頻度で実行されるジョブによって低頻度で実行されるジョブのログが消えることになる
-						removeOnComplete: {
-							age: 3600 * 24 * 7, // keep up to 7 days
-						},
-						removeOnFail: {
-							age: 3600 * 24 * 7, // keep up to 7 days
-						},
+		for (const def of REPEATABLE_SYSTEM_JOB_DEF) {
+			await this.systemQueue.upsertJobScheduler(def.name, {
+				pattern: def.pattern,
+				immediately: false,
+			}, {
+				name: def.name,
+				opts: {
+					// 期限ではなくcountで設定したいが、ジョブごとではなくキュー全体でカウントされるため、高頻度で実行されるジョブによって低頻度で実行されるジョブのログが消えることになる
+					removeOnComplete: {
+						age: 3600 * 24 * 7, // keep up to 7 days
 					},
-				});
-				console.log('[QueueService] Result:', def.name, result);
-			}
+					removeOnFail: {
+						age: 3600 * 24 * 7, // keep up to 7 days
+					},
+				},
+			});
+		}
 
-			// 古いバージョンで作成され現在使われなくなったrepeatableジョブをクリーンアップ
-			const schedulers = await this.systemQueue.getJobSchedulers();
-			console.log('[QueueService] Found', schedulers.length, 'existing schedulers');
-			for (const scheduler of schedulers) {
-				if (!REPEATABLE_SYSTEM_JOB_DEF.some(def => def.name === scheduler.key)) {
-					await this.systemQueue.removeJobScheduler(scheduler.key);
-				}
+		// 古いバージョンで作成され現在使われなくなったrepeatableジョブをクリーンアップ
+		const schedulers = await this.systemQueue.getJobSchedulers();
+		for (const scheduler of schedulers) {
+			if (!REPEATABLE_SYSTEM_JOB_DEF.some(def => def.name === scheduler.key)) {
+				await this.systemQueue.removeJobScheduler(scheduler.key);
 			}
-			console.log('[QueueService] onModuleInit: All repeatable jobs set up successfully');
-		} catch (error) {
-			console.error('[QueueService] ERROR in onModuleInit:', error);
-			throw error;
 		}
 	}
 

--- a/packages/backend/src/core/QueueService.ts
+++ b/packages/backend/src/core/QueueService.ts
@@ -124,30 +124,35 @@ export class QueueService implements OnModuleInit {
 	) { }
 
 	async onModuleInit() {
-		for (const def of REPEATABLE_SYSTEM_JOB_DEF) {
-			await this.systemQueue.upsertJobScheduler(def.name, {
-				pattern: def.pattern,
-				immediately: false,
-			}, {
-				name: def.name,
-				opts: {
-					// 期限ではなくcountで設定したいが、ジョブごとではなくキュー全体でカウントされるため、高頻度で実行されるジョブによって低頻度で実行されるジョブのログが消えることになる
-					removeOnComplete: {
-						age: 3600 * 24 * 7, // keep up to 7 days
+		try {
+			for (const def of REPEATABLE_SYSTEM_JOB_DEF) {
+				await this.systemQueue.upsertJobScheduler(def.name, {
+					pattern: def.pattern,
+					immediately: false,
+				}, {
+					name: def.name,
+					opts: {
+						// 期限ではなくcountで設定したいが、ジョブごとではなくキュー全体でカウントされるため、高頻度で実行されるジョブによって低頻度で実行されるジョブのログが消えることになる
+						removeOnComplete: {
+							age: 3600 * 24 * 7, // keep up to 7 days
+						},
+						removeOnFail: {
+							age: 3600 * 24 * 7, // keep up to 7 days
+						},
 					},
-					removeOnFail: {
-						age: 3600 * 24 * 7, // keep up to 7 days
-					},
-				},
-			});
-		}
-
-		// 古いバージョンで作成され現在使われなくなったrepeatableジョブをクリーンアップ
-		const schedulers = await this.systemQueue.getJobSchedulers();
-		for (const scheduler of schedulers) {
-			if (!REPEATABLE_SYSTEM_JOB_DEF.some(def => def.name === scheduler.key)) {
-				await this.systemQueue.removeJobScheduler(scheduler.key);
+				});
 			}
+
+			// 古いバージョンで作成され現在使われなくなったrepeatableジョブをクリーンアップ
+			const schedulers = await this.systemQueue.getJobSchedulers();
+			for (const scheduler of schedulers) {
+				if (!REPEATABLE_SYSTEM_JOB_DEF.some(def => def.name === scheduler.key)) {
+					await this.systemQueue.removeJobScheduler(scheduler.key);
+				}
+			}
+		} catch (error) {
+			console.error('[QueueService] ERROR in onModuleInit:', error);
+			throw error;
 		}
 	}
 
@@ -861,7 +866,6 @@ export class QueueService implements OnModuleInit {
 
 	@bindThis
 	private packJobData(job: Bull.Job): Packed<'QueueJob'> {
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 		const stacktrace = job.stacktrace ? job.stacktrace.filter(Boolean) : [];
 		stacktrace.reverse();
 


### PR DESCRIPTION
## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
`packages/backend/src/core/QueueService.ts` の `onModuleInit()` 内に残っていたデバッグ用ログ(`[QueueService] ...` の `console.log` 5箇所・~~`console.error` 1箇所~~)を削除しました。

あわせて、ログ出力専用になっていた `const result` の受け取りと、再throwするだけだった try/catch を除去しました。repeatableジョブ(`autoDeleteNotes` 等)の登録・旧スケジューラのクリーンアップといった機能ロジックは一切変更していません。

これにより、E2Eテストや開発時のサーバー起動ごとに大量に出力されていた `[QueueService]` ログが消えます。

## Why
<!-- なぜそうするのか？ 何が困っているのか？ -->
auto-delete 機能実装時に混入したデバッグログが、E2Eテスト(`NODE_ENV=test`)の出力を大きく汚して視認性を損なっていたためです。

- テスト時は `envOption.quiet` により Logger 経由のログは抑制されますが、このログは生の `console.log` であるため抑制をすり抜ける
- E2E ではテストファイルごとにサーバーが起動するため、起動のたびに数行 × ファイル数分出力される
- 該当コードは auto-delete 機能の実装時にデバッグ用として追加されたもので、misskey 本家(misskey-dev/misskey)には存在しないコード

## Additional info (optional)
<!-- テスト観点など -->
- backend の typecheck(tsgo ×3 config)+ eslint が通ることを確認済み
- エラー伝播は維持されています(NestJS は `onModuleInit()` を await するため、起動失敗時は例外として検知可能)

## Checklist
- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the contribution guide)
- [x] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)