### PR TITLE
test(backend): e2eでDBリセット前にテストサーバーを停止するよう順序を変更し不安定な失敗を解消

### DIFF
--- a/packages/backend/test-server/entry.ts
+++ b/packages/backend/test-server/entry.ts
@@ -70,7 +70,8 @@ async function killTestServer() {
 		if (pid && pid !== process.pid) {
 			await fkill(pid, { force: true });
 		}
-	} catch { // NOP;
+	} catch {
+		// NOP;
 	}
 }
 

--- a/packages/backend/test-server/entry.ts
+++ b/packages/backend/test-server/entry.ts
@@ -22,13 +22,7 @@ let serverService: ServerService;
 export async function setup() {
 	await killTestServer();
 
-	console.log('starting application...');
-
-	app = await NestFactory.createApplicationContext(MainModule, {
-		logger: new NestLogger(),
-	});
-	serverService = app.get(ServerService);
-	await serverService.launch();
+	await launchApp();
 
 	await startControllerEndpoints();
 
@@ -36,6 +30,25 @@ export async function setup() {
 	// ジョブキューが動くとテスト結果の確認に支障が出ることがあるので意図的に動かさないでいる
 
 	console.log('application initialized.');
+}
+
+async function launchApp() {
+	console.log('starting application...');
+
+	app = await NestFactory.createApplicationContext(MainModule, {
+		logger: new NestLogger(),
+	});
+	serverService = app.get(ServerService);
+	await serverService.launch();
+}
+
+async function disposeApp() {
+	process.env = JSON.parse(originEnv);
+
+	await serverService.dispose();
+	await app.close();
+
+	await killTestServer();
 }
 
 /**
@@ -54,11 +67,10 @@ async function killTestServer() {
 	//
 	try {
 		const pid = await portToPid(config.port);
-		if (pid) {
+		if (pid && pid !== process.pid) {
 			await fkill(pid, { force: true });
 		}
-	} catch {
-		// NOP;
+	} catch { // NOP;
 	}
 }
 
@@ -82,21 +94,14 @@ async function startControllerEndpoints(port = config.port + 1000) {
 		res.code(200).send({ success: true });
 	});
 
-	fastify.post<{ Body: { key?: string, value?: string } }>('/env-reset', async (req, res) => {
-		process.env = JSON.parse(originEnv);
+	fastify.post('/dispose', async (req, res) => {
+		await disposeApp();
 
-		await serverService.dispose();
-		await app.close();
+		res.code(200).send({ success: true });
+	});
 
-		await killTestServer();
-
-		console.log('starting application...');
-
-		app = await NestFactory.createApplicationContext(MainModule, {
-			logger: new NestLogger(),
-		});
-		serverService = app.get(ServerService);
-		await serverService.launch();
+	fastify.post('/launch', async (req, res) => {
+		await launchApp();
 
 		res.code(200).send({ success: true });
 	});

--- a/packages/backend/test/setup.e2e.ts
+++ b/packages/backend/test/setup.e2e.ts
@@ -4,9 +4,10 @@
  */
 
 import { beforeAll } from 'vitest';
-import { initTestDb, sendEnvResetRequest } from './utils.js';
+import { initTestDb, startTestServer, stopTestServer } from './utils.js';
 
 beforeAll(async () => {
+	await stopTestServer();
 	await initTestDb(false);
-	await sendEnvResetRequest();
+	await startTestServer();
 });

--- a/packages/backend/test/utils.ts
+++ b/packages/backend/test/utils.ts
@@ -679,9 +679,9 @@ export async function sendEnvUpdateRequest(params: { key: string, value?: string
 	}
 }
 
-export async function sendEnvResetRequest() {
+export async function stopTestServer() {
 	const res = await fetch(
-		`http://localhost:${port + 1000}/env-reset`,
+		`http://localhost:${port + 1000}/dispose`,
 		{
 			method: 'POST',
 			body: JSON.stringify({}),
@@ -689,7 +689,21 @@ export async function sendEnvResetRequest() {
 	);
 
 	if (res.status !== 200) {
-		throw new Error('server env update failed.');
+		throw new Error('server dispose failed.');
+	}
+}
+
+export async function startTestServer() {
+	const res = await fetch(
+		`http://localhost:${port + 1000}/launch`,
+		{
+			method: 'POST',
+			body: JSON.stringify({}),
+		},
+	);
+
+	if (res.status !== 200) {
+		throw new Error('server launch failed.');
 	}
 }
 


### PR DESCRIPTION
## What
backend e2e テストにおいて、DB リセット（`initTestDb(false)` の dropSchema + synchronize）の前に必ずテストサーバーを停止するよう順序を変更しました。

- `test-server/entry.ts`: コントローラーエンドポイントに `/dispose` と `/launch` を追加
- `test/setup.e2e.ts`: `stopTestServer() → initTestDb(false) → startTestServer()` の順に変更
- `test/utils.ts`: `stopTestServer()` / `startTestServer()` ヘルパーを追加し、利用されなくなった `sendEnvResetRequest()` を削除
- `killTestServer()` に自プロセスを kill しないガードを追加

## Why
2026.6.0 マージ以降、test-backend の E2E が不安定で develop の CI 失敗率が約 3 割に達していました。

各テストファイルの beforeAll では `dropSchema` + `synchronize` で全テーブルを再作成しますが、globalSetup のテストサーバーはその間も起動し続けているため、

- サーバー側の非同期処理が drop 中のテーブルにアクセスして `Unhandled Rejection (relation "user" does not exist)` となり、テストアノテーション無しでジョブ全体が落ちる
- サーバーの接続ロックにより DROP がブロックされ、`hookTimeout` (10s) 超過でファイル単位で落ちる

という 2 形態のフレーキーな失敗が発生していました（例: https://github.com/yojo-art/cherrypick/actions/runs/32644421590 ）。

本 PR は DB リセット時にアプリが一切接続を持たない状態を作ることでレースを構造的に排除します。サーバーの再起動は従来も毎ファイル行われていたため、実行時間の増加はありません。

## Additional info (optional)
Node v24.18.0 + PostgreSQL 18 + Redis 8 のローカル環境での検証結果:

| | 修正前 | 修正後 |
| --- | --- | --- |
| フル E2E (35 files / 1503 tests) | Test Files 3 failed（hook timeout ×2 ほか） | Test Files 1 failed* |
| テスト通過数 | 1286 passed | **1471 passed** |
| 所要時間 | 1522s | 1098s |

\* 失敗は `endpoints.ts` のファイルアップロード 3 テストのみで、Node 24 の undici における FormData ブランドチェックの問題です。

なお `move.ts` がファイル内で `initTestDb(false)` を呼ぶ箇所は既存パターンとして残っていますが、今回の実行では問題は観測されていません。

## Checklist
- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)