### PR TITLE
test(backend): e2e環境でドライブのURLが解決できない問題の修正

### DIFF
--- a/packages/backend/src/core/InternalStorageService.ts
+++ b/packages/backend/src/core/InternalStorageService.ts
@@ -35,14 +35,24 @@ export class InternalStorageService {
 	public saveFromPath(key: string, srcPath: string) {
 		fs.mkdirSync(this.path, { recursive: true });
 		fs.copyFileSync(srcPath, this.resolvePath(key));
-		return `${this.config.url}/files/${key}`;
+		return this.getUrl(key);
 	}
 
 	@bindThis
 	public saveFromBuffer(key: string, data: Buffer) {
 		fs.mkdirSync(this.path, { recursive: true });
 		fs.writeFileSync(this.resolvePath(key), data);
-		return `${this.config.url}/files/${key}`;
+		return this.getUrl(key);
+	}
+
+	@bindThis
+	private getUrl(key: string) {
+		// e2eテスト環境ではmisskey.localが名前解決できず、ポート番号も本番のURLに含まれていないため、
+		// テスト時のみlocalhost:[port]形式のURLに差し替える。
+		const base = (process.env.NODE_ENV === 'test')
+			? `http://localhost:${this.config.port}`
+			: this.config.url;
+		return `${base}/files/${key}`;
 	}
 
 	@bindThis


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
misskey.localは実在しないホストのため、サーバー自身が自分の公開URLを
ダウンロードする処理(カスタム絵文字の再アップロード等)がe2eで
ENOTFOUNDになり500を返していたため、その修正

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
`misskey.local`を解決するには、`/etc/hosts`を書き換えるという方法もあるが、port番号も指定する必要があるためこの方法が一番シンプルと思われる

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [ ] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
