### PR TITLE
perf(test): 検索E2Eテストの実行時間を短縮

### DIFF
--- a/packages/backend/test/e2e/search-notes.ts
+++ b/packages/backend/test/e2e/search-notes.ts
@@ -6,7 +6,7 @@
 process.env.NODE_ENV = 'test';
 
 import * as assert from 'assert';
-import { beforeAll, describe, test } from 'vitest';
+import { beforeAll, describe, test, vi } from 'vitest';
 import { api, post, signup, uploadUrl } from '../utils.js';
 import type * as misskey from 'misskey-js';
 import { query } from '@/misc/prelude/url.js';
@@ -280,14 +280,16 @@ describeOpenSearchE2E('検索', () => {
 			noteId: tomNoteDirect.id,
 		}, alice);
 		assert.strictEqual(rres2.status, 204);
-		await new Promise(resolve => setTimeout(resolve, 5000));
 
-		const asres0 = await api('notes/advanced-search', {
-			query: 'ff_test',
-		}, alice);
-		assert.strictEqual(asres0.status, 200);
-		assert.strictEqual(Array.isArray(asres0.body), true);
-		assert.strictEqual(asres0.body.length, 2);
+		const asres0 = await vi.waitFor(async () => {
+			const n = await api('notes/advanced-search', {
+				query: 'ff_test',
+			}, alice);
+			assert.strictEqual(n.status, 200);
+			assert.strictEqual(Array.isArray(n.body), true);
+			assert.strictEqual(n.body.length, 2);
+			return n;
+		}, { timeout: 5_000, interval: 500 });
 
 		const ids = asres0.body.map((x) => x.id);
 		assert.strictEqual(ids.includes(tomNote.id), true);
@@ -413,13 +415,16 @@ describeOpenSearchE2E('検索', () => {
 			noteId: reactedNote.id,
 		}, alice);
 		assert.strictEqual(rres.status, 204);
-		await new Promise(resolve => setTimeout(resolve, 5000));
-		const asres1 = await api('notes/advanced-search', {
-			query: 'indexable_text',
-		}, alice);
-		assert.strictEqual(asres1.status, 200);
-		assert.strictEqual(Array.isArray(asres1.body), true);
-		assert.strictEqual(asres1.body.length, 1);
+
+		const asres1 = await vi.waitFor(async () => {
+			const n = await api('notes/advanced-search', {
+				query: 'indexable_text',
+			}, alice);
+			assert.strictEqual(n.status, 200);
+			assert.strictEqual(Array.isArray(n.body), true);
+			assert.strictEqual(n.body.length, 1);
+			return n;
+		}, { timeout: 5_000, interval: 500 });
 
 		const asnids1 = asres1.body.map( x => x.id);
 		assert.strictEqual(asnids1.includes(reactedNote.id), true);
@@ -440,15 +445,18 @@ describeOpenSearchE2E('検索', () => {
 		const rnres = await api('notes/create', {
 			renoteId: renotedNote.id,
 		}, alice);
-		await new Promise(resolve => setTimeout(resolve, 5000));
 		assert.strictEqual(rnres.status, 200);
 		rnId = rnres.body.createdNote.id;
-		const asres2 = await api('notes/advanced-search', {
-			query: 'indexable_text',
-		}, alice);
-		assert.strictEqual(asres2.status, 200);
-		assert.strictEqual(Array.isArray(asres2.body), true);
-		assert.strictEqual(asres2.body.length, 2);
+
+		const asres2 = await vi.waitFor(async () => {
+			const n = await api('notes/advanced-search', {
+				query: 'indexable_text',
+			}, alice);
+			assert.strictEqual(n.status, 200);
+			assert.strictEqual(Array.isArray(n.body), true);
+			assert.strictEqual(n.body.length, 2);
+			return n;
+		}, { timeout: 5_000, interval: 500 });
 
 		const asnids2 = asres2.body.map( x => x.id);
 		assert.strictEqual(asnids2.includes(renotedNote.id), true);
@@ -472,14 +480,16 @@ describeOpenSearchE2E('検索', () => {
 		}, alice);
 		assert.strictEqual(rpres.status, 200);
 		replyId = rpres.body.createdNote.id;
-		await new Promise(resolve => setTimeout(resolve, 5000));
 
-		const asres3 = await api('notes/advanced-search', {
-			query: 'indexable_text',
-		}, alice);
-		assert.strictEqual(asres3.status, 200);
-		assert.strictEqual(Array.isArray(asres3.body), true);
-		assert.strictEqual(asres3.body.length, 3);
+		const asres3 = await vi.waitFor(async () => {
+			const n = await api('notes/advanced-search', {
+				query: 'indexable_text',
+			}, alice);
+			assert.strictEqual(n.status, 200);
+			assert.strictEqual(Array.isArray(n.body), true);
+			assert.strictEqual(n.body.length, 3);
+			return n;
+		}, { timeout: 5_000, interval: 500 });
 
 		const asnids3 = asres3.body.map( x => x.id);
 		assert.strictEqual(asnids3.includes(replyedNote.id), true);
@@ -500,14 +510,16 @@ describeOpenSearchE2E('検索', () => {
 			noteId: favoritedNote.id,
 		}, alice);
 		assert.strictEqual(fvres.status, 204);
-		await new Promise(resolve => setTimeout(resolve, 5000));
 
-		const asres4 = await api('notes/advanced-search', {
-			query: 'indexable_text',
-		}, alice);
-		assert.strictEqual(asres4.status, 200);
-		assert.strictEqual(Array.isArray(asres4.body), true);
-		assert.strictEqual(asres4.body.length, 4);
+		const asres4 = await vi.waitFor(async () => {
+			const n = await api('notes/advanced-search', {
+				query: 'indexable_text',
+			}, alice);
+			assert.strictEqual(n.status, 200);
+			assert.strictEqual(Array.isArray(n.body), true);
+			assert.strictEqual(n.body.length, 4);
+			return n;
+		}, { timeout: 5_000, interval: 500 });
 
 		const asnids4 = asres4.body.map( x => x.id);
 		assert.strictEqual(asnids4.includes(favoritedNote.id), true);
@@ -537,13 +549,16 @@ describeOpenSearchE2E('検索', () => {
 			noteId: clipedNote.id,
 		}, alice);
 		assert.strictEqual(clpaddres.status, 204);
-		await new Promise(resolve => setTimeout(resolve, 5000));
-		const asres5 = await api('notes/advanced-search', {
-			query: 'indexable_text',
-		}, alice);
-		assert.strictEqual(asres5.status, 200);
-		assert.strictEqual(Array.isArray(asres5.body), true);
-		assert.strictEqual(asres5.body.length, 5);
+
+		const asres5 = await vi.waitFor(async () => {
+			const n = await api('notes/advanced-search', {
+				query: 'indexable_text',
+			}, alice);
+			assert.strictEqual(n.status, 200);
+			assert.strictEqual(Array.isArray(n.body), true);
+			assert.strictEqual(n.body.length, 5);
+			return n;
+		}, { timeout: 5_000, interval: 500 });
 
 		const asnids5 = asres5.body.map( x => x.id);
 		assert.strictEqual(asnids5.includes(clipedNote.id), true);
@@ -565,13 +580,16 @@ describeOpenSearchE2E('検索', () => {
 			choice: 0,
 		}, alice);
 		assert.strictEqual(vres.status, 204);
-		await new Promise(resolve => setTimeout(resolve, 5000));
-		const asres6 = await api('notes/advanced-search', {
-			query: 'indexable_text',
-		}, alice);
-		assert.strictEqual(asres6.status, 200);
-		assert.strictEqual(Array.isArray(asres6.body), true);
-		assert.strictEqual(asres6.body.length, 6);
+
+		const asres6 = await vi.waitFor(async () => {
+			const n = await api('notes/advanced-search', {
+				query: 'indexable_text',
+			}, alice);
+			assert.strictEqual(n.status, 200);
+			assert.strictEqual(Array.isArray(n.body), true);
+			assert.strictEqual(n.body.length, 6);
+			return n;
+		}, { timeout: 5_000, interval: 500 });
 
 		const asnids6 = asres6.body.map( x => x.id);
 		assert.strictEqual(asnids6.includes(votedNote.id), true);
@@ -593,13 +611,16 @@ describeOpenSearchE2E('検索', () => {
 			noteId: reactedNote.id,
 		}, alice);
 		assert.strictEqual(rres.status, 204);
-		await new Promise(resolve => setTimeout(resolve, 5000));
-		const asres1 = await api('notes/advanced-search', {
-			query: 'indexable_text',
-		}, alice);
-		assert.strictEqual(asres1.status, 200);
-		assert.strictEqual(Array.isArray(asres1.body), true);
-		assert.strictEqual(asres1.body.length, 5);
+
+		const asres1 = await vi.waitFor(async () => {
+			const n = await api('notes/advanced-search', {
+				query: 'indexable_text',
+			}, alice);
+			assert.strictEqual(n.status, 200);
+			assert.strictEqual(Array.isArray(n.body), true);
+			assert.strictEqual(n.body.length, 5);
+			return n;
+		}, { timeout: 5_000, interval: 500 });
 
 		const asnids1 = asres1.body.map( x => x.id);
 		assert.strictEqual(asnids1.includes(reactedNote.id), false);
@@ -620,13 +641,16 @@ describeOpenSearchE2E('検索', () => {
 			noteId: rnId,
 		}, alice);
 		assert.strictEqual(rnres.status, 204);
-		await new Promise(resolve => setTimeout(resolve, 5000));
-		const asres2 = await api('notes/advanced-search', {
-			query: 'indexable_text',
-		}, alice);
-		assert.strictEqual(asres2.status, 200);
-		assert.strictEqual(Array.isArray(asres2.body), true);
-		assert.strictEqual(asres2.body.length, 4);
+
+		const asres2 = await vi.waitFor(async () => {
+			const n = await api('notes/advanced-search', {
+				query: 'indexable_text',
+			}, alice);
+			assert.strictEqual(n.status, 200);
+			assert.strictEqual(Array.isArray(n.body), true);
+			assert.strictEqual(n.body.length, 4);
+			return n;
+		}, { timeout: 5_000, interval: 500 });
 
 		const asnids2 = asres2.body.map( x => x.id);
 		assert.strictEqual(asnids2.includes(renotedNote.id), false);
@@ -647,13 +671,16 @@ describeOpenSearchE2E('検索', () => {
 			noteId: replyId,
 		}, alice);
 		assert.strictEqual(rnres.status, 204);
-		await new Promise(resolve => setTimeout(resolve, 5000));
-		const asres2 = await api('notes/advanced-search', {
-			query: 'indexable_text',
-		}, alice);
-		assert.strictEqual(asres2.status, 200);
-		assert.strictEqual(Array.isArray(asres2.body), true);
-		assert.strictEqual(asres2.body.length, 3);
+
+		const asres2 = await vi.waitFor(async () => {
+			const n = await api('notes/advanced-search', {
+				query: 'indexable_text',
+			}, alice);
+			assert.strictEqual(n.status, 200);
+			assert.strictEqual(Array.isArray(n.body), true);
+			assert.strictEqual(n.body.length, 3);
+			return n;
+		}, { timeout: 5_000, interval: 500 });
 
 		const asnids2 = asres2.body.map( x => x.id);
 		assert.strictEqual(asnids2.includes(renotedNote.id), false);
@@ -675,13 +702,16 @@ describeOpenSearchE2E('検索', () => {
 			noteId: clipedNote.id,
 		}, alice);
 		assert.strictEqual(clpaddres.status, 204);
-		await new Promise(resolve => setTimeout(resolve, 5000));
-		const asres5 = await api('notes/advanced-search', {
-			query: 'indexable_text',
-		}, alice);
-		assert.strictEqual(asres5.status, 200);
-		assert.strictEqual(Array.isArray(asres5.body), true);
-		assert.strictEqual(asres5.body.length, 2);
+
+		const asres5 = await vi.waitFor(async () => {
+			const n = await api('notes/advanced-search', {
+				query: 'indexable_text',
+			}, alice);
+			assert.strictEqual(n.status, 200);
+			assert.strictEqual(Array.isArray(n.body), true);
+			assert.strictEqual(n.body.length, 2);
+			return n;
+		}, { timeout: 5_000, interval: 500 });
 
 		const asnids5 = asres5.body.map( x => x.id);
 		assert.strictEqual(asnids5.includes(clipedNote.id), false);
@@ -700,14 +730,16 @@ describeOpenSearchE2E('検索', () => {
 	test('indexable false お気に入り消したらでない', async() => {
 		const fvres = await api('notes/favorites/delete', { noteId: favoritedNote.id }, alice);
 		assert.strictEqual(fvres.status, 204);
-		await new Promise(resolve => setTimeout(resolve, 5000));
 
-		const asres4 = await api('notes/advanced-search', {
-			query: 'indexable_text',
-		}, alice);
-		assert.strictEqual(asres4.status, 200);
-		assert.strictEqual(Array.isArray(asres4.body), true);
-		assert.strictEqual(asres4.body.length, 1);
+		const asres4 = await vi.waitFor(async () => {
+			const n = await api('notes/advanced-search', {
+				query: 'indexable_text',
+			}, alice);
+			assert.strictEqual(n.status, 200);
+			assert.strictEqual(Array.isArray(n.body), true);
+			assert.strictEqual(n.body.length, 1);
+			return n;
+		}, { timeout: 5_000, interval: 500 });
 
 		const asnids4 = asres4.body.map( x => x.id);
 		assert.strictEqual(asnids4.includes(favoritedNote.id), false);
@@ -792,20 +824,20 @@ describeOpenSearchE2E('検索', () => {
 		assert.strictEqual(rres3.status, 204);
 		assert.strictEqual(rres4.status, 204);
 		assert.strictEqual(rres5.status, 204);
-		await new Promise(resolve => setTimeout(resolve, 5000));
+		await vi.waitFor(async () => {
+			const n = await api('notes/advanced-search', {
+				query: 'SearchableBy_Test',
+			}, alice);
+			assert.strictEqual(n.status, 200);
 
-		const res = await api('notes/advanced-search', {
-			query: 'SearchableBy_Test',
-		}, alice);
-		assert.strictEqual(res.status, 200);
-
-		const noteIds = res.body.map( x => x.id);
-		assert.strictEqual(noteIds.includes(noteSearchableByNull.id), true);
-		assert.strictEqual(noteIds.includes(noteSearchableByPrivate.id), false);
-		assert.strictEqual(noteIds.includes(noteSearchableByPublic.id), true);
-		assert.strictEqual(noteIds.includes(noteSearchableByFollowersAndReacted.id), true);
-		assert.strictEqual(noteIds.includes(noteSearchableByReacted.id), true);
-		assert.strictEqual(noteIds.length, 4);
+			const noteIds = n.body.map( x => x.id);
+			assert.strictEqual(noteIds.includes(noteSearchableByNull.id), true);
+			assert.strictEqual(noteIds.includes(noteSearchableByPrivate.id), false);
+			assert.strictEqual(noteIds.includes(noteSearchableByPublic.id), true);
+			assert.strictEqual(noteIds.includes(noteSearchableByFollowersAndReacted.id), true);
+			assert.strictEqual(noteIds.includes(noteSearchableByReacted.id), true);
+			assert.strictEqual(noteIds.length, 4);
+		}, { timeout: 5_000, interval: 500 });
 
 		const rdres = await api('notes/reactions/delete', {
 			noteId: noteSearchableByPublic.id,
@@ -828,7 +860,6 @@ describeOpenSearchE2E('検索', () => {
 		assert.strictEqual(rdres3.status, 204);
 		assert.strictEqual(rdres4.status, 204);
 		assert.strictEqual(rdres5.status, 204);
-		await new Promise(resolve => setTimeout(resolve, 5000));
 	});
 
 	//nullとpublicだけ出てくる
@@ -838,15 +869,17 @@ describeOpenSearchE2E('検索', () => {
 		}, carol);
 		assert.strictEqual(ires.status, 200);
 
-		const res = await api('notes/advanced-search', {
-			query: 'SearchableBy_Test',
-		}, alice);
-		assert.strictEqual(res.status, 200);
+		await vi.waitFor(async () => {
+			const res = await api('notes/advanced-search', {
+				query: 'SearchableBy_Test',
+			}, alice);
+			assert.strictEqual(res.status, 200);
 
-		const noteIds = res.body.map( x => x.id);
-		assert.strictEqual(noteIds.includes(noteSearchableByNull.id), true);
-		assert.strictEqual(noteIds.includes(noteSearchableByPublic.id), true);
-		assert.strictEqual(noteIds.length, 2);
+			const noteIds = res.body.map( x => x.id);
+			assert.strictEqual(noteIds.includes(noteSearchableByNull.id), true);
+			assert.strictEqual(noteIds.includes(noteSearchableByPublic.id), true);
+			assert.strictEqual(noteIds.length, 2);
+		}, { timeout: 5_000, interval: 500 });
 	});
 
 	//nullとpublicだけ出てくる
@@ -895,19 +928,20 @@ describeOpenSearchE2E('検索', () => {
 		assert.strictEqual(rres1.status, 204);
 		assert.strictEqual(rres2.status, 204);
 		assert.strictEqual(rres3.status, 204);
-		await new Promise(resolve => setTimeout(resolve, 5000));
 
-		const res = await api('notes/advanced-search', {
-			query: 'SearchableBy_Test',
-		}, alice);
-		assert.strictEqual(res.status, 200);
+		await vi.waitFor(async () => {
+			const n = await api('notes/advanced-search', {
+				query: 'SearchableBy_Test',
+			}, alice);
+			assert.strictEqual(n.status, 200);
 
-		const noteIds = res.body.map( x => x.id);
-		assert.strictEqual(noteIds.includes(noteSearchableByNull.id), true);
-		assert.strictEqual(noteIds.includes(noteSearchableByPublic.id), true);
-		assert.strictEqual(noteIds.includes(noteSearchableByFollowersAndReacted.id), true);
-		assert.strictEqual(noteIds.includes(noteSearchableByReacted.id), true);
-		assert.strictEqual(noteIds.length, 4);
+			const noteIds = n.body.map( x => x.id);
+			assert.strictEqual(noteIds.includes(noteSearchableByNull.id), true);
+			assert.strictEqual(noteIds.includes(noteSearchableByPublic.id), true);
+			assert.strictEqual(noteIds.includes(noteSearchableByFollowersAndReacted.id), true);
+			assert.strictEqual(noteIds.includes(noteSearchableByReacted.id), true);
+			assert.strictEqual(noteIds.length, 4);
+		}, { timeout: 5_000, interval: 500 });
 
 		const rdres1 = await api('notes/reactions/delete', {
 			noteId: noteSearchableByFollowersAndReacted.id,
@@ -922,7 +956,27 @@ describeOpenSearchE2E('検索', () => {
 		assert.strictEqual(rdres1.status, 204);
 		assert.strictEqual(rdres2.status, 204);
 		assert.strictEqual(rdres3.status, 204);
-		await new Promise(resolve => setTimeout(resolve, 5000));
+
+		await vi.waitFor(async () => {
+			const n = await api('notes/advanced-search', {
+				query: 'SearchableBy_Test',
+			}, alice);
+			assert.strictEqual(n.status, 200);
+
+			const noteIds = n.body.map( x => x.id);
+			assert.strictEqual(noteIds.length, 1);
+
+			for (const targetId of [
+				noteSearchableByNull.id,
+				noteSearchableByFollowersAndReacted.id,
+				noteSearchableByReacted.id,
+			]) {
+				const found = n.body.find(x => x.id === targetId);
+				if (found) {
+					assert.strictEqual(found.reactionCount, 0);
+				}
+			}
+		}, { timeout: 5_000, interval: 500 });
 	});
 	test('searchableBy(user: reactedOnly, indexable false)', async () =>	{
 		const ires = await api('i/update', {
@@ -939,18 +993,19 @@ describeOpenSearchE2E('検索', () => {
 		}, alice);
 		assert.strictEqual(rres1.status, 204);
 		assert.strictEqual(rres2.status, 204);
-		await new Promise(resolve => setTimeout(resolve, 5000));
 
-		const res = await api('notes/advanced-search', {
-			query: 'SearchableBy_Test',
-		}, alice);
-		assert.strictEqual(res.status, 200);
+		await vi.waitFor(async () => {
+			const res = await api('notes/advanced-search', {
+				query: 'SearchableBy_Test',
+			}, alice);
+			assert.strictEqual(res.status, 200);
 
-		const noteIds = res.body.map( x => x.id);
-		assert.strictEqual(noteIds.includes(noteSearchableByNull.id), true);
-		assert.strictEqual(noteIds.includes(noteSearchableByPublic.id), true);
-		assert.strictEqual(noteIds.includes(noteSearchableByReacted.id), true);
-		assert.strictEqual(noteIds.length, 3);
+			const noteIds = res.body.map( x => x.id);
+			assert.strictEqual(noteIds.includes(noteSearchableByNull.id), true);
+			assert.strictEqual(noteIds.includes(noteSearchableByPublic.id), true);
+			assert.strictEqual(noteIds.includes(noteSearchableByReacted.id), true);
+			assert.strictEqual(noteIds.length, 3);
+		}, { timeout: 5_000, interval: 500 });
 
 		const rdres1 = await api('notes/reactions/delete', {
 			noteId: noteSearchableByReacted.id,
@@ -960,7 +1015,19 @@ describeOpenSearchE2E('検索', () => {
 		}, alice);
 		assert.strictEqual(rdres1.status, 204);
 		assert.strictEqual(rdres2.status, 204);
-		await new Promise(resolve => setTimeout(resolve, 5000));
+
+		await vi.waitFor(async () => {
+			const res = await api('notes/advanced-search', {
+				query: 'SearchableBy_Test',
+			}, alice);
+			assert.strictEqual(res.status, 200);
+
+			const noteIds = res.body.map( x => x.id);
+			assert.strictEqual(noteIds.includes(noteSearchableByNull.id), false);
+			assert.strictEqual(noteIds.includes(noteSearchableByPublic.id), true);
+			assert.strictEqual(noteIds.includes(noteSearchableByReacted.id), false);
+			assert.strictEqual(noteIds.length, 1);
+		}, { timeout: 5_000, interval: 500 });
 	});
 
 	test('searchableBy(user: private, indexable false)', async () =>	{


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
100秒ほどかかっていた`test/e2e/search-notes.ts`を27秒程度まで短縮

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
