### PR TITLE
refactor(frontend): お知らせリアクションをノートリアクションのコードベースのものに書き換え

### DIFF
--- a/packages/frontend/src/components/MkAnnouncementReaction.vue
+++ b/packages/frontend/src/components/MkAnnouncementReaction.vue
@@ -10,6 +10,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 	class="_button"
 	:class="[$style.root, { [$style.reacted]: isReacted, [$style.canToggle]: (canToggle || alternative), [$style.small]: prefer.s.reactionsDisplaySize === 'small', [$style.large]: prefer.s.reactionsDisplaySize === 'large' }]"
 	@click.stop="(ev) => toggleReaction(ev)"
+	@contextmenu.prevent.stop="menu"
 >
 	<MkReactionIcon style="pointer-events: none;" :class="prefer.s.limitWidthOfReaction ? $style.limitWidth : ''" :reaction="reaction"/>
 	<span :class="$style.count">{{ count }}</span>
@@ -21,8 +22,10 @@ import { computed, onMounted, useTemplateRef, watch, ref } from 'vue';
 import * as Misskey from 'misskey-js';
 import { getUnicodeEmojiOrNull } from '@@/js/emojilist.js';
 import type { ComputedRef } from 'vue';
+import type { MenuItem } from '@/types/menu';
 import XDetails from '@/components/MkReactionsViewer.details.vue';
 import MkReactionIcon from '@/components/MkReactionIcon.vue';
+import MkCustomEmojiDetailedDialog from '@/components/MkCustomEmojiDetailedDialog.vue';
 import * as os from '@/os.js';
 import { misskeyApi, misskeyApiGet } from '@/utility/misskey-api.js';
 import { useTooltip } from '@/composables/use-tooltip.js';
@@ -33,6 +36,11 @@ import * as sound from '@/utility/sound.js';
 import { customEmojis, customEmojisMap } from '@/custom-emojis.js';
 import { prefer } from '@/preferences.js';
 import { haptic } from '@/utility/haptic.js';
+import { copyToClipboard } from '@/utility/copy-to-clipboard.js';
+import { mute as muteEmoji, unmute as unmuteEmoji, checkMuted as isEmojiMuted } from '@/utility/emoji-mute.js';
+import { addToEmojiPalette } from '@/utility/emoji-palette.js';
+import { useRouter } from '@/router.js';
+import { advanccedNotesSearchAvailable } from '@/utility/check-permissions.js';
 
 const props = defineProps<{
 	announcementId: Misskey.entities.Announcement['id'];
@@ -44,6 +52,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
 	(ev: 'announcementReactionToggled', reaction: string, delta: number): void;
+	(ev: 'showUsers', reaction: string): void;
 }>();
 
 const buttonEl = useTemplateRef('buttonEl');
@@ -65,6 +74,18 @@ const reactionName = computed(() => {
 });
 
 const alternative: ComputedRef<string | null> = computed(() => prefer.s.reactableRemoteReactionEnabled ? (customEmojis.value.find(it => it.name === reactionName.value)?.name ?? null) : null);
+
+const canGetInfo = computed(() => props.reaction.startsWith(':'));
+const isLocalCustomEmoji = computed(() => props.reaction[0] === ':' && props.reaction.includes('@.'));
+
+const reactionHost = computed(() => {
+	const r = props.reaction.replaceAll(':', '');
+	return r.split('@')[1];
+});
+
+const reactionLabel = computed(() => props.reaction.startsWith(':') ? `:${reactionName.value}:` : props.reaction);
+
+const router = useRouter();
 
 const toggling = ref(false);
 
@@ -179,6 +200,110 @@ async function chooseAlternative() {
 			});
 		}
 	}
+}
+
+async function menu(ev: PointerEvent) {
+	const isCustomEmoji = props.reaction.endsWith(':');
+	let menuItems: MenuItem[] = [];
+
+	menuItems.push({
+		type: 'label',
+		text: reactionLabel.value,
+	});
+
+	if (canGetInfo.value) {
+		menuItems.push({
+			text: i18n.ts.info,
+			icon: 'ti ti-info-circle',
+			action: async () => {
+				const { dispose } = os.popup(MkCustomEmojiDetailedDialog, {
+					emoji: await misskeyApiGet('emoji', isLocalCustomEmoji.value ? { name: reactionName.value } : {
+						name: reactionName.value,
+						host: reactionHost.value,
+					}),
+				}, {
+					closed: () => dispose(),
+				});
+			},
+		});
+	}
+
+	if (customEmojis.value.find(it => it.name === reactionName.value)) {
+		menuItems.push({
+			text: i18n.ts.copy,
+			icon: 'ti ti-copy',
+			action: () => {
+				copyToClipboard(`:${reactionName.value}:`);
+			},
+		});
+	}
+
+	if (isEmojiMuted(props.reaction).value) {
+		menuItems.push({
+			text: i18n.ts.emojiUnmute,
+			icon: 'ti ti-mood-smile',
+			action: () => {
+				os.confirm({
+					type: 'question',
+					title: i18n.tsx.unmuteX({ x: isLocalCustomEmoji.value ? `:${emojiName.value}:` : props.reaction }),
+				}).then(({ canceled }) => {
+					if (canceled) return;
+					unmuteEmoji(props.reaction);
+				});
+			},
+		});
+	} else {
+		menuItems.push({
+			text: i18n.ts.emojiMute,
+			icon: 'ti ti-mood-off',
+			action: () => {
+				os.confirm({
+					type: 'question',
+					title: i18n.tsx.muteX({ x: isLocalCustomEmoji.value ? `:${emojiName.value}:` : props.reaction }),
+				}).then(({ canceled }) => {
+					if (canceled) return;
+					muteEmoji(props.reaction);
+				});
+			},
+		});
+	}
+
+	if (canToggle.value) {
+		menuItems.push({
+			text: i18n.ts.addToEmojiPalette,
+			icon: 'ti ti-palette',
+			action: () => {
+				addToEmojiPalette(isLocalCustomEmoji.value ? `:${emojiName.value}:` : props.reaction);
+			},
+		});
+	}
+
+	if (advanccedNotesSearchAvailable) {
+		menuItems.push({
+			text: i18n.ts.searchThisReaction,
+			icon: 'ti ti-search',
+			action: () => {
+				router.pushByPath(`/search?type=anote&reactions=${encodeURIComponent(isCustomEmoji ? props.reaction.endsWith('@.:') ? props.reaction.replace('@.', '') : props.reaction : props.reaction)}`);
+			},
+		});
+		if (isCustomEmoji) {
+			menuItems.push({
+				text: `${i18n.ts.searchThisReaction}(${i18n.ts.partialMatch})`,
+				icon: 'ti ti-search',
+				action: () => {
+					router.pushByPath(`/search?type=anote&reactions=${encodeURIComponent(`${props.reaction.endsWith('@.:') ? props.reaction.replace('@.:', '') : props.reaction.split('@')[0]}*`)}`);
+				},
+			});
+		}
+	}
+
+	menuItems.push({
+		icon: 'ti ti-users',
+		text: i18n.ts.reactionUsers,
+		action: () => emit('showUsers', props.reaction),
+	});
+
+	os.popupMenu(menuItems, ev.currentTarget ?? ev.target);
 }
 
 watch(() => props.count, (newCount, oldCount) => {

--- a/packages/frontend/src/components/MkAnnouncementReaction.vue
+++ b/packages/frontend/src/components/MkAnnouncementReaction.vue
@@ -11,7 +11,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 	:class="[$style.root, { [$style.reacted]: isReacted, [$style.canToggle]: (canToggle || alternative), [$style.small]: prefer.s.reactionsDisplaySize === 'small', [$style.large]: prefer.s.reactionsDisplaySize === 'large' }]"
 	@click.stop="(ev) => toggleReaction(ev)"
 >
-	<MkReactionIcon style="pointer-events: none;" :class="prefer.s.limitWidthOfReaction ? $style.limitWidth : ''" :reaction="reaction" @click.stop="(ev: PointerEvent) => { toggleReaction(ev); }"/>
+	<MkReactionIcon style="pointer-events: none;" :class="prefer.s.limitWidthOfReaction ? $style.limitWidth : ''" :reaction="reaction"/>
 	<span :class="$style.count">{{ count }}</span>
 </button>
 </template>
@@ -40,7 +40,6 @@ const props = defineProps<{
 	count: number;
 	isInitial: boolean;
 	myReactions: string[];
-	reactions: Record<string, number>;
 }>();
 
 const emit = defineEmits<{
@@ -73,10 +72,9 @@ async function toggleReaction(ev: MouseEvent) {
 	haptic();
 
 	if (!canToggle.value) {
-		await chooseAlternative(ev as PointerEvent);
+		await chooseAlternative();
 		return;
 	}
-	if ($i == null) return;
 
 	await toggleAnnouncementReaction(ev);
 }
@@ -137,7 +135,7 @@ function anime() {
 	});
 }
 
-async function chooseAlternative(ev: PointerEvent) {
+async function chooseAlternative() {
 	if (!alternative.value) return;
 
 	const reaction = `:${alternative.value}:`;
@@ -149,10 +147,18 @@ async function chooseAlternative(ev: PointerEvent) {
 		});
 		if (confirm.canceled) return;
 		emit('announcementReactionToggled', reaction, -1);
-		await misskeyApi('announcements/reactions/delete', {
-			announcementId: props.announcementId,
-			reaction,
-		});
+		try {
+			await misskeyApi('announcements/reactions/delete', {
+				announcementId: props.announcementId,
+				reaction,
+			});
+		} catch (err) {
+			emit('announcementReactionToggled', reaction, 1);
+			os.alert({
+				type: 'error',
+				text: i18n.ts.somethingHappened,
+			});
+		}
 	} else {
 		emit('announcementReactionToggled', reaction, 1);
 		try {

--- a/packages/frontend/src/components/MkAnnouncementReaction.vue
+++ b/packages/frontend/src/components/MkAnnouncementReaction.vue
@@ -33,7 +33,6 @@ import * as sound from '@/utility/sound.js';
 import { customEmojis, customEmojisMap } from '@/custom-emojis.js';
 import { prefer } from '@/preferences.js';
 import { haptic } from '@/utility/haptic.js';
-import { useRouter } from '@/router.js';
 
 const props = defineProps<{
 	announcementId: Misskey.entities.Announcement['id'];
@@ -60,33 +59,13 @@ const canToggle = computed(() => {
 	const emoji = customEmojisMap.get(emojiName.value) ?? getUnicodeEmojiOrNull(props.reaction);
 	return props.reaction.match(/@\w/) == null && $i != null && emoji != null;
 });
-const canGetInfo = computed(() => props.reaction.startsWith(':'));
-const isLocalCustomEmoji = props.reaction[0] === ':' && props.reaction.includes('@.');
 
 const reactionName = computed(() => {
 	const r = props.reaction.replace(':', '');
 	return r.slice(0, r.indexOf('@'));
 });
 
-const reactionHost = computed(() => {
-	const r = props.reaction.replaceAll(':', '');
-	return r.split('@')[1];
-});
-
-const router = useRouter();
-
 const alternative: ComputedRef<string | null> = computed(() => prefer.s.reactableRemoteReactionEnabled ? (customEmojis.value.find(it => it.name === reactionName.value)?.name ?? null) : null);
-
-const canImport = computed(() =>
-	$i != null &&
-	($i.isAdmin || $i.policies.canManageCustomEmojis) &&
-	props.reaction.startsWith(':') &&
-	!!reactionHost.value &&
-	reactionHost.value !== '.' &&
-	!customEmojisMap.has(reactionName.value),
-);
-
-const reactionLabel = computed(() => props.reaction.startsWith(':') ? `:${reactionName.value}:` : props.reaction);
 
 const toggling = ref(false);
 

--- a/packages/frontend/src/components/MkAnnouncementReaction.vue
+++ b/packages/frontend/src/components/MkAnnouncementReaction.vue
@@ -158,6 +158,7 @@ function anime() {
 
 async function chooseAlternative() {
 	if (!alternative.value) return;
+	if ($i == null) return;
 
 	const reaction = `:${alternative.value}:`;
 	const isReactedNow = props.myReactions.includes(reaction);

--- a/packages/frontend/src/components/MkAnnouncementReaction.vue
+++ b/packages/frontend/src/components/MkAnnouncementReaction.vue
@@ -1,0 +1,298 @@
+<!--
+SPDX-FileCopyrightText: syuilo and misskey-project, yojo-art team
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
+<template>
+<button
+	ref="buttonEl"
+	v-ripple="canToggle"
+	class="_button"
+	:class="[$style.root, { [$style.reacted]: isReacted, [$style.canToggle]: (canToggle || alternative), [$style.small]: prefer.s.reactionsDisplaySize === 'small', [$style.large]: prefer.s.reactionsDisplaySize === 'large' }]"
+	@click.stop="(ev) => toggleReaction(ev)"
+>
+	<MkReactionIcon style="pointer-events: none;" :class="prefer.s.limitWidthOfReaction ? $style.limitWidth : ''" :reaction="reaction" @click.stop="(ev: PointerEvent) => { toggleReaction(ev); }"/>
+	<span :class="$style.count">{{ count }}</span>
+</button>
+</template>
+
+<script lang="ts" setup>
+import { computed, onMounted, useTemplateRef, watch, ref } from 'vue';
+import * as Misskey from 'misskey-js';
+import { getUnicodeEmojiOrNull } from '@@/js/emojilist.js';
+import type { ComputedRef } from 'vue';
+import XDetails from '@/components/MkReactionsViewer.details.vue';
+import MkReactionIcon from '@/components/MkReactionIcon.vue';
+import * as os from '@/os.js';
+import { misskeyApi, misskeyApiGet } from '@/utility/misskey-api.js';
+import { useTooltip } from '@/composables/use-tooltip.js';
+import { $i } from '@/i.js';
+import MkReactionEffect from '@/components/MkReactionEffect.vue';
+import { i18n } from '@/i18n.js';
+import * as sound from '@/utility/sound.js';
+import { customEmojis, customEmojisMap } from '@/custom-emojis.js';
+import { prefer } from '@/preferences.js';
+import { haptic } from '@/utility/haptic.js';
+import { useRouter } from '@/router.js';
+
+const props = defineProps<{
+	announcementId: Misskey.entities.Announcement['id'];
+	reaction: string;
+	count: number;
+	isInitial: boolean;
+	myReactions: string[];
+	reactions: Record<string, number>;
+}>();
+
+const emit = defineEmits<{
+	(ev: 'announcementReactionToggled', reaction: string, delta: number): void;
+}>();
+
+const buttonEl = useTemplateRef('buttonEl');
+
+const TOO_MANY_REACTIONS_ERROR_ID = 'd1a4b6c8-2e9f-4a3d-b7c5-6f0e8a9b2c1d';
+
+const emojiName = computed(() => props.reaction.replace(/:/g, '').replace(/@\./, ''));
+
+const isReacted = computed(() => props.myReactions.includes(props.reaction));
+
+const canToggle = computed(() => {
+	const emoji = customEmojisMap.get(emojiName.value) ?? getUnicodeEmojiOrNull(props.reaction);
+	return props.reaction.match(/@\w/) == null && $i != null && emoji != null;
+});
+const canGetInfo = computed(() => props.reaction.startsWith(':'));
+const isLocalCustomEmoji = props.reaction[0] === ':' && props.reaction.includes('@.');
+
+const reactionName = computed(() => {
+	const r = props.reaction.replace(':', '');
+	return r.slice(0, r.indexOf('@'));
+});
+
+const reactionHost = computed(() => {
+	const r = props.reaction.replaceAll(':', '');
+	return r.split('@')[1];
+});
+
+const router = useRouter();
+
+const alternative: ComputedRef<string | null> = computed(() => prefer.s.reactableRemoteReactionEnabled ? (customEmojis.value.find(it => it.name === reactionName.value)?.name ?? null) : null);
+
+const canImport = computed(() =>
+	$i != null &&
+	($i.isAdmin || $i.policies.canManageCustomEmojis) &&
+	props.reaction.startsWith(':') &&
+	!!reactionHost.value &&
+	reactionHost.value !== '.' &&
+	!customEmojisMap.has(reactionName.value),
+);
+
+const reactionLabel = computed(() => props.reaction.startsWith(':') ? `:${reactionName.value}:` : props.reaction);
+
+const toggling = ref(false);
+
+async function toggleReaction(ev: MouseEvent) {
+	haptic();
+
+	if (!canToggle.value) {
+		await chooseAlternative(ev as PointerEvent);
+		return;
+	}
+	if ($i == null) return;
+
+	await toggleAnnouncementReaction(ev);
+}
+
+async function toggleAnnouncementReaction(_ev?: MouseEvent) {
+	if (toggling.value) return;
+	const isReactedNow = isReacted.value;
+
+	if (isReactedNow) {
+		const confirm = await os.confirm({
+			type: 'warning',
+			text: i18n.ts.cancelReactionConfirm,
+		});
+		if (confirm.canceled) return;
+	}
+
+	toggling.value = true;
+
+	const delta = isReactedNow ? -1 : 1;
+	emit('announcementReactionToggled', props.reaction, delta);
+
+	try {
+		if (isReactedNow) {
+			await misskeyApi('announcements/reactions/delete', {
+				announcementId: props.announcementId,
+				reaction: props.reaction,
+			});
+		} else {
+			await misskeyApi('announcements/reactions/create', {
+				announcementId: props.announcementId,
+				reaction: props.reaction,
+			});
+			sound.playMisskeySfx('reaction');
+			// effect は watch(count)→anime() に一任 (二重表示防止)
+		}
+	} catch (err) {
+		emit('announcementReactionToggled', props.reaction, -delta);
+		const reactionLimit = $i?.policies.reactionLimit ?? 0;
+		os.alert({
+			type: 'error',
+			text: (err as { id?: string }).id === TOO_MANY_REACTIONS_ERROR_ID
+				? i18n.tsx._announcement.reactionLimitExceeded({ n: reactionLimit })
+				: i18n.ts.somethingHappened,
+		});
+	} finally {
+		toggling.value = false;
+	}
+}
+
+function anime() {
+	if (window.document.hidden || !prefer.s.animation || buttonEl.value == null) return;
+
+	const rect = buttonEl.value.getBoundingClientRect();
+	const x = rect.left + 16;
+	const y = rect.top + (buttonEl.value.offsetHeight / 2);
+	const { dispose } = os.popup(MkReactionEffect, { reaction: props.reaction, x, y }, {
+		end: () => dispose(),
+	});
+}
+
+async function chooseAlternative(ev: PointerEvent) {
+	if (!alternative.value) return;
+
+	const reaction = `:${alternative.value}:`;
+	const isReactedNow = props.myReactions.includes(reaction);
+	if (isReactedNow) {
+		const confirm = await os.confirm({
+			type: 'warning',
+			text: i18n.ts.cancelReactionConfirm,
+		});
+		if (confirm.canceled) return;
+		emit('announcementReactionToggled', reaction, -1);
+		await misskeyApi('announcements/reactions/delete', {
+			announcementId: props.announcementId,
+			reaction,
+		});
+	} else {
+		emit('announcementReactionToggled', reaction, 1);
+		try {
+			await misskeyApi('announcements/reactions/create', {
+				announcementId: props.announcementId,
+				reaction,
+			});
+			sound.playMisskeySfx('reaction');
+			// effect は watch(count)→anime() に一任
+		} catch (err) {
+			emit('announcementReactionToggled', reaction, -1);
+			const reactionLimit = $i?.policies.reactionLimit ?? 0;
+			os.alert({
+				type: 'error',
+				text: (err as { id?: string }).id === TOO_MANY_REACTIONS_ERROR_ID
+					? i18n.tsx._announcement.reactionLimitExceeded({ n: reactionLimit })
+					: i18n.ts.somethingHappened,
+			});
+		}
+	}
+}
+
+watch(() => props.count, (newCount, oldCount) => {
+	if (oldCount < newCount) anime();
+});
+
+onMounted(() => {
+	if (!props.isInitial) anime();
+});
+
+useTooltip(buttonEl, async (showing) => {
+	if (buttonEl.value == null) return;
+
+	const reactions = await misskeyApiGet('announcements/reactions', {
+		announcementId: props.announcementId,
+		type: props.reaction,
+		limit: 10,
+		_cacheKey_: props.count,
+	});
+	const users = reactions.map(x => x.user);
+	const { dispose } = os.popup(XDetails, {
+		showing,
+		reaction: props.reaction,
+		users,
+		count: props.count,
+		anchorElement: buttonEl.value,
+	}, {
+		closed: () => dispose(),
+	});
+}, 100);
+</script>
+
+<style lang="scss" module>
+.root {
+	display: inline-flex;
+	height: 38px;
+	padding: 0 12px;
+	font-size: 1.35em;
+	border-radius: 999px;
+	align-items: center;
+	justify-content: center;
+
+	&.canToggle {
+		background: var(--MI_THEME-buttonBg);
+
+		&:hover {
+			background: var(--MI_THEME-buttonHoverBg, rgba(0, 0, 0, 0.1));
+		}
+	}
+
+	&:not(.canToggle) {
+		cursor: default;
+	}
+
+	&.small {
+		height: 30px;
+		font-size: 1em;
+
+		> .count {
+			font-size: 0.9em;
+			line-height: 22px;
+		}
+	}
+
+	&.large {
+		height: 46px;
+		font-size: 1.8em;
+		padding: 4px 16px;
+
+		> .count {
+			font-size: 0.6em;
+			line-height: 50px;
+			margin: 0 0 0 8px;
+		}
+	}
+
+	&.reacted, &.reacted:hover {
+		background: var(--MI_THEME-accentedBg);
+		color: var(--MI_THEME-accent);
+		box-shadow: 0 0 0 1px var(--MI_THEME-accent) inset;
+
+		> .count {
+			color: var(--MI_THEME-accent);
+		}
+
+		> .icon {
+			filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.5));
+		}
+	}
+}
+
+.limitWidth {
+	max-width: 70px;
+	object-fit: contain;
+}
+
+.count {
+	font-size: 0.9em;
+	line-height: 32px;
+	margin: 0 0 0 5px;
+}
+</style>

--- a/packages/frontend/src/components/MkAnnouncementReactions.vue
+++ b/packages/frontend/src/components/MkAnnouncementReactions.vue
@@ -41,7 +41,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 			key="more"
 			class="_button"
 			:class="[$style.more, { [$style.small]: prefer.s.reactionsDisplaySize === 'small', [$style.large]: prefer.s.reactionsDisplaySize === 'large' }]"
-			@click="showReactedUsers()"
+			@click="isExpanded = true"
 		>
 			{{ i18n.ts.more }}
 		</button>
@@ -99,6 +99,7 @@ const initialReactions = new Set(Object.keys(props.reactions));
 
 const _reactions = ref<[string, number][]>([]);
 const hasMoreReactions = ref(false);
+const isExpanded = ref(false);
 
 for (const r of props.myReactions) {
 	if (!(r in props.reactions)) {
@@ -106,9 +107,10 @@ for (const r of props.myReactions) {
 	}
 }
 
-watch([() => props.reactions, () => props.maxNumber], ([newSource, maxNumber]) => {
+watch([() => props.reactions, () => props.maxNumber, isExpanded], ([newSource, maxNumber, expanded]) => {
+	const effectiveMax = expanded ? Infinity : maxNumber;
 	let newReactions: [string, number][] = [];
-	hasMoreReactions.value = Object.keys(newSource).length > maxNumber;
+	hasMoreReactions.value = !expanded && Object.keys(newSource).length > (maxNumber as number);
 
 	for (let i = 0; i < _reactions.value.length; i++) {
 		const reaction = _reactions.value[i][0];
@@ -123,10 +125,10 @@ watch([() => props.reactions, () => props.maxNumber], ([newSource, maxNumber]) =
 		...newReactions,
 		...Object.entries(newSource)
 			.sort((a, b) => b[1] - a[1])
-			.filter(([y], i) => i < (maxNumber as number) && !newReactionsNames.includes(y)),
+			.filter(([y], i) => i < (effectiveMax as number) && !newReactionsNames.includes(y)),
 	];
 
-	newReactions = newReactions.slice(0, props.maxNumber);
+	newReactions = newReactions.slice(0, effectiveMax as number);
 
 	for (const mr of myReactions.value) {
 		if (!newReactions.map(([x]) => x).includes(mr) && mr in newSource) {

--- a/packages/frontend/src/components/MkAnnouncementReactions.vue
+++ b/packages/frontend/src/components/MkAnnouncementReactions.vue
@@ -61,7 +61,7 @@ const props = withDefaults(defineProps<{
 	myReactions: string[];
 	maxNumber?: number;
 }>(), {
-	maxNumber: Infinity,
+	maxNumber: 20,
 });
 
 const emit = defineEmits<{

--- a/packages/frontend/src/components/MkAnnouncementReactions.vue
+++ b/packages/frontend/src/components/MkAnnouncementReactions.vue
@@ -14,7 +14,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 	tag="div" :class="$style.root"
 >
 	<MkAnnouncementReaction
-		v-for="[reaction, count] in sortedReactions"
+		v-for="[reaction, count] in _reactions"
 		:key="reaction"
 		:announcementId="announcementId"
 		:reaction="reaction"
@@ -36,16 +36,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 	>
 		<i class="ti ti-plus"></i>
 	</button>
-	<slot v-if="hasReactions" name="more">
-		<button
-			key="more"
-			class="_button"
-			:class="[$style.more, { [$style.small]: prefer.s.reactionsDisplaySize === 'small', [$style.large]: prefer.s.reactionsDisplaySize === 'large' }]"
-			@click="showReactedUsers()"
-		>
-			{{ i18n.ts.more }}
-		</button>
-	</slot>
+	<slot v-if="hasMoreReactions" name="more"></slot>
 </component>
 </template>
 
@@ -64,11 +55,14 @@ import * as sound from '@/utility/sound.js';
 import { useStream } from '@/stream.js';
 import { prefer } from '@/preferences.js';
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
 	announcementId: Misskey.entities.Announcement['id'];
 	reactions: Record<string, number>;
 	myReactions: string[];
-}>();
+	maxNumber?: number;
+}>(), {
+	maxNumber: Infinity,
+});
 
 const emit = defineEmits<{
 	(ev: 'update', reactions: Record<string, number>, myReactions: string[]): void;
@@ -93,6 +87,46 @@ const stream = useStream();
 const mainChannel = $i != null ? stream.useChannel('main') : null;
 
 const initialReactions = new Set(Object.keys(props.reactions));
+
+const _reactions = ref<[string, number][]>([]);
+const hasMoreReactions = ref(false);
+
+for (const r of props.myReactions) {
+	if (!(r in props.reactions)) {
+		_reactions.value.push([r, 0]);
+	}
+}
+
+watch([() => props.reactions, () => props.maxNumber], ([newSource, maxNumber]) => {
+	let newReactions: [string, number][] = [];
+	hasMoreReactions.value = Object.keys(newSource).length > maxNumber;
+
+	for (let i = 0; i < _reactions.value.length; i++) {
+		const reaction = _reactions.value[i][0];
+		if (reaction in newSource && newSource[reaction] !== 0) {
+			_reactions.value[i][1] = newSource[reaction];
+			newReactions.push(_reactions.value[i]);
+		}
+	}
+
+	const newReactionsNames = newReactions.map(([x]) => x);
+	newReactions = [
+		...newReactions,
+		...Object.entries(newSource)
+			.sort((a, b) => b[1] - a[1])
+			.filter(([y], i) => i < (maxNumber as number) && !newReactionsNames.includes(y)),
+	];
+
+	newReactions = newReactions.slice(0, props.maxNumber);
+
+	for (const mr of myReactions.value) {
+		if (!newReactions.map(([x]) => x).includes(mr) && mr in newSource) {
+			newReactions.push([mr, (newSource as Record<string, number>)[mr]]);
+		}
+	}
+
+	_reactions.value = newReactions;
+}, { immediate: true, deep: true });
 
 watch(() => props.reactions, (newReactions) => {
 	reactions.value = { ...newReactions };
@@ -146,12 +180,6 @@ onUnmounted(() => {
 	mainChannel?.off('announcementUnreacted', onUnreacted);
 	mainChannel?.dispose();
 });
-
-const sortedReactions = computed(() => Object.entries(reactions.value)
-	.filter(([, count]) => count > 0)
-	.sort((a, b) => b[1] - a[1]));
-
-const hasReactions = computed(() => sortedReactions.value.length > 0);
 
 function showReactedUsers(initialReaction?: string) {
 	const { dispose } = os.popup(MkAnnouncementReactedUsersDialog, {

--- a/packages/frontend/src/components/MkAnnouncementReactions.vue
+++ b/packages/frontend/src/components/MkAnnouncementReactions.vue
@@ -36,7 +36,16 @@ SPDX-License-Identifier: AGPL-3.0-only
 	>
 		<i class="ti ti-plus"></i>
 	</button>
-	<slot v-if="hasMoreReactions" name="more"></slot>
+	<slot v-if="hasMoreReactions" name="more">
+		<button
+			key="more"
+			class="_button"
+			:class="[$style.more, { [$style.small]: prefer.s.reactionsDisplaySize === 'small', [$style.large]: prefer.s.reactionsDisplaySize === 'large' }]"
+			@click="showReactedUsers()"
+		>
+			{{ i18n.ts.more }}
+		</button>
+	</slot>
 </component>
 </template>
 

--- a/packages/frontend/src/components/MkAnnouncementReactions.vue
+++ b/packages/frontend/src/components/MkAnnouncementReactions.vue
@@ -22,6 +22,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 		:isInitial="initialReactions.has(reaction)"
 		:myReactions="myReactions"
 		@announcementReactionToggled="onAnnouncementReactionToggled"
+		@showUsers="showReactedUsers"
 	/>
 	<button
 		v-if="canAddReaction"

--- a/packages/frontend/src/components/MkAnnouncementReactions.vue
+++ b/packages/frontend/src/components/MkAnnouncementReactions.vue
@@ -1,51 +1,57 @@
 <!--
-SPDX-FileCopyrightText: syuilo and misskey-project
+SPDX-FileCopyrightText: syuilo and misskey-project, yojo-art team
 SPDX-License-Identifier: AGPL-3.0-only
 -->
 
 <template>
-<div :class="$style.root">
-	<button
+<component
+	:is="prefer.s.animation ? TransitionGroup : 'div'"
+	:enterActiveClass="$style.transition_x_enterActive"
+	:leaveActiveClass="$style.transition_x_leaveActive"
+	:enterFromClass="$style.transition_x_enterFrom"
+	:leaveToClass="$style.transition_x_leaveTo"
+	:moveClass="$style.transition_x_move"
+	tag="div" :class="$style.root"
+>
+	<MkAnnouncementReaction
 		v-for="[reaction, count] in sortedReactions"
 		:key="reaction"
-		v-ripple="canToggle"
-		class="_button"
-		:class="[$style.reaction, { [$style.reacted]: myReactions.includes(reaction), [$style.canToggle]: canToggle }]"
-		:disabled="!canToggle"
-		:aria-pressed="myReactions.includes(reaction)"
-		:aria-label="reaction"
-		@click="toggle(reaction)"
-		@contextmenu.prevent.stop="showReactedUsers(reaction)"
-	>
-		<MkReactionIcon style="pointer-events: none;" :reaction="reaction"/>
-		<span :class="$style.count">{{ count }}</span>
-	</button>
+		:announcementId="announcementId"
+		:reaction="reaction"
+		:count="count"
+		:isInitial="initialReactions.has(reaction)"
+		:myReactions="myReactions"
+		:reactions="reactions"
+		@announcementReactionToggled="onAnnouncementReactionToggled"
+	/>
 	<button
 		v-if="canAddReaction"
 		ref="pickerButtonEl"
 		v-tooltip="i18n.ts.reaction"
 		class="_button"
-		:class="[$style.reaction, $style.add]"
+		:class="[$style.add, { [$style.small]: prefer.s.reactionsDisplaySize === 'small', [$style.large]: prefer.s.reactionsDisplaySize === 'large' }]"
 		:aria-label="i18n.ts.reaction"
 		@click="pick"
 	>
 		<i class="ti ti-plus"></i>
 	</button>
-	<button
-		v-if="hasReactions"
-		class="_button"
-		:class="[$style.reaction, $style.more]"
-		@click="showReactedUsers()"
-	>
-		{{ i18n.ts.more }}
-	</button>
-</div>
+	<slot v-if="hasReactions" name="more">
+		<button
+			class="_button"
+			:class="[$style.more, { [$style.small]: prefer.s.reactionsDisplaySize === 'small', [$style.large]: prefer.s.reactionsDisplaySize === 'large' }]"
+			@click="showReactedUsers()"
+		>
+			{{ i18n.ts.more }}
+		</button>
+	</slot>
+</component>
 </template>
 
 <script lang="ts" setup>
 import { computed, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue';
+import { TransitionGroup } from 'vue';
 import * as Misskey from 'misskey-js';
-import MkReactionIcon from '@/components/MkReactionIcon.vue';
+import MkAnnouncementReaction from '@/components/MkAnnouncementReaction.vue';
 import MkAnnouncementReactedUsersDialog from '@/components/MkAnnouncementReactedUsersDialog.vue';
 import { misskeyApi } from '@/utility/misskey-api.js';
 import { reactionPicker } from '@/utility/reaction-picker.js';
@@ -54,6 +60,8 @@ import { $i } from '@/i.js';
 import * as os from '@/os.js';
 import * as sound from '@/utility/sound.js';
 import { useStream } from '@/stream.js';
+import MkReactionEffect from '@/components/MkReactionEffect.vue';
+import { prefer } from '@/preferences.js';
 
 const props = defineProps<{
 	announcementId: Misskey.entities.Announcement['id'];
@@ -82,6 +90,8 @@ const toggling = ref(false);
 
 const stream = useStream();
 const mainChannel = $i != null ? stream.useChannel('main') : null;
+
+const initialReactions = new Set(Object.keys(props.reactions));
 
 watch(() => props.reactions, (newReactions) => {
 	reactions.value = { ...newReactions };
@@ -153,8 +163,12 @@ function showReactedUsers(initialReaction?: string) {
 }
 
 /**
- * リアクションを楽観的に適用し、失敗時に巻き戻せるよう元の状態を返す。
+ * 子 MkReaction からの楽観的更新を受け取る
  */
+function onAnnouncementReactionToggled(reaction: string, delta: number) {
+	applyLocally(reaction, delta);
+}
+
 function applyLocally(reaction: string, delta: number) {
 	const nextReactions = { ...reactions.value };
 	const count = (nextReactions[reaction] ?? 0) + delta;
@@ -172,40 +186,22 @@ function applyLocally(reaction: string, delta: number) {
 	updateReactions(nextReactions, nextMyReactions);
 }
 
-async function toggle(reaction: string) {
-	if (!canToggle.value || toggling.value) return;
-
-	const previousReactions = { ...reactions.value };
-	const previousMyReactions = [...myReactions.value];
-	const isReacted = previousMyReactions.includes(reaction);
-
-	toggling.value = true;
-	applyLocally(reaction, isReacted ? -1 : 1);
-
-	try {
-		if (isReacted) {
-			await misskeyApi('announcements/reactions/delete', {
-				announcementId: props.announcementId,
-				reaction,
-			});
-		} else {
-			await misskeyApi('announcements/reactions/create', {
-				announcementId: props.announcementId,
-				reaction,
-			});
-			sound.playMisskeySfx('reaction');
-		}
-	} catch (err) {
-		updateReactions(previousReactions, previousMyReactions);
-		os.alert({
-			type: 'error',
-			text: (err as { id?: string }).id === TOO_MANY_REACTIONS_ERROR_ID
-				? i18n.tsx._announcement.reactionLimitExceeded({ n: reactionLimit.value })
-				: i18n.ts.somethingHappened,
-		});
-	} finally {
-		toggling.value = false;
+function showReactionEffect(reaction: string, rect: DOMRect | null) {
+	if (!prefer.s.animation) return;
+	let x: number, y: number;
+	if (rect) {
+		x = rect.left + rect.width / 2;
+		y = rect.top + rect.height / 2;
+	} else if (pickerButtonEl.value) {
+		const r = pickerButtonEl.value.getBoundingClientRect();
+		x = r.left + r.width / 2;
+		y = r.top + r.height / 2;
+	} else {
+		return;
 	}
+	const { dispose } = os.popup(MkReactionEffect, { reaction, x, y }, {
+		end: () => dispose(),
+	});
 }
 
 /**
@@ -214,76 +210,131 @@ async function toggle(reaction: string) {
  * - Unicode絵文字: 異体字セレクタ(U+FE0F)除去(ZWJ 合字はそのまま)
  */
 function normalizePickedReaction(reaction: string): string {
-	// カスタム絵文字を :name@.: 形式に変換
 	const customMatch = reaction.match(/^:([\w+-]+):$/);
 	if (customMatch) return `:${customMatch[1]}@.:`;
-	// Unicode絵文字の異体字セレクタを除去
 	return reaction.match('\u200d') ? reaction : reaction.replace(/\ufe0f/g, '');
 }
 
 function pick() {
-	if (!canAddReaction.value) return;
+	if (!canAddReaction.value || toggling.value) return;
 
-	reactionPicker.show(pickerButtonEl.value ?? null, null, (reaction) => {
+	const pickerRect = pickerButtonEl.value?.getBoundingClientRect() ?? null;
+
+	reactionPicker.show(pickerButtonEl.value ?? null, null, async (reaction) => {
 		const normalized = normalizePickedReaction(reaction);
-		// すでに付けているリアクションを選んだ場合は何もしない
 		if (myReactions.value.includes(normalized)) return;
-		toggle(normalized);
+
+		const previousReactions = { ...reactions.value };
+		const previousMyReactions = [...myReactions.value];
+
+		// エフェクト座標は pickerRect から
+		const rect = pickerRect;
+
+		toggling.value = true;
+		applyLocally(normalized, 1);
+
+		try {
+			await misskeyApi('announcements/reactions/create', {
+				announcementId: props.announcementId,
+				reaction: normalized,
+			});
+			sound.playMisskeySfx('reaction');
+			//showReactionEffect(normalized, rect);
+		} catch (err) {
+			updateReactions(previousReactions, previousMyReactions);
+			os.alert({
+				type: 'error',
+				text: (err as { id?: string }).id === TOO_MANY_REACTIONS_ERROR_ID
+					? i18n.tsx._announcement.reactionLimitExceeded({ n: reactionLimit.value })
+					: i18n.ts.somethingHappened,
+			});
+		} finally {
+			toggling.value = false;
+		}
 	});
 }
 </script>
 
 <style lang="scss" module>
+.transition_x_move,
+.transition_x_enterActive,
+.transition_x_leaveActive {
+	transition: opacity 0.2s cubic-bezier(0,.5,.5,1), transform 0.2s cubic-bezier(0,.5,.5,1) !important;
+}
+.transition_x_enterFrom,
+.transition_x_leaveTo {
+	opacity: 0;
+	transform: scale(0.7);
+}
+.transition_x_leaveActive {
+	position: absolute;
+}
+
 .root {
 	display: flex;
 	flex-wrap: wrap;
-	gap: 4px;
-}
-
-.reaction {
-	display: inline-flex;
 	align-items: center;
-	height: 32px;
-	padding: 0 6px;
-	border-radius: 4px;
-	background: var(--MI_THEME-buttonBg);
+	gap: 4px;
 
-	&.canToggle:hover {
-		background: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.05));
+	&:empty {
+		display: none;
 	}
-
-	&:not(.canToggle) {
-		cursor: default;
-	}
-
-	&.reacted,
-	&.reacted:hover {
-		background: var(--MI_THEME-accentedBg);
-		color: var(--MI_THEME-accent);
-		box-shadow: 0 0 0 1px var(--MI_THEME-accent) inset;
-
-		> .count {
-			color: var(--MI_THEME-accent);
-		}
-	}
-}
-
-.count {
-	font-size: 0.9em;
-	line-height: 32px;
-	margin: 0 0 0 4px;
 }
 
 .add {
-	color: var(--MI_THEME-fgTransparentWeak);
-}
-
-.more {
-	font-size: 0.9em;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	height: 38px;
+	padding: 0 12px;
+	font-size: 1.35em;
+	border-radius: 999px;
+	background: var(--MI_THEME-buttonBg);
 	color: var(--MI_THEME-fgTransparentWeak);
 
 	&:hover {
+		background: var(--MI_THEME-buttonHoverBg, rgba(0, 0, 0, 0.1));
+	}
+
+	&.small {
+		height: 30px;
+		padding: 0 10px;
+		font-size: 1em;
+	}
+
+	&.large {
+		height: 46px;
+		padding: 4px 16px;
+		font-size: 1.8em;
+	}
+}
+
+.more {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	height: 38px;
+	padding: 0 12px;
+	font-size: 0.9em;
+	border-radius: 999px;
+	background: var(--MI_THEME-buttonBg);
+	color: var(--MI_THEME-fgTransparentWeak);
+
+	&:hover {
+		background: var(--MI_THEME-buttonHoverBg, rgba(0, 0, 0, 0.1));
 		color: var(--MI_THEME-fg);
+	}
+
+	&.small {
+		height: 30px;
+		padding: 0 10px;
+		font-size: 0.8em;
+	}
+
+	&.large {
+		height: 46px;
+		padding: 4px 16px;
+		font-size: 1em;
 	}
 }
 </style>

--- a/packages/frontend/src/components/MkAnnouncementReactions.vue
+++ b/packages/frontend/src/components/MkAnnouncementReactions.vue
@@ -21,11 +21,11 @@ SPDX-License-Identifier: AGPL-3.0-only
 		:count="count"
 		:isInitial="initialReactions.has(reaction)"
 		:myReactions="myReactions"
-		:reactions="reactions"
 		@announcementReactionToggled="onAnnouncementReactionToggled"
 	/>
 	<button
 		v-if="canAddReaction"
+		key="add-reaction"
 		ref="pickerButtonEl"
 		v-tooltip="i18n.ts.reaction"
 		class="_button"
@@ -37,6 +37,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 	</button>
 	<slot v-if="hasReactions" name="more">
 		<button
+			key="more"
 			class="_button"
 			:class="[$style.more, { [$style.small]: prefer.s.reactionsDisplaySize === 'small', [$style.large]: prefer.s.reactionsDisplaySize === 'large' }]"
 			@click="showReactedUsers()"
@@ -60,7 +61,6 @@ import { $i } from '@/i.js';
 import * as os from '@/os.js';
 import * as sound from '@/utility/sound.js';
 import { useStream } from '@/stream.js';
-import MkReactionEffect from '@/components/MkReactionEffect.vue';
 import { prefer } from '@/preferences.js';
 
 const props = defineProps<{
@@ -186,24 +186,6 @@ function applyLocally(reaction: string, delta: number) {
 	updateReactions(nextReactions, nextMyReactions);
 }
 
-function showReactionEffect(reaction: string, rect: DOMRect | null) {
-	if (!prefer.s.animation) return;
-	let x: number, y: number;
-	if (rect) {
-		x = rect.left + rect.width / 2;
-		y = rect.top + rect.height / 2;
-	} else if (pickerButtonEl.value) {
-		const r = pickerButtonEl.value.getBoundingClientRect();
-		x = r.left + r.width / 2;
-		y = r.top + r.height / 2;
-	} else {
-		return;
-	}
-	const { dispose } = os.popup(MkReactionEffect, { reaction, x, y }, {
-		end: () => dispose(),
-	});
-}
-
 /**
  * ピッカーが返す生の絵文字文字列をバックエンドの decodeReaction と同じルールで変換する。
  * - カスタム絵文字: :name: → :name@.: (APIレスポンスがこの形式で返ってくる)
@@ -218,17 +200,12 @@ function normalizePickedReaction(reaction: string): string {
 function pick() {
 	if (!canAddReaction.value || toggling.value) return;
 
-	const pickerRect = pickerButtonEl.value?.getBoundingClientRect() ?? null;
-
 	reactionPicker.show(pickerButtonEl.value ?? null, null, async (reaction) => {
 		const normalized = normalizePickedReaction(reaction);
 		if (myReactions.value.includes(normalized)) return;
 
 		const previousReactions = { ...reactions.value };
 		const previousMyReactions = [...myReactions.value];
-
-		// エフェクト座標は pickerRect から
-		const rect = pickerRect;
 
 		toggling.value = true;
 		applyLocally(normalized, 1);
@@ -239,7 +216,6 @@ function pick() {
 				reaction: normalized,
 			});
 			sound.playMisskeySfx('reaction');
-			//showReactionEffect(normalized, rect);
 		} catch (err) {
 			updateReactions(previousReactions, previousMyReactions);
 			os.alert({

--- a/packages/frontend/src/components/MkAnnouncementReactions.vue
+++ b/packages/frontend/src/components/MkAnnouncementReactions.vue
@@ -130,12 +130,6 @@ watch([() => props.reactions, () => props.maxNumber, isExpanded], ([newSource, m
 
 	newReactions = newReactions.slice(0, effectiveMax as number);
 
-	for (const mr of myReactions.value) {
-		if (!newReactions.map(([x]) => x).includes(mr) && mr in newSource) {
-			newReactions.push([mr, (newSource as Record<string, number>)[mr]]);
-		}
-	}
-
 	_reactions.value = newReactions;
 }, { immediate: true, deep: true });
 


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
お知らせリアクションをノートリアクションのコードに合わせた

**before**
<img width="823" height="179" alt="image" src="https://github.com/user-attachments/assets/05d255e1-777b-4641-b6f0-5e406051319a" />
**aflter**
<img width="833" height="171" alt="image" src="https://github.com/user-attachments/assets/d852dff6-5b73-4ce5-a53b-fb5065ec20b9" />

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
リアクション時のエフェクトが正しくレンダリングされなかったため
close: #1327

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [x] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)
