### PR TITLE
Feat: 通報作成時にモデレーターの通知欄にもin-app通知を残すように

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -3407,6 +3407,7 @@ _notification:
   loginDescription: "{ip}でログインされました。\n承認されていない機器であれば、セキュリティのために「{text}」を通じてすべての機器でログアウトを行ってください。"
   createToken: "アクセストークンが作成されました"
   createTokenDescription: "心当たりがない場合は「{text}」を通じてアクセストークンを削除してください。"
+  abuseReport: "通報がありました"
 
   _types:
     all: "すべて"
@@ -3431,6 +3432,7 @@ _notification:
     createToken: "アクセストークンの作成"
     test: "通知のテスト"
     app: "連携アプリからの通知"
+    abuseReport: "通報があった"
 
   _actions:
     followBack: "フォローバック"

--- a/packages/backend/src/core/AbuseReportNotificationService.ts
+++ b/packages/backend/src/core/AbuseReportNotificationService.ts
@@ -23,6 +23,7 @@ import { RecipientMethod } from '@/models/AbuseReportNotificationRecipient.js';
 import { ModerationLogService } from '@/core/ModerationLogService.js';
 import { SystemWebhookService } from '@/core/SystemWebhookService.js';
 import { UserEntityService } from '@/core/entities/UserEntityService.js';
+import { NotificationService } from '@/core/NotificationService.js';
 import { IdService } from './IdService.js';
 
 @Injectable()
@@ -44,6 +45,7 @@ export class AbuseReportNotificationService implements OnApplicationShutdown {
 		private moderationLogService: ModerationLogService,
 		private globalEventService: GlobalEventService,
 		private userEntityService: UserEntityService,
+		private notificationService: NotificationService,
 	) {
 		this.redisForSub.on('message', this.onMessage);
 	}
@@ -78,6 +80,53 @@ export class AbuseReportNotificationService implements OnApplicationShutdown {
 						comment: abuseReport.comment,
 					},
 				);
+			}
+		}
+	}
+
+	/**
+	 * 通知欄（ベル）にも{@link abuseReports}の内容を残す.
+	 * **upstream には無い機能** — {@link notifyAdminStream}はその瞬間に管理画面を
+	 * 開いている人にしか届かず、後から見返すことができないため追加している。
+	 * 通知先ユーザは{@link getModeratorIds}の取得結果に依る。
+	 *
+	 * 通報コメント本文は通知に含めない — 定型フォームの全文は通知欄では読みにくい上、
+	 * Redis に本文を複製する理由が無く、権限を失った元モデレーターに読まれる面も
+	 * 減らせるため。通知は{@link NotificationService.createNotification}が best-effort
+	 * で作成する。
+	 *
+	 * **notifierId には reporterId を渡さない。** createNotification へ notifierId を
+	 * 渡すと、NotificationService / NotificationEntityService 側の汎用フィルタ
+	 * (ミュート・サスペンド判定) が通報者に対して適用されてしまい、「モデレーターが
+	 * 通報者をミュートしている」「通報後に通報者がサスペンドされた」というだけで
+	 * この通知が作成されない・後から読めなくなる (通知欄に残す目的そのものを破る)。
+	 * そのため notifierId は渡さず、通報者自身がモデレーターの場合の自己通知抑止も
+	 * ここで明示的に行う (createNotification 側の notifierId 起点の自己抑止に頼らない)。
+	 * reporter の解決は NotificationEntityService が reportId 経由で行う。
+	 *
+	 * @see RoleService.getModeratorIds
+	 * @see NotificationService.createNotification
+	 */
+	@bindThis
+	public async notifyInApp(abuseReports: MiAbuseUserReport[]) {
+		if (abuseReports.length <= 0) {
+			return;
+		}
+
+		const moderatorIds = await this.roleService.getModeratorIds({
+			includeAdmins: true,
+			excludeExpire: true,
+		});
+
+		for (const moderatorId of moderatorIds) {
+			for (const abuseReport of abuseReports) {
+				// 通報者自身がモデレーターなら自分の通知欄には出さない。
+				if (moderatorId === abuseReport.reporterId) {
+					continue;
+				}
+				this.notificationService.createNotification(moderatorId, 'abuseReport', {
+					reportId: abuseReport.id,
+				});
 			}
 		}
 	}

--- a/packages/backend/src/core/AbuseReportService.ts
+++ b/packages/backend/src/core/AbuseReportService.ts
@@ -36,6 +36,7 @@ export class AbuseReportService {
 	/**
 	 * ユーザからの通報をDBに記録し、その内容を下記の手段で管理者各位に通知する.
 	 * - 管理者用Redisイベント
+	 * - 通知欄（ベル）に残る in-app 通知
 	 * - EMail（モデレータ権限所有者ユーザ＋metaテーブルに設定されているメールアドレス）
 	 * - SystemWebhook
 	 *
@@ -69,6 +70,7 @@ export class AbuseReportService {
 
 		return Promise.all([
 			this.abuseReportNotificationService.notifyAdminStream(reports),
+			this.abuseReportNotificationService.notifyInApp(reports),
 			this.abuseReportNotificationService.notifySystemWebhook(reports, 'abuseReport'),
 			this.abuseReportNotificationService.notifyMail(reports),
 		]);

--- a/packages/backend/src/core/entities/NotificationEntityService.ts
+++ b/packages/backend/src/core/entities/NotificationEntityService.ts
@@ -7,7 +7,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { In } from 'typeorm';
 import { DI } from '@/di-symbols.js';
-import type { FollowRequestsRepository, NotesRepository, MiUser, UsersRepository, UserGroupInvitationsRepository } from '@/models/_.js';
+import type { FollowRequestsRepository, NotesRepository, MiUser, UsersRepository, UserGroupInvitationsRepository, AbuseUserReportsRepository, MiAbuseUserReport } from '@/models/_.js';
 import { awaitAll } from '@/misc/prelude/await-all.js';
 import type { MiGroupedNotification, MiNotification } from '@/models/Notification.js';
 import type { MiNote } from '@/models/Note.js';
@@ -59,6 +59,9 @@ export class NotificationEntityService implements OnModuleInit {
 		@Inject(DI.userGroupInvitationsRepository)
 		private userGroupInvitationsRepository: UserGroupInvitationsRepository,
 
+		@Inject(DI.abuseUserReportsRepository)
+		private abuseUserReportsRepository: AbuseUserReportsRepository,
+
 		private cacheService: CacheService,
 	) {
 	}
@@ -83,6 +86,7 @@ export class NotificationEntityService implements OnModuleInit {
 		hint?: {
 			packedNotes: Map<MiNote['id'], Packed<'Note'>>;
 			packedUsers: Map<MiUser['id'], Packed<'UserLite'>>;
+			abuseReports?: Map<MiAbuseUserReport['id'], MiAbuseUserReport>;
 		},
 	): Promise<Packed<'Notification'> | null> {
 		const notification = src;
@@ -191,6 +195,37 @@ export class NotificationEntityService implements OnModuleInit {
 			return null;
 		}
 
+		// abuseReport通知は永続化された内容を持たず、read時に現在の通報の状態
+		// (reporterId / targetUserId / resolved / resolvedAs / assigneeId) を
+		// 都度引き直す。他のモデレーターが対処した後も通知欄が「未対応」のまま
+		// 残るのを防ぐため。
+		const needsAbuseReport = notification.type === 'abuseReport';
+		const abuseReport = needsAbuseReport ? (
+			hint?.abuseReports != null
+				? (hint.abuseReports.get(notification.reportId) ?? null)
+				: await this.abuseUserReportsRepository.findOneBy({ id: notification.reportId })
+		) : undefined;
+		// if the report has been deleted, don't show this notification
+		if (needsAbuseReport && !abuseReport) {
+			return null;
+		}
+
+		// 通報者(reporter)は notifierId ではなく abuseReport.reporterId から解決する。
+		// notifierId にすると #validateNotifier の isSuspended / mutings チェックが
+		// 通報者に対して効いてしまい、モデレーターが通報者をミュートしている・
+		// 通報後に通報者がサスペンドされた、というだけでこの通知が作成されない/
+		// 読めなくなる (通知欄に残す目的そのものを破る)。ここでは deleted のみを
+		// drop 条件にする。
+		const abuseReportReporter = needsAbuseReport && abuseReport != null ? (
+			hint?.packedUsers != null && hint.packedUsers.has(abuseReport.reporterId)
+				? hint.packedUsers.get(abuseReport.reporterId)
+				: await this.userEntityService.pack(abuseReport.reporterId, { id: meId })
+		) : undefined;
+		// if the reporter has been deleted, don't show this notification
+		if (needsAbuseReport && !abuseReportReporter) {
+			return null;
+		}
+
 		return await awaitAll({
 			id: notification.id,
 			createdAt: new Date(notification.createdAt).toISOString(),
@@ -228,6 +263,20 @@ export class NotificationEntityService implements OnModuleInit {
 				header: notification.customHeader,
 				icon: notification.customIcon,
 			} : {}),
+			...(notification.type === 'abuseReport' ? {
+				reportId: notification.reportId,
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				targetUserId: abuseReport!.targetUserId,
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				resolved: abuseReport!.resolved,
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				resolvedAs: abuseReport!.resolvedAs,
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				assigneeId: abuseReport!.assigneeId,
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				userId: abuseReport!.reporterId,
+				user: abuseReportReporter,
+			} : {}),
 		});
 	}
 
@@ -261,12 +310,26 @@ export class NotificationEntityService implements OnModuleInit {
 
 		validNotifications = validNotifications.filter(x => !('noteId' in x) || packedNotes.has(x.noteId));
 
+		// abuseReport の reporter は notifierId ではなく reportId 経由で解決するため
+		// (#packInternal 参照)、userIds を集める前に abuseReports を引いておく必要がある。
+		const reportIds = validNotifications.map(x => x.type === 'abuseReport' ? x.reportId : null).filter(x => x != null);
+		const abuseReportsArray = reportIds.length > 0 ? await this.abuseUserReportsRepository.find({
+			where: { id: In(reportIds) },
+		}) : [];
+		const abuseReports = new Map(abuseReportsArray.map(r => [r.id, r]));
+
+		validNotifications = validNotifications.filter(x => x.type !== 'abuseReport' || abuseReports.has(x.reportId));
+
 		const userIds = [];
 		for (const notification of validNotifications) {
 			if ('notifierId' in notification) userIds.push(notification.notifierId);
 			if (notification.type === 'reaction:grouped') userIds.push(...notification.reactions.map(x => x.userId));
 			if (notification.type === 'renote:grouped') userIds.push(...notification.userIds);
 			if (notification.type === 'note:grouped') userIds.push(...notification.notifierIds);
+			if (notification.type === 'abuseReport') {
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				userIds.push(abuseReports.get(notification.reportId)!.reporterId);
+			}
 		}
 		const users = userIds.length > 0 ? await this.usersRepository.find({
 			where: { id: In(userIds) },
@@ -288,7 +351,7 @@ export class NotificationEntityService implements OnModuleInit {
 				x,
 				meId,
 				{ checkValidNotifier: false },
-				{ packedNotes, packedUsers },
+				{ packedNotes, packedUsers, abuseReports },
 			);
 		});
 
@@ -306,6 +369,7 @@ export class NotificationEntityService implements OnModuleInit {
 		hint?: {
 			packedNotes: Map<MiNote['id'], Packed<'Note'>>;
 			packedUsers: Map<MiUser['id'], Packed<'UserLite'>>;
+			abuseReports?: Map<MiAbuseUserReport['id'], MiAbuseUserReport>;
 		},
 	): Promise<Packed<'Notification'> | null> {
 		return await this.#packInternal(src, meId, options, hint);

--- a/packages/backend/src/models/Notification.ts
+++ b/packages/backend/src/models/Notification.ts
@@ -11,6 +11,7 @@ import { MiAccessToken } from './AccessToken.js';
 import { MiRole } from './Role.js';
 import { MiDriveFile } from './DriveFile.js';
 import { MiNoteDraft } from './NoteDraft.js';
+import { MiAbuseUserReport } from './AbuseUserReport.js';
 
 // misskey-js の notificationTypes と同期すべし
 export type MiNotification = {
@@ -150,6 +151,16 @@ export type MiNotification = {
 	type: 'test';
 	id: string;
 	createdAt: string;
+} | {
+	type: 'abuseReport';
+	id: string;
+	createdAt: string;
+	// notifierId (通報者) を持たない。持たせると #validateNotifier の
+	// isSuspended / mutings チェックが効いてしまい、モデレーターが通報者を
+	// ミュートしている・通報後に通報者がサスペンドされた、というだけで
+	// この通知が作成されない/読めなくなる (通知欄に残す目的そのものを破る)。
+	// reporterId / targetUserId は reportId から read 時に都度解決する。
+	reportId: MiAbuseUserReport['id'];
 };
 
 export type MiGroupedNotification = MiNotification | {

--- a/packages/backend/src/models/json-schema/notification.ts
+++ b/packages/backend/src/models/json-schema/notification.ts
@@ -512,6 +512,50 @@ export const packedNotificationSchema = {
 			type: {
 				type: 'string',
 				optional: false, nullable: false,
+				enum: ['abuseReport'],
+			},
+			user: {
+				type: 'object',
+				ref: 'UserLite',
+				optional: false, nullable: false,
+			},
+			userId: {
+				type: 'string',
+				optional: false, nullable: false,
+				format: 'id',
+			},
+			reportId: {
+				type: 'string',
+				optional: false, nullable: false,
+				format: 'id',
+			},
+			targetUserId: {
+				type: 'string',
+				optional: false, nullable: false,
+				format: 'id',
+			},
+			resolved: {
+				type: 'boolean',
+				optional: false, nullable: false,
+			},
+			resolvedAs: {
+				type: 'string',
+				optional: false, nullable: true,
+				enum: ['accept', 'reject', null],
+			},
+			assigneeId: {
+				type: 'string',
+				optional: false, nullable: true,
+				format: 'id',
+			},
+		},
+	}, {
+		type: 'object',
+		properties: {
+			...baseSchema.properties,
+			type: {
+				type: 'string',
+				optional: false, nullable: false,
 				enum: ['groupInvited'],
 			},
 			user: {

--- a/packages/backend/src/models/json-schema/user.ts
+++ b/packages/backend/src/models/json-schema/user.ts
@@ -680,6 +680,7 @@ export const packedMeDetailedOnlySchema = {
 				login: { optional: true, ...notificationRecieveConfig },
 				createToken: { optional: true, ...notificationRecieveConfig },
 				exportCompleted: { optional: true, ...notificationRecieveConfig },
+				abuseReport: { optional: true, ...notificationRecieveConfig },
 			},
 		},
 		emailNotificationTypes: {

--- a/packages/backend/src/server/api/endpoints/i/update.ts
+++ b/packages/backend/src/server/api/endpoints/i/update.ts
@@ -240,6 +240,7 @@ export const paramDef = {
 				achievementEarned: notificationRecieveConfig,
 				app: notificationRecieveConfig,
 				test: notificationRecieveConfig,
+				abuseReport: notificationRecieveConfig,
 			},
 		},
 		emailNotificationTypes: { type: 'array', items: {

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -25,6 +25,7 @@
  * createToken - トークン作成
  * app - アプリ通知
  * test - テスト通知（サーバー側）
+ * abuseReport - 通報があった（モデレーター/管理者向け）
  */
 export const notificationTypes = [
 	'note',
@@ -48,6 +49,7 @@ export const notificationTypes = [
 	'createToken',
 	'app',
 	'test',
+	'abuseReport',
 ] as const;
 
 export const groupedNotificationTypes = [

--- a/packages/backend/test/e2e/synalio/abuse-report.ts
+++ b/packages/backend/test/e2e/synalio/abuse-report.ts
@@ -107,7 +107,8 @@ describe('[シナリオ] ユーザ通報', () => {
 		alice = await signup({ username: 'alice' });
 		bob = await signup({ username: 'bob' });
 
-		await role(admin, { isAdministrator: true });
+		const adminRole = await role(admin, { isAdministrator: true });
+		await api('admin/roles/assign', { userId: admin.id, roleId: adminRole.id }, admin);
 	}, 1000 * 60 * 2);
 
 	afterAll(async () => {

--- a/packages/backend/test/e2e/synalio/abuse-report.ts
+++ b/packages/backend/test/e2e/synalio/abuse-report.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { setTimeout } from 'node:timers/promises';
 import { entities } from 'misskey-js';
 import {
 	beforeEach,
@@ -71,6 +72,19 @@ describe('[シナリオ] ユーザ通報', () => {
 			credential ?? admin,
 		);
 		return res.body;
+	}
+
+	// notifications の discriminated union は misskey-js の autogen 型が持つが、
+	// Array.prototype.find の型ガード無しでは呼び出し側で narrowing されないため、
+	// テストの見やすさのために緩く型付けした専用 helper を用意する。
+	function findAbuseReportNotification(body: unknown[], reportId: string) {
+		return body.find(n => (n as { type?: string }).type === 'abuseReport' && (n as { reportId?: string }).reportId === reportId) as {
+			targetUserId: string;
+			userId: string;
+			resolved: boolean;
+			resolvedAs: string | null;
+			assigneeId: string | null;
+		} | undefined;
 	}
 
 	async function resolveAbuseReport(args?: Partial<entities.AdminResolveAbuseUserReportRequest>, credential?: UserToken): Promise<entities.EmptyResponse> {
@@ -356,6 +370,59 @@ describe('[シナリオ] ユーザ通報', () => {
 			}).catch(e => e.message);
 
 			expect(webhookBody2).toBe('timeout');
+		});
+	});
+
+	describe('InAppNotification', () => {
+		test('通報を受けた -> モデレーターの通知欄にabuseReport通知が作成される(コメントは含まれない)', async () => {
+			// 通報(bob -> alice)
+			const abuse = {
+				userId: alice.id,
+				comment: randomString(),
+			};
+			await createAbuseReport(abuse, bob);
+
+			// Redisに追加されるのを待つ
+			await setTimeout(100);
+
+			const abuseReportId = (await api('admin/abuse-user-reports', {}, admin)).body[0].id;
+
+			const notifRes = await api('i/notifications', {}, admin);
+			expect(notifRes.status).toBe(200);
+
+			const abuseNotif = findAbuseReportNotification(notifRes.body, abuseReportId);
+
+			if (abuseNotif == null) {
+				throw new Error('abuseReport notification not found');
+			}
+			expect(abuseNotif.targetUserId).toBe(alice.id);
+			expect(abuseNotif.userId).toBe(bob.id);
+			expect(abuseNotif.resolved).toBe(false);
+			expect(abuseNotif.resolvedAs).toBeNull();
+			expect(abuseNotif.assigneeId).toBeNull();
+			expect(abuseNotif).not.toHaveProperty('comment');
+		});
+
+		test('通報を解決すると、既存の通知のresolvedが更新される(read時に都度解決される)', async () => {
+			const abuse = {
+				userId: alice.id,
+				comment: randomString(),
+			};
+			await createAbuseReport(abuse, bob);
+			await setTimeout(100);
+
+			const abuseReportId = (await api('admin/abuse-user-reports', {}, admin)).body[0].id;
+
+			await resolveAbuseReport({ reportId: abuseReportId }, admin);
+
+			const notifRes = await api('i/notifications', {}, admin);
+			const abuseNotif = findAbuseReportNotification(notifRes.body, abuseReportId);
+
+			if (abuseNotif == null) {
+				throw new Error('abuseReport notification not found');
+			}
+			expect(abuseNotif.resolved).toBe(true);
+			expect(abuseNotif.assigneeId).toBe(admin.id);
 		});
 	});
 });

--- a/packages/backend/test/unit/AbuseReportNotificationService.ts
+++ b/packages/backend/test/unit/AbuseReportNotificationService.ts
@@ -29,6 +29,7 @@ import { GlobalEventService } from '@/core/GlobalEventService.js';
 import { RecipientMethod } from '@/models/AbuseReportNotificationRecipient.js';
 import { SystemWebhookService } from '@/core/SystemWebhookService.js';
 import { UserEntityService } from '@/core/entities/UserEntityService.js';
+import { NotificationService } from '@/core/NotificationService.js';
 
 process.env.NODE_ENV = 'test';
 
@@ -46,6 +47,7 @@ describe('AbuseReportNotificationService', () => {
 	let roleService: Mocked<RoleService>;
 	let emailService: Mocked<EmailService>;
 	let webhookService: Mocked<SystemWebhookService>;
+	let notificationService: Mocked<NotificationService>;
 
 	// --------------------------------------------------------------------------------------
 
@@ -133,6 +135,9 @@ describe('AbuseReportNotificationService', () => {
 					{
 						provide: GlobalEventService, useFactory: () => ({ publishAdminStream: vi.fn() }),
 					},
+					{
+						provide: NotificationService, useFactory: () => ({ createNotification: vi.fn() }),
+					},
 				],
 			})
 			.compile();
@@ -147,6 +152,7 @@ describe('AbuseReportNotificationService', () => {
 		roleService = app.get(RoleService) as Mocked<RoleService>;
 		emailService = app.get<EmailService>(EmailService) as Mocked<EmailService>;
 		webhookService = app.get<SystemWebhookService>(SystemWebhookService) as Mocked<SystemWebhookService>;
+		notificationService = app.get<NotificationService>(NotificationService) as Mocked<NotificationService>;
 
 		app.enableShutdownHooks();
 	});
@@ -164,6 +170,7 @@ describe('AbuseReportNotificationService', () => {
 	afterEach(async () => {
 		emailService.sendEmail.mockClear();
 		webhookService.enqueueSystemWebhook.mockClear();
+		notificationService.createNotification.mockClear();
 
 		await usersRepository.createQueryBuilder().delete().execute();
 		await userProfilesRepository.createQueryBuilder().delete().execute();
@@ -390,6 +397,67 @@ describe('AbuseReportNotificationService', () => {
 			expect(webhookService.enqueueSystemWebhook).toHaveBeenCalledTimes(1);
 			expect(webhookService.enqueueSystemWebhook.mock.calls[0][0]).toBe('abuseReport');
 			expect(webhookService.enqueueSystemWebhook.mock.calls[0][2]).toEqual({ excludes: [systemWebhook2.id] });
+		});
+	});
+
+	describe('notifyInApp', () => {
+		function buildReport(data: Partial<MiAbuseUserReport> = {}): MiAbuseUserReport {
+			return {
+				id: idService.gen(),
+				targetUserId: alice.id,
+				targetUser: alice,
+				reporterId: bob.id,
+				reporter: bob,
+				assigneeId: null,
+				assignee: null,
+				resolved: false,
+				forwarded: false,
+				comment: 'test',
+				moderationNote: '',
+				resolvedAs: null,
+				targetUserHost: null,
+				reporterHost: null,
+				...data,
+			};
+		}
+
+		test('モデレーターごとに通知が作成される(通報コメント・notifierIdは含まれない)', async () => {
+			const report = buildReport();
+
+			await service.notifyInApp([report]);
+
+			// beforeEachでgetModeratorIdsは[root, alice, bob]を返すようモックされている。
+			// bob は通報者自身なので自分には作成されない (下の別テストで確認)。
+			expect(notificationService.createNotification).toHaveBeenCalledTimes(2);
+			for (const moderatorId of [root.id, alice.id]) {
+				expect(notificationService.createNotification).toHaveBeenCalledWith(
+					moderatorId,
+					'abuseReport',
+					{ reportId: report.id },
+				);
+			}
+		});
+
+		test('通報者自身がモデレーターの場合、自分には作成されない', async () => {
+			// createNotification へ notifierId を渡すと NotificationService /
+			// NotificationEntityService の汎用ミュート/サスペンド判定が通報者に
+			// 対して効いてしまうため、notifierId には依存せずここで明示的に
+			// 自己通知を抑止している (#20)。
+			const report = buildReport({ reporterId: bob.id });
+
+			await service.notifyInApp([report]);
+
+			expect(notificationService.createNotification).not.toHaveBeenCalledWith(
+				bob.id,
+				expect.anything(),
+				expect.anything(),
+			);
+		});
+
+		test('通報が0件なら何もしない', async () => {
+			await service.notifyInApp([]);
+
+			expect(notificationService.createNotification).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/frontend/src/components/MkNotification.vue
+++ b/packages/frontend/src/components/MkNotification.vue
@@ -33,6 +33,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 				[$style.t_createToken]: notification.type === 'createToken',
 				[$style.t_chatRoomInvitationReceived]: notification.type === 'chatRoomInvitationReceived',
 				[$style.t_roleAssigned]: notification.type === 'roleAssigned' && notification.role.iconUrl == null,
+				[$style.t_abuseReport]: notification.type === 'abuseReport',
 			}]"
 		>
 			<i v-if="notification.type === 'follow'" class="ti ti-plus"></i>
@@ -51,6 +52,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 			<i v-else-if="notification.type === 'login'" class="ti ti-login-2"></i>
 			<i v-else-if="notification.type === 'createToken'" class="ti ti-key"></i>
 			<i v-else-if="notification.type === 'chatRoomInvitationReceived'" class="ti ti-messages"></i>
+			<i v-else-if="notification.type === 'abuseReport'" class="ti ti-flag"></i>
 			<template v-else-if="notification.type === 'roleAssigned'">
 				<img v-if="notification.role.iconUrl" style="height: 1.3em; vertical-align: -22%; border-radius: 0.4em;" :src="notification.role.iconUrl" alt=""/>
 				<i v-else class="ti ti-badges"></i>
@@ -72,6 +74,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 			<span v-else-if="notification.type === 'note'" :class="$style.headerText">{{ i18n.ts._notification.newNote }}: <MkUserName :user="notification.note.user"/></span>
 			<span v-else-if="notification.type === 'roleAssigned'" :class="$style.headerText">{{ i18n.ts._notification.roleAssigned }}</span>
 			<span v-else-if="notification.type === 'chatRoomInvitationReceived'" :class="$style.headerText">{{ i18n.ts._notification.chatRoomInvitationReceived }}</span>
+			<span v-else-if="notification.type === 'abuseReport'" :class="$style.headerText">{{ i18n.ts._notification.abuseReport }}</span>
 			<span v-else-if="notification.type === 'achievementEarned'" :class="$style.headerText">{{ i18n.ts._notification.achievementEarned }}</span>
 			<span v-else-if="notification.type === 'login'" :class="$style.headerText">{{ i18n.ts._notification.login }}</span>
 			<span v-else-if="notification.type === 'createToken'" :class="$style.headerText">{{ i18n.ts._notification.createToken }}</span>
@@ -130,6 +133,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 			<div v-else-if="notification.type === 'chatRoomInvitationReceived'" :class="$style.text">
 				{{ notification.invitation.room.name }}
 			</div>
+			<MkA v-else-if="notification.type === 'abuseReport'" :class="$style.text" to="/admin/abuses">
+				{{ notification.resolved ? i18n.ts.resolved : i18n.ts.unresolved }}
+			</MkA>
 			<MkA v-else-if="notification.type === 'achievementEarned'" :class="$style.text" to="/my/achievements">
 				{{ i18n.ts._achievements._types[`_${notification.achievement}`].title }}
 			</MkA>
@@ -448,6 +454,11 @@ const rejectGroupInvitation = () => {
 }
 
 .t_chatRoomInvitationReceived {
+	background: var(--eventOther);
+	pointer-events: none;
+}
+
+.t_abuseReport {
 	background: var(--eventOther);
 	pointer-events: none;
 }

--- a/packages/frontend/src/pages/settings/notifications.vue
+++ b/packages/frontend/src/pages/settings/notifications.vue
@@ -134,7 +134,7 @@ const nonConfigurableNotificationTypes = ['note', 'roleAssigned', 'followRequest
 
 const configurableNotificationTypes = notificationTypes.filter(type => !nonConfigurableNotificationTypes.includes(type as any)) as Exclude<typeof notificationTypes[number], typeof nonConfigurableNotificationTypes[number]>[];
 
-const onlyOnOrOffNotificationTypes = ['app', 'achievementEarned', 'login', 'createToken', 'scheduledNotePosted', 'scheduledNotePostFailed'] as const satisfies (typeof notificationTypes[number])[];
+const onlyOnOrOffNotificationTypes = ['app', 'achievementEarned', 'login', 'createToken', 'scheduledNotePosted', 'scheduledNotePostFailed', 'abuseReport'] as const satisfies (typeof notificationTypes[number])[];
 
 const allowButton = useTemplateRef('allowButton');
 const pushRegistrationInServer = computed(() => allowButton.value?.pushRegistrationInServer);

--- a/packages/i18n/src/autogen/locale.ts
+++ b/packages/i18n/src/autogen/locale.ts
@@ -12940,6 +12940,10 @@ export interface Locale extends ILocale {
          * 心当たりがない場合は「{text}」を通じてアクセストークンを削除してください。
          */
         "createTokenDescription": ParameterizedString<"text">;
+        /**
+         * 通報がありました
+         */
+        "abuseReport": string;
         "_types": {
             /**
              * すべて
@@ -13029,6 +13033,10 @@ export interface Locale extends ILocale {
              * 連携アプリからの通知
              */
             "app": string;
+            /**
+             * 通報があった
+             */
+            "abuseReport": string;
         };
         "_actions": {
             /**

--- a/packages/misskey-js/etc/misskey-js.api.md
+++ b/packages/misskey-js/etc/misskey-js.api.md
@@ -3573,7 +3573,7 @@ type NotificationsCreateRequest = operations['notifications___create']['requestB
 type NotificationsDeleteRequest = operations['notifications___delete']['requestBody']['content']['application/json'];
 
 // @public (undocumented)
-export const notificationTypes: readonly ["note", "follow", "mention", "reply", "renote", "quote", "reaction", "pollEnded", "scheduledNotePosted", "scheduledNotePostFailed", "receiveFollowRequest", "followRequestAccepted", "groupInvited", "app", "roleAssigned", "chatRoomInvitationReceived", "achievementEarned", "exportCompleted", "test", "login", "createToken"];
+export const notificationTypes: readonly ["note", "follow", "mention", "reply", "renote", "quote", "reaction", "pollEnded", "scheduledNotePosted", "scheduledNotePostFailed", "receiveFollowRequest", "followRequestAccepted", "groupInvited", "app", "roleAssigned", "chatRoomInvitationReceived", "achievementEarned", "exportCompleted", "test", "login", "createToken", "abuseReport"];
 
 // @public (undocumented)
 export function nyaize(text: string): string;

--- a/packages/misskey-js/src/autogen/types.ts
+++ b/packages/misskey-js/src/autogen/types.ts
@@ -4831,6 +4831,15 @@ export type components = {
                     /** Format: misskey:id */
                     userListId: string;
                 };
+                abuseReport?: {
+                    /** @enum {string} */
+                    type: 'all' | 'following' | 'follower' | 'mutualFollow' | 'followingOrFollower' | 'never';
+                } | {
+                    /** @enum {string} */
+                    type: 'list';
+                    /** Format: misskey:id */
+                    userListId: string;
+                };
             };
             emailNotificationTypes: string[];
             achievements: components['schemas']['Achievement'][];
@@ -5358,6 +5367,25 @@ export type components = {
             createdAt: string;
             /** @enum {string} */
             type: 'test';
+        } | {
+            /** Format: id */
+            id: string;
+            /** Format: date-time */
+            createdAt: string;
+            /** @enum {string} */
+            type: 'abuseReport';
+            user: components['schemas']['UserLite'];
+            /** Format: id */
+            userId: string;
+            /** Format: id */
+            reportId: string;
+            /** Format: id */
+            targetUserId: string;
+            resolved: boolean;
+            /** @enum {string|null} */
+            resolvedAs: 'accept' | 'reject' | null;
+            /** Format: id */
+            assigneeId: string | null;
         } | {
             /** Format: id */
             id: string;
@@ -28891,8 +28919,8 @@ export interface operations {
                     untilDate?: number;
                     /** @default true */
                     markAsRead?: boolean;
-                    includeTypes?: ('note' | 'follow' | 'mention' | 'reply' | 'renote' | 'quote' | 'reaction' | 'pollEnded' | 'scheduledNotePosted' | 'scheduledNotePostFailed' | 'receiveFollowRequest' | 'followRequestAccepted' | 'groupInvited' | 'roleAssigned' | 'chatRoomInvitationReceived' | 'achievementEarned' | 'exportCompleted' | 'login' | 'createToken' | 'app' | 'test' | 'pollVote')[];
-                    excludeTypes?: ('note' | 'follow' | 'mention' | 'reply' | 'renote' | 'quote' | 'reaction' | 'pollEnded' | 'scheduledNotePosted' | 'scheduledNotePostFailed' | 'receiveFollowRequest' | 'followRequestAccepted' | 'groupInvited' | 'roleAssigned' | 'chatRoomInvitationReceived' | 'achievementEarned' | 'exportCompleted' | 'login' | 'createToken' | 'app' | 'test' | 'pollVote')[];
+                    includeTypes?: ('note' | 'follow' | 'mention' | 'reply' | 'renote' | 'quote' | 'reaction' | 'pollEnded' | 'scheduledNotePosted' | 'scheduledNotePostFailed' | 'receiveFollowRequest' | 'followRequestAccepted' | 'groupInvited' | 'roleAssigned' | 'chatRoomInvitationReceived' | 'achievementEarned' | 'exportCompleted' | 'login' | 'createToken' | 'app' | 'test' | 'abuseReport' | 'pollVote')[];
+                    excludeTypes?: ('note' | 'follow' | 'mention' | 'reply' | 'renote' | 'quote' | 'reaction' | 'pollEnded' | 'scheduledNotePosted' | 'scheduledNotePostFailed' | 'receiveFollowRequest' | 'followRequestAccepted' | 'groupInvited' | 'roleAssigned' | 'chatRoomInvitationReceived' | 'achievementEarned' | 'exportCompleted' | 'login' | 'createToken' | 'app' | 'test' | 'abuseReport' | 'pollVote')[];
                 };
             };
         };
@@ -28981,8 +29009,8 @@ export interface operations {
                      * @default false
                      */
                     groupNote?: boolean;
-                    includeTypes?: ('note' | 'follow' | 'mention' | 'reply' | 'renote' | 'quote' | 'reaction' | 'pollEnded' | 'scheduledNotePosted' | 'scheduledNotePostFailed' | 'receiveFollowRequest' | 'followRequestAccepted' | 'groupInvited' | 'roleAssigned' | 'chatRoomInvitationReceived' | 'achievementEarned' | 'exportCompleted' | 'login' | 'createToken' | 'app' | 'test' | 'pollVote')[];
-                    excludeTypes?: ('note' | 'follow' | 'mention' | 'reply' | 'renote' | 'quote' | 'reaction' | 'pollEnded' | 'scheduledNotePosted' | 'scheduledNotePostFailed' | 'receiveFollowRequest' | 'followRequestAccepted' | 'groupInvited' | 'roleAssigned' | 'chatRoomInvitationReceived' | 'achievementEarned' | 'exportCompleted' | 'login' | 'createToken' | 'app' | 'test' | 'pollVote')[];
+                    includeTypes?: ('note' | 'follow' | 'mention' | 'reply' | 'renote' | 'quote' | 'reaction' | 'pollEnded' | 'scheduledNotePosted' | 'scheduledNotePostFailed' | 'receiveFollowRequest' | 'followRequestAccepted' | 'groupInvited' | 'roleAssigned' | 'chatRoomInvitationReceived' | 'achievementEarned' | 'exportCompleted' | 'login' | 'createToken' | 'app' | 'test' | 'abuseReport' | 'pollVote')[];
+                    excludeTypes?: ('note' | 'follow' | 'mention' | 'reply' | 'renote' | 'quote' | 'reaction' | 'pollEnded' | 'scheduledNotePosted' | 'scheduledNotePostFailed' | 'receiveFollowRequest' | 'followRequestAccepted' | 'groupInvited' | 'roleAssigned' | 'chatRoomInvitationReceived' | 'achievementEarned' | 'exportCompleted' | 'login' | 'createToken' | 'app' | 'test' | 'abuseReport' | 'pollVote')[];
                 };
             };
         };
@@ -30464,6 +30492,15 @@ export interface operations {
                             userListId: string;
                         };
                         test?: {
+                            /** @enum {string} */
+                            type: 'all' | 'following' | 'follower' | 'mutualFollow' | 'followingOrFollower' | 'never';
+                        } | {
+                            /** @enum {string} */
+                            type: 'list';
+                            /** Format: misskey:id */
+                            userListId: string;
+                        };
+                        abuseReport?: {
                             /** @enum {string} */
                             type: 'all' | 'following' | 'follower' | 'mutualFollow' | 'followingOrFollower' | 'never';
                         } | {

--- a/packages/misskey-js/src/consts.ts
+++ b/packages/misskey-js/src/consts.ts
@@ -38,6 +38,7 @@ export const notificationTypes = [
 	'test',
 	'login',
 	'createToken',
+	'abuseReport',
 ] as const;
 
 export const noteVisibilities = ['public', 'home', 'followers', 'specified'] as const;

--- a/packages/sw/src/scripts/create-notification.ts
+++ b/packages/sw/src/scripts/create-notification.ts
@@ -252,6 +252,14 @@ async function composeNotification(data: PushNotificationDataMap[keyof PushNotif
 						],
 					}];
 
+				case 'abuseReport':
+					return [i18n.ts._notification.abuseReport, {
+						body: `${getUserName(data.body.user)} (@${data.body.user.username}${data.body.user.host != null ? '@' + data.body.user.host : ''})`,
+						icon: data.body.user.avatarUrl ?? undefined,
+						badge: iconUrl('bell'),
+						data,
+					}];
+
 				case 'achievementEarned':
 					return [i18n.ts._notification.achievementEarned, {
 						body: i18n.ts._achievements._types[`_${data.body.achievement}`].title,


### PR DESCRIPTION
## What
  - 通報作成時にモデレーター/管理者の通知欄（ベル）にも in-app 通知を残す
  - 新しい通知タイプ abuseReport を追加。reportId のみ永続化し、resolved/resolvedAs/assigneeId/対象ユーザー/通報者は read 時に都度解決
  - 通報コメント本文は含めない
  - 設定画面で on/off のみ選択可能な通知種別として追加
  - Service Worker のプッシュ通知にも対応

## Why
  - 既存の admin stream はその瞬間に管理画面を開いている人にしか届かず、後から見返せない
  - 設計上の注意：通報者を notifierId として扱うと、汎用のミュート/サスペンド判定が適用されてしまい「モデレーターが通報者をミュートしている」「通報後に通報者がサスペンドされた」
    だけで通知が消える不具合になるため、reportId 経由で解決する設計にしている（レビューで見つけた重大な設計不備を修正済み）

##  Additional info
  - typecheck/eslint はクリーン、misskey-js再生成も反映済み
  - DBが無い環境のためユニット/E2Eテストは未実行 — マージ前にCI/ローカルでの実行が必要
  - CHANGELOG_YOJO.md は未更新（リリース時運用のため、要確認）

## Checklist
- [ ] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [ ] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [ ] (必要なら)テストの追加((If possible) Add tests)

Porting from https://github.com/shiroha-a/mk