### PR TITLE
fix(backend): グループ削除後に残る招待通知で i/notifications が 500 になる問題を修正

### DIFF
--- a/packages/backend/src/core/entities/NotificationEntityService.ts
+++ b/packages/backend/src/core/entities/NotificationEntityService.ts
@@ -191,6 +191,13 @@ export class NotificationEntityService implements OnModuleInit {
 			return null;
 		}
 
+		const needsGroupInvitation = notification.type === 'groupInvited';
+		const groupInvitation = needsGroupInvitation ? await this.userGroupInvitationEntityService.pack(notification.userGroupInvitationId).catch(() => null) : undefined;
+		// if the invitation has been deleted, don't show this notification
+		if (needsGroupInvitation && !groupInvitation) {
+			return null;
+		}
+
 		return await awaitAll({
 			id: notification.id,
 			createdAt: new Date(notification.createdAt).toISOString(),
@@ -202,7 +209,7 @@ export class NotificationEntityService implements OnModuleInit {
 				reaction: notification.reaction,
 			} : {}),
 			...(notification.type === 'groupInvited' ? {
-				invitation: this.userGroupInvitationEntityService.pack(notification.userGroupInvitationId),
+				invitation: groupInvitation,
 			} : {}),
 			...(notification.type === 'roleAssigned' ? {
 				role: role,

--- a/packages/backend/src/server/api/endpoints/users/groups/delete.ts
+++ b/packages/backend/src/server/api/endpoints/users/groups/delete.ts
@@ -4,8 +4,9 @@
  */
 
 import { Inject, Injectable } from '@nestjs/common';
-import type { UserGroupsRepository } from '@/models/_.js';
+import type { UserGroupsRepository, UserGroupInvitationsRepository } from '@/models/_.js';
 import { Endpoint } from '@/server/api/endpoint-base.js';
+import { NotificationService } from '@/core/NotificationService.js';
 import { DI } from '@/di-symbols.js';
 import { ApiError } from '../../../error.js';
 
@@ -40,6 +41,11 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 	constructor(
 		@Inject(DI.userGroupsRepository)
 		private userGroupsRepository: UserGroupsRepository,
+
+		@Inject(DI.userGroupInvitationsRepository)
+		private userGroupInvitationsRepository: UserGroupInvitationsRepository,
+
+		private notificationService: NotificationService,
 	) {
 		super(meta, paramDef, async (ps, me) => {
 			const userGroup = await this.userGroupsRepository.findOneBy({
@@ -50,6 +56,16 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 			if (userGroup == null) {
 				throw new ApiError(meta.errors.noSuchGroup);
 			}
+
+			const invitations = await this.userGroupInvitationsRepository.findBy({
+				userGroupId: userGroup.id,
+			});
+
+			// グループ削除で招待行は FK cascade により消えるが、Redis 上の招待通知は残るため先に掃除する
+			// 通知が残ると通知の pack が失敗し、招待されたユーザーの i/notifications が 500 になる
+			await Promise.all(invitations.map(invitation =>
+				this.notificationService.deleteUserGroupInvitation(invitation.userId, invitation.id),
+			));
 
 			await this.userGroupsRepository.delete(userGroup.id);
 		});

--- a/packages/backend/test/e2e/user-group.ts
+++ b/packages/backend/test/e2e/user-group.ts
@@ -597,9 +597,9 @@ describe('UserGroup', () => {
 		let group2: any;
 
 		beforeAll(async () => {
-			owner = await signup({ username: 'group_delete_owner' });
-			invitee1 = await signup({ username: 'group_delete_invitee1' });
-			invitee2 = await signup({ username: 'group_delete_invitee2' });
+			owner = await signup({ username: 'dave' });
+			invitee1 = await signup({ username: 'erin' });
+			invitee2 = await signup({ username: 'frank' });
 		}, 1000 * 60 * 2);
 
 		afterAll(async () => {

--- a/packages/backend/test/e2e/user-group.ts
+++ b/packages/backend/test/e2e/user-group.ts
@@ -7,7 +7,8 @@ process.env.NODE_ENV = 'test';
 
 import * as assert from 'assert';
 import { afterAll, beforeAll, describe, test } from 'vitest';
-import { api, signup, sleep } from '../utils.js';
+import { MiUserGroupInvitation } from '@/models/UserGroupInvitation.js';
+import { api, initTestDb, signup, sleep } from '../utils.js';
 import type * as misskey from 'misskey-js';
 
 describe('UserGroup', () => {
@@ -586,5 +587,70 @@ describe('UserGroup', () => {
 			await api('users/groups/delete', { groupId: bobGroup.body.id }, bob);
 			await api('users/groups/delete', { groupId: carolGroup.body.id }, carol);
 		});
+	});
+
+	describe('users/groups/delete', () => {
+		let owner: misskey.entities.SignupResponse;
+		let invitee1: misskey.entities.SignupResponse;
+		let invitee2: misskey.entities.SignupResponse;
+		let group1: any;
+		let group2: any;
+
+		beforeAll(async () => {
+			owner = await signup({ username: 'group_delete_owner' });
+			invitee1 = await signup({ username: 'group_delete_invitee1' });
+			invitee2 = await signup({ username: 'group_delete_invitee2' });
+		}, 1000 * 60 * 2);
+
+		afterAll(async () => {
+			if (group1 != null) await api('users/groups/delete', { groupId: group1.body.id }, owner);
+			if (group2 != null) await api('users/groups/delete', { groupId: group2.body.id }, owner);
+		});
+
+		// i/notifications は 30req/30s のレート制限があるため、ポーリング回数を抑える
+		async function waitForGroupInvitedNotification(user: misskey.entities.SignupResponse): Promise<any[]> {
+			for (let i = 0; i < 20; i++) {
+				const res = await api('i/notifications', { limit: 100 }, user);
+				assert.strictEqual(res.status, 200);
+				if (res.body.some((n: any) => n.type === 'groupInvited')) return res.body;
+				await sleep(250);
+			}
+			throw new Error('groupInvited notification was not created in time');
+		}
+
+		test('グループ削除時に招待された側の通知も消える', async () => {
+			group1 = await api('users/groups/create', { name: 'delete-notification-group' }, owner);
+			assert.strictEqual(group1.status, 200);
+
+			await api('users/groups/invite', { groupId: group1.body.id, userId: invitee1.id }, owner);
+			await waitForGroupInvitedNotification(invitee1);
+
+			const del = await api('users/groups/delete', { groupId: group1.body.id }, owner);
+			assert.strictEqual(del.status, 204);
+
+			const after = await api('i/notifications', { limit: 100 }, invitee1);
+			assert.strictEqual(after.status, 200);
+			assert.strictEqual(after.body.some((n: any) => n.type === 'groupInvited'), false);
+		}, 1000 * 60);
+
+		test('招待行が消えても Redis に通知が残っていれば i/notifications は 500 にならない', async () => {
+			group2 = await api('users/groups/create', { name: 'stale-notification-group' }, owner);
+			assert.strictEqual(group2.status, 200);
+
+			await api('users/groups/invite', { groupId: group2.body.id, userId: invitee2.id }, owner);
+			await waitForGroupInvitedNotification(invitee2);
+
+			// FK cascade 相当の状況を再現: 招待行のみ直接削除し、Redis 上には通知を残す
+			const connection = await initTestDb(true);
+			try {
+				await connection.getRepository(MiUserGroupInvitation).delete({ userGroupId: group2.body.id });
+			} finally {
+				await connection.destroy();
+			}
+
+			const after = await api('i/notifications', { limit: 100 }, invitee2);
+			assert.strictEqual(after.status, 200);
+			assert.strictEqual(after.body.some((n: any) => n.type === 'groupInvited'), false);
+		}, 1000 * 60);
 	});
 });


### PR DESCRIPTION
## What
- `users/groups/delete` で、グループ削除の前に当該グループの保留中招待に対応する Redis の `groupInvited` 通知を削除するようにしました
- `NotificationEntityService` で、招待が既に削除されている `groupInvited` 通知を非表示（`null`）にするようにしました（`roleAssigned` / `chatRoomInvitationReceived` と同じ扱い）

グループ削除後も招待されたユーザーの `i/notifications` は 200 を返し、該当通知は表示されなくなります。

## Why
グループ削除では `user_group_invitation` は FK cascade で削除されますが、Redis の通知タイムラインに残った `groupInvited` 通知を pack する際に `UserGroupInvitationEntityService.pack` の `findOneByOrFail` が throw するため、招待されたユーザーの `i/notifications` が 500 になっていました。

通知の掃除だけでは、通知作成が await されていないことによる「招待直後にグループを削除」のレースや、修正前に既に Redis に残っている通知を救済できないため、pack 側の防御も入れています。これにより、グループ所有者のユーザー削除など、グループ削除以外の cascade 経路でも同様に 500 になりません。

## Additional info (optional)
追加した回帰テスト（`packages/backend/test/e2e/user-group.ts`）:
- グループ削除で招待通知が消えること
- 招待行のみ消えて Redis に通知が残っていても 500 にならず非表示になること

検証:
- `pnpm --filter backend typecheck` / `pnpm --filter backend eslint` pass
- e2e は環境の都合で未実行のため、以下で確認をお願いします
  `docker compose -f packages/backend/test/compose.yml up -d && pnpm --filter backend test:e2e user-group`

## Checklist
- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [ ] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [x] (必要なら)テストの追加((If possible) Add tests)