### PR TITLE
Fix: ゲストがバブルタイムラインのノートを受信できない問題を修正

### DIFF
--- a/packages/backend/src/server/api/stream/channels/bubble-timeline.ts
+++ b/packages/backend/src/server/api/stream/channels/bubble-timeline.ts
@@ -13,6 +13,7 @@ import { RoleService } from '@/core/RoleService.js';
 import type { MiMeta } from '@/models/Meta.js';
 import { isRenotePacked, isQuotePacked } from '@/misc/is-renote.js';
 import type { JsonObject } from '@/misc/json-value.js';
+import { NoteStreamingHidingService } from '../NoteStreamingHidingService.js';
 import Channel, { type ChannelRequest } from '../channel.js';
 
 @Injectable({ scope: Scope.TRANSIENT })
@@ -33,6 +34,7 @@ export class BubbleTimelineChannel extends Channel {
 		private metaService: MetaService,
 		private roleService: RoleService,
 		private noteEntityService: NoteEntityService,
+		private noteStreamingHidingService: NoteStreamingHidingService,
 
 	) {
 		super(request);
@@ -67,9 +69,10 @@ export class BubbleTimelineChannel extends Channel {
 
 		if (isRenotePacked(note) && !isQuotePacked(note) && !this.withRenotes) return;
 
-		if (!this.following[note.userId] && note.userId !== this.user!.id) return;
-
 		if (this.isNoteMutedOrBlocked(note)) return;
+
+		const { shouldSkip } = await this.noteStreamingHidingService.processHiding(note, this.user?.id ?? null);
+		if (shouldSkip) return;
 
 		if (this.user && isRenotePacked(note) && !isQuotePacked(note)) {
 			if (note.renote && Object.keys(note.renote.reactions).length > 0) {

--- a/packages/backend/test/e2e/bubble-timeline.ts
+++ b/packages/backend/test/e2e/bubble-timeline.ts
@@ -10,7 +10,7 @@ import { WebSocket } from 'ws';
 import { api, port, post, randomString, signup } from '../utils.js';
 import type * as misskey from 'misskey-js';
 
-describe('Bubble timeline streaming (0222)', () => {
+describe('Bubble timeline streaming', () => {
 	let root: misskey.entities.SignupResponse;
 
 	beforeAll(async () => {
@@ -80,7 +80,7 @@ describe('Bubble timeline streaming (0222)', () => {
 		const remote = await signup({ username: randomString(), host: 'bubble.example' });
 		const { ws, waitForNote } = await connectGuestChannel('bubbleTimeline');
 		try {
-			const note = await post(remote, { text: 'poc-0222', visibility: 'public' });
+			const note = await post(remote, { text: 'guest-bubble-note', visibility: 'public' });
 			const received = await waitForNote(note.id);
 			expect(received.id).toBe(note.id);
 			expect(received.user.host).toBe('bubble.example');

--- a/packages/backend/test/e2e/bubble-timeline.ts
+++ b/packages/backend/test/e2e/bubble-timeline.ts
@@ -1,0 +1,94 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { beforeAll, describe, expect, test } from 'vitest';
+import { WebSocket } from 'ws';
+import { api, port, post, randomString, signup } from '../utils.js';
+import type * as misskey from 'misskey-js';
+
+describe('Bubble timeline streaming (0222)', () => {
+	let root: misskey.entities.SignupResponse;
+
+	beforeAll(async () => {
+		root = await signup({ username: 'bubble_root' });
+		await api('admin/update-meta', { bubbleInstances: ['bubble.example'] }, root);
+		// MetaService のキャッシュが Redis 経由で更新されるまで待つ
+		await new Promise(resolve => setTimeout(resolve, 250));
+	}, 1000 * 60);
+
+	async function connectGuestChannel(channel: string, params?: Record<string, unknown>): Promise<{
+		ws: WebSocket;
+		waitForNote: (noteId: string) => Promise<any>;
+	}> {
+		const ws = new WebSocket(`ws://127.0.0.1:${port}/streaming`);
+
+		const pending: any[] = [];
+		const listeners: ((msg: any) => void)[] = [];
+
+		await new Promise<void>((resolve, reject) => {
+			ws.once('open', resolve);
+			ws.once('error', reject);
+			ws.once('unexpected-response', (_req, res) => reject(new Error(`unexpected response: ${res.statusCode}`)));
+		});
+
+		ws.on('message', data => {
+			const msg = JSON.parse(data.toString());
+			pending.push(msg);
+			for (const listener of [...listeners]) listener(msg);
+		});
+
+		const waitFor = (cond: (msg: any) => boolean, timeout = 5000): Promise<any> => {
+			for (const msg of pending) {
+				if (cond(msg)) return Promise.resolve(msg);
+			}
+			return new Promise((resolve, reject) => {
+				const listener = (msg: any) => {
+					if (cond(msg)) {
+						listeners.splice(listeners.indexOf(listener), 1);
+						resolve(msg);
+					}
+				};
+				listeners.push(listener);
+				setTimeout(() => {
+					const i = listeners.indexOf(listener);
+					if (i >= 0) listeners.splice(i, 1);
+					reject(new Error('timeout waiting for stream message'));
+				}, timeout);
+			});
+		};
+
+		ws.send(JSON.stringify({
+			type: 'connect',
+			body: { channel, id: 'a', pong: true, params },
+		}));
+
+		await waitFor(msg => msg.type === 'connected' && msg.body.id === 'a');
+
+		return {
+			ws,
+			waitForNote: noteId => waitFor(msg =>
+				msg.type === 'channel' && msg.body.id === 'a' && msg.body.type === 'note' && msg.body.body.id === noteId,
+			).then(msg => msg.body.body),
+		};
+	}
+
+	test('ゲストが bubble instance の公開ノートを受信できる', async () => {
+		const remote = await signup({ username: randomString(), host: 'bubble.example' });
+		const { ws, waitForNote } = await connectGuestChannel('bubbleTimeline');
+		try {
+			const note = await post(remote, { text: 'poc-0222', visibility: 'public' });
+			const received = await waitForNote(note.id);
+			expect(received.id).toBe(note.id);
+			expect(received.user.host).toBe('bubble.example');
+
+			// 背景で走る notesCount の更新がDB切断と競合しないよう待つ
+			await new Promise(resolve => setTimeout(resolve, 500));
+		} finally {
+			ws.close();
+		}
+	}, 1000 * 60);
+});

--- a/packages/backend/test/unit/server/api/stream/channels/bubble-timeline.ts
+++ b/packages/backend/test/unit/server/api/stream/channels/bubble-timeline.ts
@@ -1,0 +1,135 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { EventEmitter } from 'node:events';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { mockDeep } from 'vitest-mock-extended';
+import type { Mocked } from 'vitest';
+import { NoteStreamingHidingService } from '@/server/api/stream/NoteStreamingHidingService.js';
+import { BubbleTimelineChannel } from '@/server/api/stream/channels/bubble-timeline.js';
+import { MetaService } from '@/core/MetaService.js';
+import { NoteEntityService } from '@/core/entities/NoteEntityService.js';
+import { DEFAULT_POLICIES, RoleService } from '@/core/RoleService.js';
+import type { ChannelRequest } from '@/server/api/stream/channel.js';
+import type { Packed } from '@/misc/json-schema.js';
+import type { MiMeta } from '@/models/Meta.js';
+import type { MiUser } from '@/models/User.js';
+
+describe('BubbleTimelineChannel', () => {
+	let metaService: Mocked<MetaService>;
+	let roleService: Mocked<RoleService>;
+	let noteEntityService: Mocked<NoteEntityService>;
+	let noteStreamingHidingService: Mocked<NoteStreamingHidingService>;
+
+	let sendMessageToWs: ReturnType<typeof vi.fn>;
+	let subscriber: EventEmitter;
+
+	beforeEach(() => {
+		metaService = mockDeep<MetaService>();
+		roleService = mockDeep<RoleService>();
+		noteEntityService = mockDeep<NoteEntityService>();
+		noteStreamingHidingService = mockDeep<NoteStreamingHidingService>();
+
+		metaService.fetch.mockResolvedValue({ bubbleInstances: ['bubble.example'] } as unknown as MiMeta);
+		roleService.getUserPolicies.mockResolvedValue({ ...DEFAULT_POLICIES });
+		noteStreamingHidingService.processHiding.mockResolvedValue({ shouldSkip: false });
+
+		sendMessageToWs = vi.fn();
+		subscriber = new EventEmitter();
+	});
+
+	function createChannel(user: MiUser | null): BubbleTimelineChannel {
+		const connection = {
+			user,
+			userProfile: null,
+			following: {},
+			followingChannels: new Set<string>(),
+			mutingChannels: new Set<string>(),
+			userIdsWhoMeMuting: new Set<string>(),
+			userIdsWhoBlockingMe: new Set<string>(),
+			userIdsWhoMeMutingRenotes: new Set<string>(),
+			userMutedInstances: new Set<string>(),
+			subscriber,
+			sendMessageToWs,
+		} as unknown as ChannelRequest['connection'];
+
+		return new BubbleTimelineChannel(
+			{ id: 'a', connection },
+			metaService,
+			roleService,
+			noteEntityService,
+			noteStreamingHidingService,
+		);
+	}
+
+	function createNote(overrides: Partial<Packed<'Note'>> = {}): Packed<'Note'> {
+		return {
+			id: 'note1',
+			userId: 'remote-user',
+			channelId: null,
+			renoteId: null,
+			visibility: 'public',
+			fileIds: [],
+			user: {
+				id: 'remote-user',
+				host: 'bubble.example',
+				isCat: false,
+				isBot: false,
+			},
+			...overrides,
+		} as unknown as Packed<'Note'>;
+	}
+
+	function onNote(channel: BubbleTimelineChannel, note: Packed<'Note'>): Promise<void> {
+		return (channel as unknown as { onNote(note: Packed<'Note'>): Promise<void> }).onNote(note);
+	}
+
+	test('ゲスト接続でも bubble instance の公開ノートを受信できる', async () => {
+		const channel = createChannel(null);
+		await channel.init({});
+
+		const note = createNote();
+		await expect(onNote(channel, note)).resolves.toBeUndefined();
+
+		expect(noteStreamingHidingService.processHiding).toHaveBeenCalledWith(note, null);
+		expect(sendMessageToWs).toHaveBeenCalledWith('channel', {
+			id: 'a',
+			type: 'note',
+			body: note,
+		});
+	});
+
+	test('フォローしていないユーザーのノートも受信できる', async () => {
+		const user = { id: 'me' } as unknown as MiUser;
+		const channel = createChannel(user);
+		await channel.init({});
+
+		await onNote(channel, createNote());
+
+		expect(sendMessageToWs).toHaveBeenCalledTimes(1);
+	});
+
+	test('bubbleInstances に含まれないホストのノートは受信しない', async () => {
+		const channel = createChannel(null);
+		await channel.init({});
+
+		const note = createNote({ user: { id: 'remote-user', host: 'other.example' } as unknown as Packed<'Note'>['user'] });
+		await onNote(channel, note);
+
+		expect(sendMessageToWs).not.toHaveBeenCalled();
+	});
+
+	test('NoteStreamingHidingService が非表示としたノートは受信しない', async () => {
+		noteStreamingHidingService.processHiding.mockResolvedValue({ shouldSkip: true });
+		const channel = createChannel(null);
+		await channel.init({});
+
+		await onNote(channel, createNote());
+
+		expect(sendMessageToWs).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## What

- ゲスト (未ログイン) 状態でもバブルタイムラインのストリーミングでノートを受信できるように修正
- `BubbleTimelineChannel.onNote` に残っていたフォロー条件 (`this.user!.id` 参照) を削除し、他の公開タイムラインチャンネルと同様に `NoteStreamingHidingService.processHiding` によるハイド判定に置換
- 回帰テストを追加 (ストリーミングチャンネルの unit テスト + ゲスト WebSocket が bubble instance の公開ノートを受信する e2e テスト)

## Why

- `BubbleTimelineChannel` はゲスト接続を許可している (`requireCredential = false`) にもかかわらず、古いフォロー条件が `this.user!.id` を参照していたため、ゲストがノートを受信するたびに TypeError が発生し、unhandledRejection ハンドラ経由でログが出力されていた
- 同じ条件は「フォローしていないユーザーのノートを除外する」動作にもなっており、`notes/bubble-timeline` (REST) やフロントエンドのゲスト対応と矛盾していた

## Additional info (optional)

- 変更ファイル:
  - `packages/backend/src/server/api/stream/channels/bubble-timeline.ts`
  - `packages/backend/test/unit/server/api/stream/channels/bubble-timeline.ts` (新規)
  - `packages/backend/test/e2e/bubble-timeline.ts` (新規)
- テスト観点: ゲスト WebSocket 接続で bubble instance (`bubble.example`) の公開ノートが配信されること。フォロー関係のないユーザーからのノートも受信できること

## Checklist

- [x] [コントリビューションガイド](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md)を読みました( Read the [contribution guide](https://github.com/yojo-art/cherrypick/blob/develop/CONTRIBUTING.md))
- [ ] ローカル環境で動作しました(Test working in a local environment)
- [ ] (必要なら)CHANGELOG_YOJO.mdの更新((If needed) Update CHANGELOG_YOJO.md)
- [x] (必要なら)テストの追加((If possible) Add tests)